### PR TITLE
Added KernelConv, reintroduced kernel without KernelFn, reintroduced ConvolutionFn

### DIFF
--- a/e3nn/kernel.py
+++ b/e3nn/kernel.py
@@ -8,7 +8,7 @@ from e3nn import o3, rs
 
 class Kernel(torch.nn.Module):
     def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz, normalization='norm'):
-        '''
+        """
         :param Rs_in: list of triplet (multiplicity, representation order, parity)
         :param Rs_out: list of triplet (multiplicity, representation order, parity)
         :param RadialModel: Class(d), trainable model: R -> R^d
@@ -17,7 +17,7 @@ class Kernel(torch.nn.Module):
         :param normalization: either 'norm' or 'component'
         representation order = nonnegative integer
         parity = 0 (no parity), 1 (even), -1 (odd)
-        '''
+        """
         super().__init__()
 
         self.Rs_in = rs.simplify(Rs_in)
@@ -249,3 +249,73 @@ class KernelFn(torch.autograd.Function):
 
         del ctx
         return grad_Y, grad_R, None, None, None, None, None
+
+
+class KernelAutoBackward(Kernel):
+    def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz, normalization='norm'):
+        super(KernelAutoBackward, self).__init__(Rs_in, Rs_out, RadialModel, get_l_filters, sh, normalization)
+
+    def forward(self, r):
+        """
+        :param r: tensor [..., 3]
+        :return: tensor [..., l_out * mul_out * m_out, l_in * mul_in * m_in]
+        """
+        *size, xyz = r.size()
+        assert xyz == 3
+        r = r.reshape(-1, 3)
+
+        # precompute all needed spherical harmonics
+        Y = self.sh(self.set_of_l_filters, r)  # [l_filter * m_filter, batch]
+
+        # use the radial model to fix all the degrees of freedom
+        # note: for the normalization we assume that the variance of R[i] is one
+        radii = r.norm(2, dim=1)  # [batch]
+        R = self.R(radii)  # [batch, l_out * l_in * mul_out * mul_in * l_filter]
+
+        norm_coef = getattr(self, 'norm_coef')
+        norm_coef = norm_coef[:, :, (radii == 0).type(torch.long)]  # [l_out, l_in, batch]
+
+        batch = Y.shape[1]
+        n_in = rs.dim(self.Rs_in)
+        n_out = rs.dim(self.Rs_out)
+
+        kernel = Y.new_zeros(batch, n_out, n_in)
+
+        # note: for the normalization we assume that the variance of R[i] is one
+        begin_R = 0
+        begin_out = 0
+        for i, (mul_out, l_out, p_out) in enumerate(self.Rs_out):
+            s_out = slice(begin_out, begin_out + mul_out * (2 * l_out + 1))
+            begin_out += mul_out * (2 * l_out + 1)
+
+            begin_in = 0
+            for j, (mul_in, l_in, p_in) in enumerate(self.Rs_in):
+                s_in = slice(begin_in, begin_in + mul_in * (2 * l_in + 1))
+                begin_in += mul_in * (2 * l_in + 1)
+
+                l_filters = self.get_l_filters(l_in, p_in, l_out, p_out)
+                if not l_filters:
+                    continue
+
+                # extract the subset of the `R` that corresponds to the couple (l_out, l_in)
+                n = mul_out * mul_in * len(l_filters)
+                sub_R = R[:, begin_R: begin_R + n].contiguous().view(batch, mul_out, mul_in, -1)  # [batch, mul_out, mul_in, l_filter]
+                begin_R += n
+
+                sub_norm_coef = norm_coef[i, j]  # [batch]
+
+                # note: I don't know if we can vectorize this for loop because [l_filter * m_filter] cannot be put into [l_filter, m_filter]
+                K = 0
+                for k, l_filter in enumerate(l_filters):
+                    tmp = sum(2 * l + 1 for l in self.set_of_l_filters if l < l_filter)
+                    sub_Y = Y[tmp: tmp + 2 * l_filter + 1]  # [m, batch]
+
+                    C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=kernel)  # [m_out, m_in, m]
+
+                    # note: The multiplication with `sub_R` could also be done outside of the for loop
+                    K += torch.einsum("ijk,kz,zuv,z->zuivj", (C, sub_Y, sub_R[..., k], sub_norm_coef))  # [batch, mul_out, m_out, mul_in, m_in]
+
+                if K is not 0:
+                    kernel[:, s_out, s_in] = K.contiguous().view_as(kernel[:, s_out, s_in])
+
+        return kernel.view(*size, kernel.shape[1], kernel.shape[2])

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -1,0 +1,103 @@
+import torch
+
+import e3nn.o3 as o3
+import e3nn.rs as rs
+from e3nn.kernel import Kernel
+
+
+class KernelConv(Kernel):
+    def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz, normalization='norm'):
+        """
+        :param Rs_in: list of triplet (multiplicity, representation order, parity)
+        :param Rs_out: list of triplet (multiplicity, representation order, parity)
+        :param RadialModel: Class(d), trainable model: R -> R^d
+        :param get_l_filters: function of signature (l_in, l_out) -> [l_filter]
+        :param sh: spherical harmonics function of signature ([l_filter], xyz[..., 3]) -> Y[m, ...]
+        :param normalization: either 'norm' or 'component'
+        representation order = nonnegative integer
+        parity = 0 (no parity), 1 (even), -1 (odd)
+        """
+        super(KernelConv, self).__init__(Rs_in, Rs_out, RadialModel, get_l_filters, sh, normalization)
+
+    def forward(self, features, geometry, mask, y=None, radii=None):
+        """
+        :param features: tensor [batch, b, l_in * mul_in * m_in]
+        :param geometry: tensor [batch, a, b, xyz]
+        :param mask:     tensor [batch, b] (In order to zero contributions from padded atoms.)
+        :param y:        Optional precomputed spherical harmonics.
+        :param radii:    Optional precomputed normed geometry.
+        :return:         tensor [batch, a, l_out * mul_out * m_out]
+        """
+        batch, a, b, xyz = geometry.size()
+        assert xyz == 3
+
+        # precompute all needed spherical harmonics
+        if y is None:
+            y = self.sh(self.set_of_l_filters, geometry)  # [l_filter * m_filter, batch, a, b]
+
+        # use the radial model to fix all the degrees of freedom
+        # note: for the normalization we assume that the variance of R[i] is one
+        if radii is None:
+            radii = geometry.norm(2, dim=-1)  # [batch, a, b]
+        r = self.R(radii.flatten()).reshape(
+            *radii.shape, -1
+        )  # [batch, a, b, l_out * l_in * mul_out * mul_in * l_filter]
+
+        norm_coef = getattr(self, 'norm_coef')
+        norm_coef = norm_coef[:, :, (radii == 0).type(torch.long)]  # [l_out, l_in, batch, a, b]
+
+        kernel_conv = kernel_conv_automatic_backward(
+            features, y, r, norm_coef, self.Rs_in, self.Rs_out, self.get_l_filters, self.set_of_l_filters
+        )
+        return kernel_conv * mask.unsqueeze(-1)
+
+
+def kernel_conv_automatic_backward(features, Y, R, norm_coef, Rs_in, Rs_out, get_l_filters, set_of_l_filters):
+    batch, a, b = Y.shape[1:]
+    n_in = rs.dim(Rs_in)
+    n_out = rs.dim(Rs_out)
+
+    kernel_conv = Y.new_zeros(batch, a, n_out)
+
+    # note: for the normalization we assume that the variance of R[i] is one
+    begin_R = 0
+
+    begin_out = 0
+    for i, (mul_out, l_out, p_out) in enumerate(Rs_out):
+        s_out = slice(begin_out, begin_out + mul_out * (2 * l_out + 1))
+        begin_out += mul_out * (2 * l_out + 1)
+
+        begin_in = 0
+        for j, (mul_in, l_in, p_in) in enumerate(Rs_in):
+            s_in = slice(begin_in, begin_in + mul_in * (2 * l_in + 1))
+            begin_in += mul_in * (2 * l_in + 1)
+
+            l_filters = get_l_filters(l_in, p_in, l_out, p_out)
+            if not l_filters:
+                continue
+
+            # extract the subset of the `R` that corresponds to the couple (l_out, l_in)
+            n = mul_out * mul_in * len(l_filters)
+            sub_R = R[:, :, :, begin_R: begin_R + n].contiguous().view(
+                batch, a, b, mul_out, mul_in, -1
+            )  # [batch, a, b, mul_out, mul_in, l_filter]
+            begin_R += n
+
+            sub_norm_coef = norm_coef[i, j]  # [batch]
+
+            K = 0
+            for k, l_filter in enumerate(l_filters):
+                offset = sum(2 * l + 1 for l in set_of_l_filters if l < l_filter)
+                sub_Y = Y[offset: offset + 2 * l_filter + 1, ...]  # [m, batch, a, b]
+
+                C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=kernel_conv)  # [m_out, m_in, m]
+
+                K += torch.einsum(
+                    "ijk,kzab,zabuv,zab,zbvj->zaui",
+                    C, sub_Y, sub_R[..., k], sub_norm_coef, features[..., s_in].view(batch, b, mul_in, -1)
+                )  # [batch, a, mul_out, m_out]
+
+            if K is not 0:
+                kernel_conv[:, :, s_out] += K.view(batch, a, -1)
+
+    return kernel_conv

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -23,7 +23,7 @@ class KernelConv(Kernel):
         """
         :param features: tensor [batch, b, l_in * mul_in * m_in]
         :param geometry: tensor [batch, a, b, xyz]
