### PR TITLE
Introduced KernelConv, Introduced custom backward pass options for kernel and convolution and KernelConv

### DIFF
--- a/e3nn/kernel.py
+++ b/e3nn/kernel.py
@@ -7,7 +7,8 @@ from e3nn import o3, rs
 
 
 class Kernel(torch.nn.Module):
-    def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz, normalization='norm'):
+    def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz,
+                 normalization='norm', custom_backward=False):
         """
         :param Rs_in: list of triplet (multiplicity, representation order, parity)
         :param Rs_out: list of triplet (multiplicity, representation order, parity)
@@ -15,10 +16,12 @@ class Kernel(torch.nn.Module):
         :param get_l_filters: function of signature (l_in, l_out) -> [l_filter]
         :param sh: spherical harmonics function of signature ([l_filter], xyz[..., 3]) -> Y[m, ...]
         :param normalization: either 'norm' or 'component'
+        :param custom_backward: call KernelFn rather than using automatic differentiation
         representation order = nonnegative integer
         parity = 0 (no parity), 1 (even), -1 (odd)
         """
         super().__init__()
+        self.custom_backward = custom_backward
 
         self.Rs_in = rs.simplify(Rs_in)
         self.Rs_out = rs.simplify(Rs_out)
@@ -125,7 +128,52 @@ class Kernel(torch.nn.Module):
         norm_coef = getattr(self, 'norm_coef')
         norm_coef = norm_coef[:, :, (radii == 0).type(torch.long)]  # [l_out, l_in, batch]
 
-        kernel = KernelFn.apply(Y, R, norm_coef, self.Rs_in, self.Rs_out, self.get_l_filters, self.set_of_l_filters)
+        if self.custom_backward:
+            kernel = KernelFn.apply(Y, R, norm_coef, self.Rs_in, self.Rs_out, self.get_l_filters, self.set_of_l_filters)
+        else:
+            batch = Y.shape[1]
+            n_in = rs.dim(self.Rs_in)
+            n_out = rs.dim(self.Rs_out)
+
+            kernel = Y.new_zeros(batch, n_out, n_in)
+
+            # note: for the normalization we assume that the variance of R[i] is one
+            begin_R = 0
+            begin_out = 0
+            for i, (mul_out, l_out, p_out) in enumerate(self.Rs_out):
+                s_out = slice(begin_out, begin_out + mul_out * (2 * l_out + 1))
+                begin_out += mul_out * (2 * l_out + 1)
+
+                begin_in = 0
+                for j, (mul_in, l_in, p_in) in enumerate(self.Rs_in):
+                    s_in = slice(begin_in, begin_in + mul_in * (2 * l_in + 1))
+                    begin_in += mul_in * (2 * l_in + 1)
+
+                    l_filters = self.get_l_filters(l_in, p_in, l_out, p_out)
+                    if not l_filters:
+                        continue
+
+                    # extract the subset of the `R` that corresponds to the couple (l_out, l_in)
+                    n = mul_out * mul_in * len(l_filters)
+                    sub_R = R[:, begin_R: begin_R + n].contiguous().view(batch, mul_out, mul_in, -1)  # [batch, mul_out, mul_in, l_filter]
+                    begin_R += n
+
+                    sub_norm_coef = norm_coef[i, j]  # [batch]
+
+                    # note: I don't know if we can vectorize this for loop because [l_filter * m_filter] cannot be put into [l_filter, m_filter]
+                    K = 0
+                    for k, l_filter in enumerate(l_filters):
+                        tmp = sum(2 * l + 1 for l in self.set_of_l_filters if l < l_filter)
+                        sub_Y = Y[tmp: tmp + 2 * l_filter + 1]  # [m, batch]
+
+                        C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=kernel)  # [m_out, m_in, m]
+
+                        # note: The multiplication with `sub_R` could also be done outside of the for loop
+                        K += torch.einsum("ijk,kz,zuv,z->zuivj", (C, sub_Y, sub_R[..., k], sub_norm_coef))  # [batch, mul_out, m_out, mul_in, m_in]
+
+                    if K is not 0:
+                        kernel[:, s_out, s_in] = K.contiguous().view_as(kernel[:, s_out, s_in])
+
         return kernel.view(*size, kernel.shape[1], kernel.shape[2])
 
 
@@ -249,73 +297,3 @@ class KernelFn(torch.autograd.Function):
 
         del ctx
         return grad_Y, grad_R, None, None, None, None, None
