### PR TITLE
Include parity in selection rule

### DIFF
--- a/e3nn/networks.py
+++ b/e3nn/networks.py
@@ -25,7 +25,7 @@ class GatedConvNetwork(torch.nn.Module):
                               number_of_basis=number_of_basis, h=100,
                               L=radial_layers, act=swish)
 
-        K = partial(Kernel, RadialModel=RadialModel, get_l_filters=partial(o3.selection_rule, lmax=lmax))
+        K = partial(Kernel, RadialModel=RadialModel, get_l_filters=partial(o3.selection_rule_in_out_sh, lmax=lmax))
 
         def make_layer(Rs_in, Rs_out):
             act = GatedBlock(Rs_out, swish, sigmoid)

--- a/e3nn/o3.py
+++ b/e3nn/o3.py
@@ -176,7 +176,7 @@ def derivative_irr_repr(order, alpha, beta, gamma, dtype=None, device=None):
     return dDda, dDdb, dDdc
 
 
-def selection_rule(l1, l2, lmax=None):
+def selection_rule(l1, _p1, l2, _p2, lmax=None):
     """
     selection rule
     :return: list from |l1-l2|... to l1+l2
@@ -187,6 +187,13 @@ def selection_rule(l1, l2, lmax=None):
         l_max = min(lmax, l1 + l2)
     return list(range(abs(l1 - l2), l_max + 1))
 
+
+def selection_rule_in_out_sh(l_in, p_in, l_out, p_out, lmax=None):
+    """
+    all possible spherical harmonics such that
+    Input * SH = Output
+    """
+    return [l for l, p in selection_rule(l_in, p_in, l_out, p_out, lmax) if p_out in [0, p_in * p]]
 
 ################################################################################
 # Spherical harmonics

--- a/e3nn/o3.py
+++ b/e3nn/o3.py
@@ -193,7 +193,7 @@ def selection_rule_in_out_sh(l_in, p_in, l_out, p_out, lmax=None):
     all possible spherical harmonics such that
     Input * SH = Output
     """
-    return [l for l, p in selection_rule(l_in, p_in, l_out, p_out, lmax) if p_out in [0, p_in * p]]
+    return [l for l in selection_rule(l_in, p_in, l_out, p_out, lmax) if p_out in [0, p_in * (-1) ** l]]
 
 ################################################################################
 # Spherical harmonics

--- a/e3nn/point/kernelconv.py
+++ b/e3nn/point/kernelconv.py
@@ -7,19 +7,6 @@ from e3nn.kernel import Kernel
 
 
 class KernelConv(Kernel):
-    # def __init__(self, Rs_in, Rs_out, RadialModel, get_l_filters=o3.selection_rule, sh=o3.spherical_harmonics_xyz, normalization='norm'):
-    #     """
-    #     :param Rs_in: list of triplet (multiplicity, representation order, parity)
-    #     :param Rs_out: list of triplet (multiplicity, representation order, parity)
-    #     :param RadialModel: Class(d), trainable model: R -> R^d
-    #     :param get_l_filters: function of signature (l_in, l_out) -> [l_filter]
-    #     :param sh: spherical harmonics function of signature ([l_filter], xyz[..., 3]) -> Y[m, ...]
-    #     :param normalization: either 'norm' or 'component'
-    #     representation order = nonnegative integer
-    #     parity = 0 (no parity), 1 (even), -1 (odd)
-    #     """
-    #     super(KernelConv, self).__init__(Rs_in, Rs_out, RadialModel, get_l_filters, sh, normalization)
-
     def forward(self, features, difference_geometry, mask, y=None, radii=None, custom_backward=True):
         """
         :param features: tensor [batch, b, l_in * mul_in * m_in]

--- a/e3nn/rs.py
+++ b/e3nn/rs.py
@@ -311,13 +311,13 @@ def tensor_product(Rs_1, Rs_2, get_l_output=o3.selection_rule, paths=False):
     index_out = 0
 
     index_1 = 0
-    for mul_1, l_1, _p_1 in Rs_1:
+    for mul_1, l_1, p_1 in Rs_1:
         dim_1 = mul_1 * (2 * l_1 + 1)
 
         index_2 = 0
-        for mul_2, l_2, _p_2 in Rs_2:
+        for mul_2, l_2, p_2 in Rs_2:
             dim_2 = mul_2 * (2 * l_2 + 1)
-            for l in get_l_output(l_1, l_2):
+            for l in get_l_output(l_1, p_1, l_2, p_2):
                 dim_out = mul_1 * mul_2 * (2 * l + 1)
                 C = o3.clebsch_gordan(l, l_1, l_2, cached=True) * (2 * l + 1) ** 0.5
                 I = torch.eye(mul_1 * mul_2).view(mul_1 * mul_2, mul_1, mul_2)
@@ -361,7 +361,7 @@ def elementwise_tensor_product(Rs_1, Rs_2, get_l_output=o3.selection_rule):
     Rs_out = []
     for (mul, l_1, p_1), (mul_2, l_2, p_2) in zip(Rs_1, Rs_2):
         assert mul == mul_2
-        for l in get_l_output(l_1, l_2):
+        for l in get_l_output(l_1, p_1, l_2, p_2):
             Rs_out.append((mul, l, p_1 * p_2))
 
     Rs_out = simplify(Rs_out)
@@ -376,7 +376,7 @@ def elementwise_tensor_product(Rs_1, Rs_2, get_l_output=o3.selection_rule):
         dim_1 = mul * (2 * l_1 + 1)
         dim_2 = mul * (2 * l_2 + 1)
 
-        for l in get_l_output(l_1, l_2):
+        for l in get_l_output(l_1, p_1, l_2, p_2):
             dim_out = mul * (2 * l + 1)
             C = o3.clebsch_gordan(l, l_1, l_2, cached=True) * (2 * l + 1) ** 0.5
             I = torch.einsum("uv,wu->wuv", torch.eye(mul), torch.eye(mul))

--- a/e3nn/rs.py
+++ b/e3nn/rs.py
@@ -299,7 +299,7 @@ def tensor_product(Rs_1, Rs_2, get_l_output=o3.selection_rule, paths=False):
         path_list = []
     for mul_1, l_1, p_1 in Rs_1:
         for mul_2, l_2, p_2 in Rs_2:
-            for l in get_l_output(l_1, l_2):
+            for l in get_l_output(l_1, p_1, l_2, p_2):
                 if paths:
                     path_list.extend([[l_1, l_2, l]] * (mul_1 * mul_2))
                 Rs_out.append((mul_1 * mul_2, l, p_1 * p_2))


### PR DESCRIPTION
#43

Changed the signature of `o3.selection_rule` to
```python
o3.selection_rule(l_1, p_1, l_2, p_2)
```

This allow the user to customize `get_l_output` of `tensor_product` based on the parity.