-        :param mask:     tensor [batch, b] (In order to zero contributions from padded atoms.)
+        :param mask:     tensor [batch, a] (In order to zero contributions from padded atoms.)
         :param y:        Optional precomputed spherical harmonics.
         :param radii:    Optional precomputed normed geometry.
         :return:         tensor [batch, a, l_out * mul_out * m_out]

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -39,7 +39,7 @@ class KernelConv(Kernel):
         # note: for the normalization we assume that the variance of R[i] is one
         if radii is None:
             radii = geometry.norm(2, dim=-1)  # [batch, a, b]
-        r = self.R(radii.flatten()).reshape(
+        r = self.R(radii.flatten()).view(
             *radii.shape, -1
         )  # [batch, a, b, l_out * l_in * mul_out * mul_in * l_filter]
 

--- a/tests/kernel_test.py
+++ b/tests/kernel_test.py
@@ -2,7 +2,8 @@
 import unittest
 
 import torch
-from e3nn.kernel import Kernel, KernelFn
+
+from e3nn.kernel import Kernel, KernelFn, KernelAutoBackward
 from e3nn.radial import ConstantRadialModel
 
 
@@ -32,6 +33,34 @@ class Tests(unittest.TestCase):
                 Y, R, norm_coef, kernel.Rs_in, kernel.Rs_out, kernel.get_l_filters, kernel.set_of_l_filters
             )
             self.assertTrue(torch.autograd.gradcheck(KernelFn.apply, inputs))