-
-
-class KernelAutoBackward(Kernel):
-    def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz, normalization='norm'):
-        super(KernelAutoBackward, self).__init__(Rs_in, Rs_out, RadialModel, get_l_filters, sh, normalization)
-
-    def forward(self, r):
-        """
-        :param r: tensor [..., 3]
-        :return: tensor [..., l_out * mul_out * m_out, l_in * mul_in * m_in]
-        """
-        *size, xyz = r.size()
-        assert xyz == 3
-        r = r.reshape(-1, 3)
-
-        # precompute all needed spherical harmonics
-        Y = self.sh(self.set_of_l_filters, r)  # [l_filter * m_filter, batch]
-
-        # use the radial model to fix all the degrees of freedom
-        # note: for the normalization we assume that the variance of R[i] is one
-        radii = r.norm(2, dim=1)  # [batch]
-        R = self.R(radii)  # [batch, l_out * l_in * mul_out * mul_in * l_filter]
-
-        norm_coef = getattr(self, 'norm_coef')
-        norm_coef = norm_coef[:, :, (radii == 0).type(torch.long)]  # [l_out, l_in, batch]
-
-        batch = Y.shape[1]
-        n_in = rs.dim(self.Rs_in)
-        n_out = rs.dim(self.Rs_out)
-
-        kernel = Y.new_zeros(batch, n_out, n_in)
-
-        # note: for the normalization we assume that the variance of R[i] is one
-        begin_R = 0
-        begin_out = 0
-        for i, (mul_out, l_out, p_out) in enumerate(self.Rs_out):
-            s_out = slice(begin_out, begin_out + mul_out * (2 * l_out + 1))
-            begin_out += mul_out * (2 * l_out + 1)
-
-            begin_in = 0
-            for j, (mul_in, l_in, p_in) in enumerate(self.Rs_in):
-                s_in = slice(begin_in, begin_in + mul_in * (2 * l_in + 1))
-                begin_in += mul_in * (2 * l_in + 1)
-
-                l_filters = self.get_l_filters(l_in, p_in, l_out, p_out)
-                if not l_filters:
-                    continue
-
-                # extract the subset of the `R` that corresponds to the couple (l_out, l_in)
-                n = mul_out * mul_in * len(l_filters)
-                sub_R = R[:, begin_R: begin_R + n].contiguous().view(batch, mul_out, mul_in, -1)  # [batch, mul_out, mul_in, l_filter]
-                begin_R += n
-
-                sub_norm_coef = norm_coef[i, j]  # [batch]
-
-                # note: I don't know if we can vectorize this for loop because [l_filter * m_filter] cannot be put into [l_filter, m_filter]
-                K = 0
-                for k, l_filter in enumerate(l_filters):
-                    tmp = sum(2 * l + 1 for l in self.set_of_l_filters if l < l_filter)
-                    sub_Y = Y[tmp: tmp + 2 * l_filter + 1]  # [m, batch]
-
-                    C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=kernel)  # [m_out, m_in, m]
-
-                    # note: The multiplication with `sub_R` could also be done outside of the for loop
-                    K += torch.einsum("ijk,kz,zuv,z->zuivj", (C, sub_Y, sub_R[..., k], sub_norm_coef))  # [batch, mul_out, m_out, mul_in, m_in]
-
-                if K is not 0:
-                    kernel[:, s_out, s_in] = K.contiguous().view_as(kernel[:, s_out, s_in])
-
-        return kernel.view(*size, kernel.shape[1], kernel.shape[2])

--- a/e3nn/kernel.py
+++ b/e3nn/kernel.py
@@ -129,61 +129,68 @@ class Kernel(torch.nn.Module):
         if custom_backward:
             kernel = KernelFn.apply(Y, R, norm_coef, self.Rs_in, self.Rs_out, self.get_l_filters, self.set_of_l_filters)
         else:
-            batch = Y.shape[1]
-            n_in = rs.dim(self.Rs_in)
-            n_out = rs.dim(self.Rs_out)
-
-            kernel = Y.new_zeros(batch, n_out, n_in)
-
-            # note: for the normalization we assume that the variance of R[i] is one
-            begin_R = 0
-            begin_out = 0
-            for i, (mul_out, l_out, p_out) in enumerate(self.Rs_out):
-                s_out = slice(begin_out, begin_out + mul_out * (2 * l_out + 1))
-                begin_out += mul_out * (2 * l_out + 1)
-
-                begin_in = 0
-                for j, (mul_in, l_in, p_in) in enumerate(self.Rs_in):
-                    s_in = slice(begin_in, begin_in + mul_in * (2 * l_in + 1))
-                    begin_in += mul_in * (2 * l_in + 1)
-
-                    l_filters = self.get_l_filters(l_in, p_in, l_out, p_out)
-                    if not l_filters:
-                        continue
-
-                    # extract the subset of the `R` that corresponds to the couple (l_out, l_in)
-                    n = mul_out * mul_in * len(l_filters)
-                    sub_R = R[:, begin_R: begin_R + n].contiguous().view(batch, mul_out, mul_in, -1)  # [batch, mul_out, mul_in, l_filter]
-                    begin_R += n
-
-                    sub_norm_coef = norm_coef[i, j]  # [batch]
-
-                    # note: I don't know if we can vectorize this for loop because [l_filter * m_filter] cannot be put into [l_filter, m_filter]
-                    K = 0
-                    for k, l_filter in enumerate(l_filters):
-                        tmp = sum(2 * l + 1 for l in self.set_of_l_filters if l < l_filter)
-                        sub_Y = Y[tmp: tmp + 2 * l_filter + 1]  # [m, batch]
-
-                        C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=kernel)  # [m_out, m_in, m]
-
-                        # note: The multiplication with `sub_R` could also be done outside of the for loop
-                        K += torch.einsum("ijk,kz,zuv,z->zuivj", (C, sub_Y, sub_R[..., k], sub_norm_coef))  # [batch, mul_out, m_out, mul_in, m_in]
-
-                    if K is not 0:
-                        kernel[:, s_out, s_in] = K.contiguous().view_as(kernel[:, s_out, s_in])
+            kernel = kernel_fn_forward(Y, R, norm_coef, self.Rs_in, self.Rs_out, self.get_l_filters, self.set_of_l_filters)
 
         return kernel.view(*size, kernel.shape[1], kernel.shape[2])
