### PR TITLE
Change the order of indices in Batchnorm

### DIFF
--- a/e3nn/batchnorm.py
+++ b/e3nn/batchnorm.py
@@ -1,4 +1,4 @@
-# pylint: disable=C,R,E1101
+# pylint: disable=no-member, arguments-differ, missing-docstring, invalid-name
 import torch
 import torch.nn as nn
 
@@ -6,7 +6,18 @@ import torch.nn as nn
 class BatchNorm(nn.Module):
     def __init__(self, Rs, eps=1e-5, momentum=0.1, affine=True, reduce='mean'):
         '''
+        Batch normalization layer for orthonormal representations
+        It normalizes by the norm of the representations.
+        Not that the norm is invariant only for orthonormal representations.
+        Irreducible representations `o3.irr_repr` are orthonormal.
+
+        input shape : [batch, [spacial dimensions], stacked orthonormal representations]
+
         :param Rs: list of tuple (multiplicity, dimension)
+        :param eps: avoid division by zero when we normalize by the variance
+        :param momentum: momentum of the running average
+        :param affine: do we have weight and bias parameters
+        :param reduce: method to contract over the spacial dimensions
         '''
         super().__init__()
 
@@ -40,10 +51,12 @@ class BatchNorm(nn.Module):
     def _roll_avg(self, curr, update):
         return (1 - self.momentum) * curr + self.momentum * update.detach()
 
-    def forward(self, input):  # pylint: disable=W
+    def forward(self, input):  # pylint: disable=redefined-builtin
         '''
-        :param input: [batch, stacked feature, x, y, z]
+        :param input: [batch, ..., stacked features]
         '''
+        batch, *size, dim = input.shape
+        input = input.view(batch, -1, dim)  # [batch, sample, stacked features]
 
         if self.training:
             new_means = []
@@ -55,16 +68,17 @@ class BatchNorm(nn.Module):
         irv = 0
         iw = 0
         ib = 0
+
         for m, d in self.Rs:
-            field = input[:, ix: ix + m * d]  # [batch, feature * repr, x, y, z]
+            field = input[:, :, ix: ix + m * d]  # [batch, sample, mul * repr]
             ix += m * d
 
-            # [batch, feature, repr, x * y * z]
-            field = field.contiguous().view(input.size(0), m, d, -1)
+            # [batch, sample, mul, repr]
+            field = field.contiguous().view(batch, -1, m, d)
 
             if d == 1:  # scalars
                 if self.training:
-                    field_mean = field.mean(0).mean(-1).view(-1)  # [feature]
+                    field_mean = field.mean([0, 1]).view(m)  # [mul]
                     new_means.append(
                         self._roll_avg(self.running_mean[irm:irm + m], field_mean)
                     )
@@ -72,46 +86,44 @@ class BatchNorm(nn.Module):
                     field_mean = self.running_mean[irm: irm + m]
                 irm += m
 
-                # [batch, feature, repr, x * y * z]
-                field = field - field_mean.view(1, m, 1, 1)
+                # [batch, sample, mul, repr]
+                field = field - field_mean.view(m, 1)
 
             if self.training:
-                field_norm = torch.sum(field ** 2, dim=2)  # [batch, feature, x * y * z]
+                field_norm = field.pow(2).sum(3)  # [batch, sample, mul]
                 if self.reduce == 'mean':
-                    field_norm = field_norm.mean(-1)  # [batch, feature]
+                    field_norm = field_norm.mean(1)  # [batch, mul]
                 elif self.reduce == 'max':
-                    field_norm = field_norm.max(-1)[0]  # [batch, feature]
+                    field_norm = field_norm.max(1).values  # [batch, mul]
                 else:
                     raise ValueError("Invalid reduce option {}".format(self.reduce))
 
-                field_norm = field_norm.mean(0)  # [feature]
+                field_norm = field_norm.mean(0)  # [mul]
                 new_vars.append(self._roll_avg(self.running_var[irv: irv + m], field_norm))
             else:
                 field_norm = self.running_var[irv: irv + m]
             irv += m
 