+
+
+class TestCompare(unittest.TestCase):
+    def setUp(self):
+        super(TestCompare, self).setUp()
+        torch.set_default_dtype(torch.float64)
+        torch.backends.cudnn.deterministic = True
+        self.Rs_in = [(1, 0), (1, 1), (2, 0), (1, 2)]
+        self.Rs_out = [(2, 0), (1, 1), (1, 2), (3, 0)]
+
+        batch = 100
+        atoms = 40
+        self.geometry = torch.rand(batch, atoms, 3)
+
+        self.msg = "Kernel parameters were not identical. This means the test cannot compare outputs."
+
+    def test_compare_forward(self):
+        for normalization in ["norm", "component"]:
+            torch.manual_seed(0)
+            K = Kernel(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
+            new_features = K(self.geometry)
+
+            torch.manual_seed(0)
+            K = KernelAutoBackward(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
+            check_new_features = K(self.geometry)
+
+            assert all(torch.all(a == b) for a, b in zip(K.parameters(), K.parameters())), self.msg
+            self.assertTrue(torch.allclose(new_features, check_new_features))
 
 
 if __name__ == '__main__':

--- a/tests/point/kernelconv_test.py
+++ b/tests/point/kernelconv_test.py
@@ -1,0 +1,78 @@
+# pylint: disable=C,E1101,E1102
+import unittest
+from functools import partial
+
+import torch
+
+from e3nn.kernel import Kernel
+from e3nn.radial import ConstantRadialModel
+from e3nn.point.operations import Convolution
+from e3nn.point.kernelconv import KernelConv
+from e3nn.rs import dim
+
+
+class TestKernelConv(unittest.TestCase):
+    def setUp(self):
+        super(TestKernelConv, self).setUp()
+        torch.set_default_dtype(torch.float64)
+        torch.backends.cudnn.deterministic = True
+        self.Rs_in = [(1, 0), (1, 1), (2, 0), (1, 2)]
+        self.Rs_out = [(2, 0), (1, 1), (1, 2), (3, 0)]
+
+        batch = 100
+        atoms = 40
+        self.geometry = torch.rand(batch, atoms, 3)
+        rb = self.geometry.unsqueeze(1)  # [batch, 1, b, xyz]
+        ra = self.geometry.unsqueeze(2)  # [batch, a, 1, xyz]
+        self.r = rb - ra
+        self.features = torch.rand(batch, atoms, dim(self.Rs_in), requires_grad=True)
+        self.mask = torch.ones(batch, atoms)
+
+        self.msg = "Kernel or Convolution parameters were not identical. This means the test cannot compare outputs."
+
+    def test_compare_forward(self):
+        for normalization in ["norm", "component"]:
+            torch.manual_seed(0)
+            K = partial(Kernel, RadialModel=ConstantRadialModel, normalization=normalization)
+            C = Convolution(K, self.Rs_in, self.Rs_out)
+            new_features = C(self.features, self.geometry) * self.mask.unsqueeze(dim=-1)
+
+            torch.manual_seed(0)
+            KC = KernelConv(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
+            check_new_features = KC(self.features, self.r, self.mask)
+
+            assert all(torch.all(a == b) for a, b in zip(C.kernel.parameters(), KC.parameters())), self.msg
+            self.assertTrue(torch.allclose(new_features, check_new_features))
+
+    def test_compare_backward(self):
+        check_features = self.features.clone().detach().requires_grad_()
+        check_r = self.r.clone().detach()
+        check_mask = self.mask.clone().detach()
+
+        for normalization in ["norm", "component"]:
+            torch.manual_seed(0)
+            K = partial(Kernel, RadialModel=ConstantRadialModel, normalization=normalization)
+            C = Convolution(K, self.Rs_in, self.Rs_out)
+            new_features = C(self.features, self.geometry) * self.mask.unsqueeze(dim=-1)
+
+            torch.manual_seed(0)
+            KC = KernelConv(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
+            check_new_features = KC(check_features, check_r, check_mask)
+
+            assert all(torch.all(a == b) for a, b in zip(C.kernel.parameters(), KC.parameters())), self.msg
+
+            # Capture ground truth gradient
+            target = torch.rand_like(new_features)
+            loss = torch.norm(new_features - target)
+            loss.backward()
+
+            # Capture KernelConv gradient
+            check_target = target.clone().detach()
+            check_loss = torch.norm(check_new_features - check_target)
+            check_loss.backward()
+
+            self.assertTrue(torch.allclose(self.features.grad, check_features.grad))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This introduces a new feature KernelConv.

Adds custom forward and backward function for convolution.

Adds automatic backwards (normal pytorch behavior) Kernel. I suggest we use this by default. Right now it is listed as a separate function which has a corresponding test case.

Although it is only for a QM9 style problem (i.e. shape of input) KernelConv combines the two operations just as was requested in the optimization project.