+
+
+def kernel_fn_forward(Y, R, norm_coef, Rs_in, Rs_out, get_l_filters, set_of_l_filters):
+    """
+    :param Y: tensor [l_filter * m_filter, batch]
+    :param R: tensor [batch, l_out * l_in * mul_out * mul_in * l_filter]
+    :param norm_coef: tensor [l_out, l_in, batch]
+    :return: tensor [batch, l_out * mul_out * m_out, l_in * mul_in * m_in]
+    """
+    batch = Y.shape[1]
+    n_in = rs.dim(Rs_in)
+    n_out = rs.dim(Rs_out)
+
+    kernel = Y.new_zeros(batch, n_out, n_in)
+
+    # note: for the normalization we assume that the variance of R[i] is one
+    begin_R = 0
+
+    begin_out = 0
+    for i, (mul_out, l_out, p_out) in enumerate(Rs_out):
+        s_out = slice(begin_out, begin_out + mul_out * (2 * l_out + 1))
+        begin_out += mul_out * (2 * l_out + 1)
+
+        begin_in = 0
+        for j, (mul_in, l_in, p_in) in enumerate(Rs_in):
+            s_in = slice(begin_in, begin_in + mul_in * (2 * l_in + 1))
+            begin_in += mul_in * (2 * l_in + 1)
+
+            l_filters = get_l_filters(l_in, p_in, l_out, p_out)
+            if not l_filters:
+                continue
+
+            # extract the subset of the `R` that corresponds to the couple (l_out, l_in)
+            n = mul_out * mul_in * len(l_filters)
+            sub_R = R[:, begin_R: begin_R + n].contiguous().view(batch, mul_out, mul_in, -1)  # [batch, mul_out, mul_in, l_filter]
+            begin_R += n
+
+            sub_norm_coef = norm_coef[i, j]  # [batch]
+
+            # note: I don't know if we can vectorize this for loop because [l_filter * m_filter] cannot be put into [l_filter, m_filter]
+            K = 0
+            for k, l_filter in enumerate(l_filters):
+                tmp = sum(2 * l + 1 for l in set_of_l_filters if l < l_filter)
+                sub_Y = Y[tmp: tmp + 2 * l_filter + 1]  # [m, batch]
+
+                C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=kernel)  # [m_out, m_in, m]
+
+                # note: The multiplication with `sub_R` could also be done outside of the for loop
+                K += torch.einsum("ijk,kz,zuv,z->zuivj", (C, sub_Y, sub_R[..., k], sub_norm_coef))  # [batch, mul_out, m_out, mul_in, m_in]
+
+            if K is not 0:
+                kernel[:, s_out, s_in] = K.contiguous().view_as(kernel[:, s_out, s_in])
+    return kernel
 
 
 class KernelFn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, Y, R, norm_coef, Rs_in, Rs_out, get_l_filters, set_of_l_filters):
-        """
-        :param Y: tensor [l_filter * m_filter, batch]
-        :param R: tensor [batch, l_out * l_in * mul_out * mul_in * l_filter]
-        :param norm_coef: tensor [l_out, l_in, batch]
-        :return: tensor [batch, l_out * mul_out * m_out, l_in * mul_in * m_in]
-        """
+        f"""{kernel_fn_forward.__doc__}"""
         ctx.Rs_in = Rs_in
         ctx.Rs_out = Rs_out
         ctx.get_l_filters = get_l_filters
@@ -199,51 +206,7 @@ class KernelFn(torch.autograd.Function):
             saved_Y = Y
         ctx.save_for_backward(saved_Y, saved_R, norm_coef)
 
-        batch = Y.shape[1]
-        n_in = rs.dim(ctx.Rs_in)
-        n_out = rs.dim(ctx.Rs_out)
-
-        kernel = Y.new_zeros(batch, n_out, n_in)
-
-        # note: for the normalization we assume that the variance of R[i] is one
-        begin_R = 0
-
-        begin_out = 0
-        for i, (mul_out, l_out, p_out) in enumerate(ctx.Rs_out):
-            s_out = slice(begin_out, begin_out + mul_out * (2 * l_out + 1))
-            begin_out += mul_out * (2 * l_out + 1)
-
-            begin_in = 0
-            for j, (mul_in, l_in, p_in) in enumerate(ctx.Rs_in):
-                s_in = slice(begin_in, begin_in + mul_in * (2 * l_in + 1))
-                begin_in += mul_in * (2 * l_in + 1)
-
-                l_filters = ctx.get_l_filters(l_in, p_in, l_out, p_out)
-                if not l_filters:
-                    continue
-
-                # extract the subset of the `R` that corresponds to the couple (l_out, l_in)
-                n = mul_out * mul_in * len(l_filters)
-                sub_R = R[:, begin_R: begin_R + n].contiguous().view(batch, mul_out, mul_in, -1)  # [batch, mul_out, mul_in, l_filter]
-                begin_R += n
-
-                sub_norm_coef = norm_coef[i, j]  # [batch]
-
-                # note: I don't know if we can vectorize this for loop because [l_filter * m_filter] cannot be put into [l_filter, m_filter]
-                K = 0
-                for k, l_filter in enumerate(l_filters):
-                    tmp = sum(2 * l + 1 for l in ctx.set_of_l_filters if l < l_filter)
-                    sub_Y = Y[tmp: tmp + 2 * l_filter + 1]  # [m, batch]
-
-                    C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=kernel)  # [m_out, m_in, m]
-
-                    # note: The multiplication with `sub_R` could also be done outside of the for loop
-                    K += torch.einsum("ijk,kz,zuv,z->zuivj", (C, sub_Y, sub_R[..., k], sub_norm_coef))  # [batch, mul_out, m_out, mul_in, m_in]
-
-                if K is not 0:
-                    kernel[:, s_out, s_in] = K.contiguous().view_as(kernel[:, s_out, s_in])
-
-        return kernel
+        return kernel_fn_forward(Y, R, norm_coef, ctx.Rs_in, ctx.Rs_out, ctx.get_l_filters, ctx.set_of_l_filters)
 
     @staticmethod
     def backward(ctx, grad_kernel):
