### PR TITLE
Separate weights for special case r=0

### DIFF
--- a/e3nn/kernel.py
+++ b/e3nn/kernel.py
@@ -79,6 +79,7 @@ class Kernel(torch.nn.Module):
         # it contains the learned parameters
         self.list_of_l_filters = list_of_l_filters
         self.R = RadialModel(n_path)
+        self.weight = torch.nn.Parameter(torch.randn(n_path))
         self.set_of_l_filters = sorted(set_of_l_filters)
         self.register_buffer('norm_coef', norm_coef)
 
@@ -125,6 +126,7 @@ class Kernel(torch.nn.Module):
         # note: for the normalization we assume that the variance of R[i] is one
         radii = r.norm(2, dim=1)  # [batch]
         R = self.R(radii)  # [batch, l_out * l_in * mul_out * mul_in * l_filter]
+        R[radii == 0] = self.weight
 
         norm_coef = getattr(self, 'norm_coef')
         norm_coef = norm_coef[:, :, (radii == 0).type(torch.long)]  # [l_out, l_in, batch]

--- a/e3nn/kernel.py
+++ b/e3nn/kernel.py
@@ -126,6 +126,7 @@ class Kernel(torch.nn.Module):
         # note: for the normalization we assume that the variance of R[i] is one
         radii = r.norm(2, dim=1)  # [batch]
         R = self.R(radii)  # [batch, l_out * l_in * mul_out * mul_in * l_filter]
+        R = R.clone()
         R[radii == 0] = self.weight
 
         norm_coef = getattr(self, 'norm_coef')

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -44,6 +44,8 @@ class KernelConv(Kernel):
         r = self.R(radii.flatten()).view(
             *radii.shape, -1
         )  # [batch, a, b, l_out * l_in * mul_out * mul_in * l_filter]
+        r = r.clone()
+        r[radii == 0] = self.weight
 
         norm_coef = getattr(self, 'norm_coef')
         norm_coef = norm_coef[:, :, (radii == 0).type(torch.long)]  # [l_out, l_in, batch, a, b]


### PR DESCRIPTION
@L-sky introduced a time ago a distinction between the normalizations for r=0 and r>0.

I propose to distinguish as well the weight for r=0 and r>0.

- r>0 : we use the radial functions.
- r=0 : I propose to use separate weights.