-            # [batch, feature, repr, x * y * z]
-            field_norm = (field_norm + self.eps).pow(-0.5).view(1, m, 1, 1)
+            field_norm = (field_norm + self.eps).pow(-0.5)  # [mul]
 
             if self.affine:
-                weight = self.weight[iw: iw + m]  # [feature]
+                weight = self.weight[iw: iw + m]  # [mul]
                 iw += m
 
-                # [batch, feature, repr, x * y * z]
-                field_norm = field_norm * weight.view(1, m, 1, 1)
+                field_norm = field_norm * weight.view  # [mul]
 
-            field = field * field_norm  # [batch, feature, repr, x * y * z]
+            field = field * field_norm.view(m, 1)  # [batch, sample, mul, repr]
 
             if self.affine and d == 1:  # scalars
-                bias = self.bias[ib: ib + m]  # [feature]
+                bias = self.bias[ib: ib + m]  # [mul]
                 ib += m
-                field += bias.view(1, m, 1, 1)  # [batch, feature, repr, x * y * z]
+                field += bias.view(m, 1)  # [batch, sample, mul, repr]
 
-            fields.append(field.view(input.size(0), m * d, *input.size()[2:]))
+            fields.append(field.view(batch, -1, m * d))  # [batch, sample, mul * repr]
 
-        if ix != input.size(1):
-            fmt = "`ix` should have reached input.size(1) ({}), but it ended at {}"
-            msg = fmt.format(input.size(1), ix)
+        if ix != dim:
+            fmt = "`ix` should have reached input.size(-1) ({}), but it ended at {}"
+            msg = fmt.format(dim, ix)
             raise AssertionError(msg)
 
         if self.training:
@@ -125,4 +137,5 @@ class BatchNorm(nn.Module):
             self.running_mean.copy_(torch.cat(new_means))
             self.running_var.copy_(torch.cat(new_vars))
 
-        return torch.cat(fields, dim=1)  # [batch, stacked feature, x, y, z]
+        output = torch.cat(fields, dim=2)  # [batch, sample, stacked features]
+        return output.view(batch, *size, dim)

--- a/e3nn/batchnorm.py
+++ b/e3nn/batchnorm.py
@@ -110,7 +110,7 @@ class BatchNorm(nn.Module):
                 weight = self.weight[iw: iw + m]  # [mul]
                 iw += m
 
-                field_norm = field_norm * weight.view  # [mul]
+                field_norm = field_norm * weight  # [mul]
 
             field = field * field_norm.view(m, 1)  # [batch, sample, mul, repr]
 

--- a/tests/batchnorm_test.py
+++ b/tests/batchnorm_test.py
@@ -5,7 +5,7 @@ from e3nn.batchnorm import BatchNorm
 
 
 class Tests(unittest.TestCase):
-    def test_that_it_runs(self):
+    def test_normalization(self):
         torch.set_default_dtype(torch.float64)
 
         batch, n = 20, 20

--- a/tests/batchnorm_test.py
+++ b/tests/batchnorm_test.py
@@ -1,0 +1,22 @@
+# pylint: disable=no-member, arguments-differ, missing-docstring, invalid-name
+import unittest
+import torch
+from e3nn.batchnorm import BatchNorm
+
+
+class Tests(unittest.TestCase):
+    def test_that_it_runs(self):
+        Rs = [(3, 1), (4, 3)]
+        m = BatchNorm(Rs)
+
+        m.to(dtype=torch.float64)
+        x = torch.randn(10, sum(mul * d for mul, d in Rs), dtype=torch.float64)
+        m(x)
+
+        m.to(dtype=torch.float32)
+        x = torch.randn(10, sum(mul * d for mul, d in Rs), dtype=torch.float32)
+        m(x)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- changed the order of indices `[batch, features, spacial]` -> `[batch, spacial, features]`
- complete docstring