@@ -274,9 +237,13 @@ class KernelFn(torch.autograd.Function):
 
                 n = mul_out * mul_in * len(l_filters)
                 if grad_Y is not None:
-                    sub_R = R[:, begin_R: begin_R + n].view(-1, mul_out, mul_in, len(l_filters))  # [batch, mul_out, mul_in, l_filter]
+                    sub_R = R[:, begin_R: begin_R + n].view(
+                        -1, mul_out, mul_in, len(l_filters)
+                    )  # [batch, mul_out, mul_in, l_filter]
                 if grad_R is not None:
-                    sub_grad_R = grad_R[:, begin_R: begin_R + n].view(-1, mul_out, mul_in, len(l_filters))  # [batch, mul_out, mul_in, l_filter]
+                    sub_grad_R = grad_R[:, begin_R: begin_R + n].view(
+                        -1, mul_out, mul_in, len(l_filters)
+                    )  # [batch, mul_out, mul_in, l_filter]
                 begin_R += n
 
                 grad_K = grad_kernel[:, s_out, s_in].view(-1, mul_out, 2 * l_out + 1, mul_in, 2 * l_in + 1)
@@ -288,10 +255,16 @@ class KernelFn(torch.autograd.Function):
                     C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=grad_kernel)  # [m_out, m_in, m]
 
                     if grad_Y is not None:
-                        grad_Y[tmp: tmp + 2 * l_filter + 1] += torch.einsum("zuivj,ijk,zuv,z->kz", grad_K, C, sub_R[..., k], sub_norm_coef)
+                        grad_Y[tmp: tmp + 2 * l_filter + 1] += torch.einsum(
+                            "zuivj,ijk,zuv,z->kz",
+                            grad_K, C, sub_R[..., k], sub_norm_coef
+                        )
                     if grad_R is not None:
                         sub_Y = Y[tmp: tmp + 2 * l_filter + 1]  # [m, batch]
-                        sub_grad_R[..., k] = torch.einsum("zuivj,ijk,kz,z->zuv", grad_K, C, sub_Y, sub_norm_coef)
+                        sub_grad_R[..., k] = torch.einsum(
+                            "zuivj,ijk,kz,z->zuv",
+                            grad_K, C, sub_Y, sub_norm_coef
+                        )
 
         del ctx
         return grad_Y, grad_R, None, None, None, None, None

--- a/e3nn/kernel.py
+++ b/e3nn/kernel.py
@@ -7,8 +7,7 @@ from e3nn import o3, rs
 
 
 class Kernel(torch.nn.Module):
-    def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz,
-                 normalization='norm'):
+    def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz, normalization='norm'):
         """
         :param Rs_in: list of triplet (multiplicity, representation order, parity)
         :param Rs_out: list of triplet (multiplicity, representation order, parity)

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -131,13 +131,16 @@ class KernelConvFn(torch.autograd.Function):
         saved_Y = saved_R = saved_F = None
         if F.requires_grad:
             ctx.F_shape = F.shape
-            saved_F = F
+            saved_R = R
+            saved_Y = Y
         if Y.requires_grad:
             ctx.Y_shape = Y.shape
             saved_R = R
+            saved_F = F
         if R.requires_grad:
             ctx.R_shape = R.shape
             saved_Y = Y
+            saved_F = F
         ctx.save_for_backward(saved_F, saved_Y, saved_R, norm_coef)
 
         return kernel_conv_fn_forward(
@@ -175,7 +178,7 @@ class KernelConvFn(torch.autograd.Function):
                     continue
 
                 n = mul_out * mul_in * len(l_filters)
-                if grad_Y is not None:
+                if (grad_Y is not None) or (grad_F is not None):
                     sub_R = R[:, :, :, begin_R: begin_R + n].contiguous().view(
                         batch, a, b, mul_out, mul_in, -1
                     )  # [batch, a, b, mul_out, mul_in, l_filter]

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -19,13 +19,14 @@ class KernelConv(Kernel):
         """
         super(KernelConv, self).__init__(Rs_in, Rs_out, RadialModel, get_l_filters, sh, normalization)
 
-    def forward(self, features, difference_geometry, mask, y=None, radii=None):
+    def forward(self, features, difference_geometry, mask, y=None, radii=None, custom_backward=False):
         """
         :param features: tensor [batch, b, l_in * mul_in * m_in]
         :param difference_geometry: tensor [batch, a, b, xyz]
         :param mask:     tensor [batch, a] (In order to zero contributions from padded atoms.)
         :param y:        Optional precomputed spherical harmonics.
         :param radii:    Optional precomputed normed geometry.
+        :param custom_backward: call KernelConvFn rather than using automatic differentiation
         :return:         tensor [batch, a, l_out * mul_out * m_out]
         """
         batch, a, b, xyz = difference_geometry.size()
@@ -46,13 +47,26 @@ class KernelConv(Kernel):
         norm_coef = getattr(self, 'norm_coef')
         norm_coef = norm_coef[:, :, (radii == 0).type(torch.long)]  # [l_out, l_in, batch, a, b]
 
-        kernel_conv = kernel_conv_automatic_backward(
-            features, y, r, norm_coef, self.Rs_in, self.Rs_out, self.get_l_filters, self.set_of_l_filters
-        )
+        if custom_backward:
+            kernel_conv = KernelConvFn.apply(
+                features, y, r, norm_coef, self.Rs_in, self.Rs_out, self.get_l_filters, self.set_of_l_filters
+            )
+        else:
+            kernel_conv = kernel_conv_fn_forward(
+                features, y, r, norm_coef, self.Rs_in, self.Rs_out, self.get_l_filters, self.set_of_l_filters
+            )
+
         return kernel_conv * mask.unsqueeze(-1)
 
 
-def kernel_conv_automatic_backward(features, Y, R, norm_coef, Rs_in, Rs_out, get_l_filters, set_of_l_filters):
+def kernel_conv_fn_forward(F, Y, R, norm_coef, Rs_in, Rs_out, get_l_filters, set_of_l_filters):
+    """
+    :param F: tensor [batch, b, l_in * mul_in * m_in]
+    :param Y: tensor [l_filter * m_filter, batch, a, b]
+    :param R: tensor [batch, a, b, l_out * l_in * mul_out * mul_in * l_filter]
+    :param norm_coef: tensor [l_out, l_in, batch, a, b]
+    :return: tensor [batch, a, l_out * mul_out * m_out, l_in * mul_in * m_in]
+    """
     batch, a, b = Y.shape[1:]
     n_in = rs.dim(Rs_in)
     n_out = rs.dim(Rs_out)
@@ -94,10 +108,108 @@ def kernel_conv_automatic_backward(features, Y, R, norm_coef, Rs_in, Rs_out, get
 
                 K += torch.einsum(
                     "ijk,kzab,zabuv,zab,zbvj->zaui",
-                    C, sub_Y, sub_R[..., k], sub_norm_coef, features[..., s_in].view(batch, b, mul_in, -1)
+                    C, sub_Y, sub_R[..., k], sub_norm_coef, F[..., s_in].view(batch, b, mul_in, -1)
                 )  # [batch, a, mul_out, m_out]
 
             if K is not 0:
                 kernel_conv[:, :, s_out] += K.view(batch, a, -1)
 
     return kernel_conv
+
+
+class KernelConvFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, F, Y, R, norm_coef, Rs_in, Rs_out, get_l_filters, set_of_l_filters):
+        f"""{kernel_conv_fn_forward.__doc__}"""
+        ctx.batch, ctx.a, ctx.b = Y.shape[1:]
+        ctx.Rs_in = Rs_in
+        ctx.Rs_out = Rs_out
+        ctx.get_l_filters = get_l_filters
+        ctx.set_of_l_filters = set_of_l_filters
+
+        # save necessary tensors for backward
+        saved_Y = saved_R = saved_F = None
+        if F.requires_grad:
+            ctx.F_shape = F.shape
+            saved_F = F
+        if Y.requires_grad:
+            ctx.Y_shape = Y.shape
+            saved_R = R
+        if R.requires_grad:
+            ctx.R_shape = R.shape
+            saved_Y = Y
+        ctx.save_for_backward(saved_F, saved_Y, saved_R, norm_coef)
+
+        return kernel_conv_fn_forward(
+            F, Y, R, norm_coef, ctx.Rs_in, ctx.Rs_out, ctx.get_l_filters, ctx.set_of_l_filters
+        )
+
+    @staticmethod
+    def backward(ctx, grad_kernel):
+        F, Y, R, norm_coef = ctx.saved_tensors
+        batch, a, b = ctx.batch, ctx.a, ctx.b
+
+        grad_F = grad_Y = grad_R = None
+
+        if ctx.needs_input_grad[0]:
+            grad_F = grad_kernel.new_zeros(*ctx.F_shape)  # [batch, b, l_in * mul_in * m_in]
+        if ctx.needs_input_grad[1]:
+            grad_Y = grad_kernel.new_zeros(*ctx.Y_shape)  # [l_filter * m_filter, batch, a, b]
+        if ctx.needs_input_grad[2]:
+            grad_R = grad_kernel.new_zeros(*ctx.R_shape)  # [batch, a, b, l_out * l_in * mul_out * mul_in * l_filter]
+
+        begin_R = 0
+
+        begin_out = 0
+        for i, (mul_out, l_out, p_out) in enumerate(ctx.Rs_out):
+            s_out = slice(begin_out, begin_out + mul_out * (2 * l_out + 1))
+            begin_out += mul_out * (2 * l_out + 1)
+
+            begin_in = 0
+            for j, (mul_in, l_in, p_in) in enumerate(ctx.Rs_in):
+                s_in = slice(begin_in, begin_in + mul_in * (2 * l_in + 1))
+                begin_in += mul_in * (2 * l_in + 1)
+
+                l_filters = ctx.get_l_filters(l_in, p_in, l_out, p_out)
+                if not l_filters:
+                    continue
+
+                # if grad_F is not None:
+                #     pass  # TODO
+                n = mul_out * mul_in * len(l_filters)
+                if grad_Y is not None:
+                    sub_R = R[:, :, :, begin_R: begin_R + n].contiguous().view(
+                        batch, a, b, mul_out, mul_in, -1
+                    )  # [batch, a, b, mul_out, mul_in, l_filter]
+                if grad_R is not None:
+                    sub_grad_R = grad_R[:, :, :, begin_R: begin_R + n].contiguous().view(
+                        batch, a, b, mul_out, mul_in, -1
+                    )  # [batch, a, b, mul_out, mul_in, l_filter]
+                begin_R += n
+
+                grad_K = grad_kernel[:, :, s_out].view(
+                    batch, a, mul_out, 2 * l_out + 1
+                )
+
+                sub_norm_coef = norm_coef[i, j]  # [batch, a, b]
+
+                for k, l_filter in enumerate(l_filters):
+                    tmp = sum(2 * l + 1 for l in ctx.set_of_l_filters if l < l_filter)
+                    C = o3.clebsch_gordan(l_out, l_in, l_filter, cached=True, like=grad_kernel)  # [m_out, m_in, m]
+
+                    if grad_F is not None:
+                        pass  # TODO
+                    if grad_Y is not None:
+                        grad_Y[tmp: tmp + 2 * l_filter + 1, ...] += torch.einsum(
+                            "zui,ijk,zuv,z->kz",
+                            grad_K, C, sub_R[..., k], sub_norm_coef
+                        )
+                    if grad_R is not None:
+                        sub_Y = Y[tmp: tmp + 2 * l_filter + 1, ...]  # [m, batch, a, b]
+                        sub_grad_R[..., k] = torch.einsum(
+                            "zaui,ijk,kzab,zab,zbvj->zabuv",
+                            grad_K, C, sub_Y, sub_norm_coef, F[..., s_in].view(batch, b, mul_in, -1)
+                        )  # TODO did this one??!!
+
+
+        return grad_F, grad_Y, grad_R, None, None, None, None, None

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -19,14 +19,14 @@ class KernelConv(Kernel):
         """
         super(KernelConv, self).__init__(Rs_in, Rs_out, RadialModel, get_l_filters, sh, normalization)
 
-    def forward(self, features, difference_geometry, mask, y=None, radii=None, custom_backward=False):
+    def forward(self, features, difference_geometry, mask, y=None, radii=None, custom_backward=True):
         """
         :param features: tensor [batch, b, l_in * mul_in * m_in]
         :param difference_geometry: tensor [batch, a, b, xyz]
         :param mask:     tensor [batch, a] (In order to zero contributions from padded atoms.)
         :param y:        Optional precomputed spherical harmonics.
         :param radii:    Optional precomputed normed geometry.
-        :param custom_backward: call KernelConvFn rather than using automatic differentiation
+        :param custom_backward: call KernelConvFn rather than using automatic differentiation, (default True)
         :return:         tensor [batch, a, l_out * mul_out * m_out]
         """
         batch, a, b, xyz = difference_geometry.size()

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -39,7 +39,7 @@ class KernelConv(Kernel):
         # note: for the normalization we assume that the variance of R[i] is one
         if radii is None:
             radii = geometry.norm(2, dim=-1)  # [batch, a, b]
-        r = self.R(radii.flatten()).reshape(
+        r = self.R(radii.flatten()).view(
             *radii.shape, -1
         )  # [batch, a, b, l_out * l_in * mul_out * mul_in * l_filter]
 

--- a/e3nn/point/operations.py
+++ b/e3nn/point/operations.py
@@ -34,8 +34,7 @@ class ConvolutionEinsumFn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, k, features):
         ctx.save_for_backward(k, features)
-        a = torch.einsum("zabij,zbj->zai", k, features)  # [batch, point, channel]
-        return a
+        return torch.einsum("zabij,zbj->zai", k, features)  # [batch, point, channel]
 
     @staticmethod
     def backward(ctx, grad_output):

--- a/e3nn/point/operations.py
+++ b/e3nn/point/operations.py
@@ -31,12 +31,13 @@ class Convolution(torch.nn.Module):
 
 
 class ConvolutionEinsumFn(torch.autograd.Function):
-    """
-    Forward and backward written explicitly for the Convolution Function.
-    Educational rather than used in practice.
-    """
+    """Forward and backward written explicitly for the Convolution Function."""
     @staticmethod
     def forward(ctx, k, features):
+        """
+        :param k:        tensor [batch, out_point, in_point, l_out * mul_out * m_out, l_in * mul_in * m_in]
+        :param features: tensor [batch, in_point, l_in * mul_in * m_in]
+        """
         ctx.save_for_backward(k, features)
         return torch.einsum("zabij,zbj->zai", k, features)  # [batch, point, channel]
 

--- a/tests/kernel_test.py
+++ b/tests/kernel_test.py
@@ -3,7 +3,7 @@ import unittest
 
 import torch
 
-from e3nn.kernel import Kernel, KernelFn, KernelAutoBackward
+from e3nn.kernel import Kernel, KernelFn
 from e3nn.radial import ConstantRadialModel
 
 
@@ -56,8 +56,8 @@ class TestCompare(unittest.TestCase):
             new_features = K(self.geometry)
 
             torch.manual_seed(0)
-            K = KernelAutoBackward(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
-            check_new_features = K(self.geometry)
+            K2 = Kernel(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
+            check_new_features = K2(self.geometry, custom_backward=True)
 
             assert all(torch.all(a == b) for a, b in zip(K.parameters(), K.parameters())), self.msg
             self.assertTrue(torch.allclose(new_features, check_new_features))

--- a/tests/point/kernelconv_test.py
+++ b/tests/point/kernelconv_test.py
@@ -1,14 +1,52 @@
 # pylint: disable=C,E1101,E1102
 import unittest
 from functools import partial
+from itertools import product
 
 import torch
 
 from e3nn.kernel import Kernel
 from e3nn.radial import ConstantRadialModel
 from e3nn.point.operations import Convolution
-from e3nn.point.kernelconv import KernelConv
+from e3nn.point.kernelconv import KernelConv, KernelConvFn
 from e3nn.rs import dim
+
+
+class TestKernelConvFn(unittest.TestCase):
+    def test1(self):
+        torch.set_default_dtype(torch.float64)
+        Rs_in = [(1, 0), (1, 1), (2, 0), (1, 2)]
+        Rs_out = [(2, 0), (1, 1), (1, 2), (3, 0)]
+        KC = KernelConv(Rs_in, Rs_out, ConstantRadialModel)
+
+        n_path = 0
+        for mul_out, l_out, p_out in KC.Rs_out:
+            for mul_in, l_in, p_in in KC.Rs_in:
+                l_filters = KC.get_l_filters(l_in, p_in, l_out, p_out)
+                n_path += mul_out * mul_in * len(l_filters)
+
+        batch = 10
+        atoms = 12
+
+        true_false = [False, True]
+        options = set(product(true_false, repeat=3)) - {(False, False, False)}
+        for rg_F, rg_Y, rg_R in options:
+            F = torch.randn(batch, atoms, dim(Rs_in), requires_grad=rg_F)
+            geo = torch.randn(batch, atoms, 3)
+            r = geo.unsqueeze(1) - geo.unsqueeze(2)
+            radii = r.norm(batch, dim=1)  # [batch, a, b]
+            Y = KC.sh(KC.set_of_l_filters, r)  # [l_filter * m_filter, batch, a, b]
+            Y = Y.clone().detach().requires_grad_(rg_Y)
+            R = torch.randn(
+                batch, atoms, atoms, n_path, requires_grad=rg_R
+            )  # [batch, a, b, l_out * l_in * mul_out * mul_in * l_filter]
+            norm_coef = KC.norm_coef
+            norm_coef = norm_coef[:, :, (radii == 0).type(torch.long)]  # [l_out, l_in, batch, a, b]
+
+            inputs = (
+                F, Y, R, norm_coef, KC.Rs_in, KC.Rs_out, KC.get_l_filters, KC.set_of_l_filters
+            )
+            self.assertTrue(torch.autograd.gradcheck(KernelConvFn.apply, inputs))
 
 
 class TestKernelConv(unittest.TestCase):
@@ -30,18 +68,25 @@ class TestKernelConv(unittest.TestCase):
 
         self.msg = "Kernel or Convolution parameters were not identical. This means the test cannot compare outputs."
 
+    def get_kernel_conv_kernelconv(self, seed, normalization):
+        torch.manual_seed(seed)
+        K = partial(Kernel, RadialModel=ConstantRadialModel, normalization=normalization)
+        C = Convolution(K, self.Rs_in, self.Rs_out)
+
+        torch.manual_seed(seed)
+        KC = KernelConv(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
+        return K, C, KC
+
+    def insure_parameters_same(self, conv, kernel_conv):
+        assert all(torch.all(a == b) for a, b in zip(conv.kernel.parameters(), kernel_conv.parameters())), self.msg
+
     def test_compare_forward(self):
         for normalization in ["norm", "component"]:
-            torch.manual_seed(0)
-            K = partial(Kernel, RadialModel=ConstantRadialModel, normalization=normalization)
-            C = Convolution(K, self.Rs_in, self.Rs_out)
+            K, C, KC = self.get_kernel_conv_kernelconv(0, normalization)
             new_features = C(self.features, self.geometry) * self.mask.unsqueeze(dim=-1)
-
-            torch.manual_seed(0)
-            KC = KernelConv(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
             check_new_features = KC(self.features, self.r, self.mask)
 
-            assert all(torch.all(a == b) for a, b in zip(C.kernel.parameters(), KC.parameters())), self.msg
+            self.insure_parameters_same(C, KC)
             self.assertTrue(torch.allclose(new_features, check_new_features))
 
     def test_compare_backward(self):
@@ -50,16 +95,11 @@ class TestKernelConv(unittest.TestCase):
         check_mask = self.mask.clone().detach()
 
         for normalization in ["norm", "component"]:
-            torch.manual_seed(0)
-            K = partial(Kernel, RadialModel=ConstantRadialModel, normalization=normalization)
-            C = Convolution(K, self.Rs_in, self.Rs_out)
+            K, C, KC = self.get_kernel_conv_kernelconv(0, normalization)
             new_features = C(self.features, self.geometry) * self.mask.unsqueeze(dim=-1)
-
-            torch.manual_seed(0)
-            KC = KernelConv(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
             check_new_features = KC(check_features, check_r, check_mask)
 
-            assert all(torch.all(a == b) for a, b in zip(C.kernel.parameters(), KC.parameters())), self.msg
+            self.insure_parameters_same(C, KC)
 
             # Capture ground truth gradient
             target = torch.rand_like(new_features)
@@ -70,7 +110,29 @@ class TestKernelConv(unittest.TestCase):
             check_target = target.clone().detach()
             check_loss = torch.norm(check_new_features - check_target)
             check_loss.backward()
+            self.assertTrue(torch.allclose(self.features.grad, check_features.grad))
 
+    def test_compare_custom_backward(self):
+        check_features = self.features.clone().detach().requires_grad_()
+        check_r = self.r.clone().detach()
+        check_mask = self.mask.clone().detach()
+
+        for normalization in ["norm", "component"]:
+            K, C, KC = self.get_kernel_conv_kernelconv(0, normalization)
+            new_features = C(self.features, self.geometry) * self.mask.unsqueeze(dim=-1)
+            check_new_features = KC(check_features, check_r, check_mask, custom_backward=True)
+
+            self.insure_parameters_same(C, KC)
+
+            # Capture ground truth gradient
+            target = torch.rand_like(new_features)
+            loss = torch.norm(new_features - target)
+            loss.backward()
+
+            # Capture KernelConv gradient
+            check_target = target.clone().detach()
+            check_loss = torch.norm(check_new_features - check_target)
+            check_loss.backward()
             self.assertTrue(torch.allclose(self.features.grad, check_features.grad))
 
 

--- a/tests/point/kernelconv_test.py
+++ b/tests/point/kernelconv_test.py
@@ -34,7 +34,7 @@ class TestKernelConvFn(unittest.TestCase):
             F = torch.randn(batch, atoms, dim(Rs_in), requires_grad=rg_F)
             geo = torch.randn(batch, atoms, 3)
             r = geo.unsqueeze(1) - geo.unsqueeze(2)
-            radii = r.norm(batch, dim=1)  # [batch, a, b]
+            radii = r.norm(batch, dim=-1)  # [batch, a, b]
             Y = KC.sh(KC.set_of_l_filters, r)  # [l_filter * m_filter, batch, a, b]
             Y = Y.clone().detach().requires_grad_(rg_Y)
             R = torch.randn(

--- a/tests/point/kernelconv_test.py
+++ b/tests/point/kernelconv_test.py
@@ -82,7 +82,7 @@ class TestKernelConv(unittest.TestCase):
         KC = KernelConv(self.Rs_in, self.Rs_out, RadialModel=ConstantRadialModel, normalization=normalization)
         return K, C, KC
 
-    def insure_parameters_same(self, conv, kernel_conv):
+    def ensure_parameters_same(self, conv, kernel_conv):
         assert all(torch.all(a == b) for a, b in zip(conv.kernel.parameters(), kernel_conv.parameters())), self.msg
 
     def test_compare_forward(self):
@@ -91,7 +91,7 @@ class TestKernelConv(unittest.TestCase):
             new_features = C(self.features, self.geometry) * self.mask.unsqueeze(dim=-1)
             check_new_features = KC(self.features, self.r, self.mask)
 
-            self.insure_parameters_same(C, KC)
+            self.ensure_parameters_same(C, KC)
             self.assertTrue(torch.allclose(new_features, check_new_features))
 
     def test_compare_backward(self):
@@ -104,7 +104,7 @@ class TestKernelConv(unittest.TestCase):
             new_features = C(self.features, self.geometry) * self.mask.unsqueeze(dim=-1)
             check_new_features = KC(check_features, check_r, check_mask)
 
-            self.insure_parameters_same(C, KC)
+            self.ensure_parameters_same(C, KC)
 
             # Capture ground truth gradient
             target = torch.rand_like(new_features)
@@ -127,7 +127,7 @@ class TestKernelConv(unittest.TestCase):
             new_features = C(self.features, self.geometry) * self.mask.unsqueeze(dim=-1)
             check_new_features = KC(check_features, check_r, check_mask, custom_backward=True)
 
-            self.insure_parameters_same(C, KC)
+            self.ensure_parameters_same(C, KC)
 
             # Capture ground truth gradient
             target = torch.rand_like(new_features)


### PR DESCRIPTION
I think @mariogeiger might not like that there is a keyword argument. The biggest offender is probably the new convolution. Let me know if you think I should change it.

Another option is to instead create an attribute of the object which says whether or not to use custom_backward or not. I didn't like this as much since it is less flexible; however, it is more "object oriented."

The introduction of KernelConv solves issue #18 

--

The default behavior is to use custom backward for KernelConv and the automatic backward for kernel and convolution.

When using KernelConv with custom_backward=True in qm9 I was able to do 1000 molecule epochs in 11 seconds. When using custom_backward=False in qm9 the same number of molecules were iterated over in nearly 18 seconds.

It seems the behavior of these functions depends on the context. I believe it calls for further looking into whether or not custom_backward for Kernel should be enabled by default. (In this pull request custom_backward = False is default for Kernel and Convolution) 