### PR TITLE
LearnableTensorProduct

### DIFF
--- a/e3nn/networks.py
+++ b/e3nn/networks.py
@@ -33,7 +33,7 @@ class GatedConvNetwork(torch.nn.Module):
         def make_layer(Rs_in, Rs_out):
             if feature_product:
                 tr1 = rs.TransposeToMulL(Rs_in)
-                lts = LearnableTensorSquare(tr1.Rs_out, partial(o3.selection_rule, lmax=lmax))
+                lts = LearnableTensorSquare(tr1.Rs_out, list(range(lmax + 1)), allow_change_output=True)
                 tr2 = torch.nn.Flatten(2)
                 Rs = tr1.mul * lts.Rs_out
                 act = GatedBlock(Rs_out, swish, sigmoid)
@@ -100,7 +100,7 @@ class GatedConvParityNetwork(torch.nn.Module):
 
             if feature_product:
                 tr1 = rs.TransposeToMulL(act.Rs_out)
-                lts = LearnableTensorSquare(tr1.Rs_out, partial(o3.selection_rule, lmax=lmax))
+                lts = LearnableTensorSquare(tr1.Rs_out, [(1, l, p) for l in range(lmax + 1) for p in [-1, 1]], allow_change_output=True)
                 tr2 = torch.nn.Flatten(2)
                 act = torch.nn.Sequential(act, tr1, lts, tr2)
                 Rs = tr1.mul * lts.Rs_out

--- a/e3nn/tensor_product.py
+++ b/e3nn/tensor_product.py
@@ -4,25 +4,29 @@ from functools import partial
 import torch
 
 from e3nn import o3, rs
-from e3nn.linear import Linear
 from e3nn.linear_mod import KernelLinear
 from e3nn.util.sparse import get_sparse_buffer, register_sparse_buffer
 
 
 class LearnableTensorSquare(torch.nn.Module):
-    """
-    (A x A)_k =  C_ijk A_i A_j
-
-    [(2, 0), (2, 1)] x [(2, 0), (2, 1)] = [(3, 0), (4, 1), (3, 0), (1, 1), (3, 2)]
-    """
-    def __init__(self, Rs_in, selection_rule=o3.selection_rule, mul=1):
+    def __init__(self, Rs_in, Rs_out, allow_change_out=False):
         super().__init__()
 
         self.Rs_in = rs.simplify(Rs_in)
-        Rs_ts, T = rs.tensor_square(self.Rs_in, selection_rule, sorted=True)
+        self.Rs_out = rs.simplify(Rs_out)
+
+        ls = [l for _, l, _ in self.Rs_out]
+        selection_rule = partial(o3.selection_rule, lfilter=lambda l: l in ls)
+
+        Rs_ts, T = rs.tensor_square(self.Rs_in, selection_rule)
         register_sparse_buffer(self, 'T', T)  # [out, in1 * in2]
 
-        self.Rs_out = sorted({(mul, l, p) for _, l, p in Rs_ts})
+        ls = [l for _, l, _ in Rs_ts]
+        if allow_change_out:
+            self.Rs_out = [(mul, l, p) for mul, l, p in self.Rs_out if l in ls]
+        else:
+            assert all(l in ls for _, l, _ in self.Rs_out)
+
         self.kernel = KernelLinear(Rs_ts, self.Rs_out)  # [out, in, w]
 
     def __repr__(self):
@@ -39,47 +43,46 @@ class LearnableTensorSquare(torch.nn.Module):
         *size, n = features.size()
         features = features.reshape(-1, n)
 
-        # kernel = torch.einsum('ij,jkl->ikl', self.kernel(), self.T)  # [out, in1, in2]
-        T = get_sparse_buffer(self, 'T')
+        T = get_sparse_buffer(self, 'T')  # [out, in1 * in2]
         kernel = (T.t() @ self.kernel().T).T.reshape(rs.dim(self.Rs_out), rs.dim(self.Rs_in), rs.dim(self.Rs_in))  # [out, in1, in2]
         features = torch.einsum('kij,zi,zj->zk', kernel, features, features)
         return features.reshape(*size, -1)
 
 
 class LearnableTensorProduct(torch.nn.Module):
-    def __init__(self, Rs_mid_1, Rs_mid_2, mul_mid, Rs_out, selection_rule=o3.selection_rule):
+    def __init__(self, Rs_in1, Rs_in2, Rs_out, allow_change_out=False):
         super().__init__()
-        self.mul_mid = mul_mid
-        self.tp = rs.TensorProduct(Rs_mid_1, Rs_mid_2, selection_rule)
-        self.lin = Linear(mul_mid * self.tp.Rs_out, Rs_out)
 
-    def forward(self, x1, x2):
+        self.Rs_in1 = rs.simplify(Rs_in1)
+        self.Rs_in2 = rs.simplify(Rs_in2)
+        self.Rs_out = rs.simplify(Rs_out)
+
+        ls = [l for _, l, _ in self.Rs_out]
+        selection_rule = partial(o3.selection_rule, lfilter=lambda l: l in ls)
+
+        Rs_ts, T = rs.tensor_product(self.Rs_in1, self.Rs_in2, selection_rule)
+        register_sparse_buffer(self, 'T', T)  # [out, in1 * in2]
+
+        ls = [l for _, l, _ in Rs_ts]
+        if allow_change_out:
+            self.Rs_out = [(mul, l, p) for mul, l, p in self.Rs_out if l in ls]
+        else:
+            assert all(l in ls for _, l, _ in self.Rs_out)
+
+        self.kernel = KernelLinear(Rs_ts, self.Rs_out)  # [out, in, w]
+
+    def forward(self, features_1, features_2):
         """
         :return:         tensor [..., channel]
         """
-        # split into mul x Rs
-        *size, _ = x1.shape
-        x1 = x1.reshape(*size, self.mul_mid, -1)
-        x2 = x2.reshape(*size, self.mul_mid, -1)
+        *size, n = features_1.size()
+        features_1 = features_1.reshape(-1, n)
+        assert n == rs.dim(self.Rs_in1)
+        *size2, n = features_2.size()
+        features_2 = features_2.reshape(-1, n)
+        assert size == size2
 
-        x = self.tp(x1, x2).reshape(*size, -1)
-        x = self.lin(x)
-        return x
-
-
-class LearnableBispectrum(torch.nn.Module):
-    def __init__(self, Rs_in, mul_hidden, mul_out):
-        super().__init__()
-        self.lmax = max(l for mul, l in Rs_in)
-        Rs_hidden = [(mul_hidden, l) for l in range(self.lmax + 1)]
-        # Learnable tensor product of signal with itself
-        self.tp = LearnableTensorProduct(Rs_in, Rs_in, 1, Rs_hidden,
-                                         partial(o3.selection_rule, lmax=self.lmax))
-        # Dot product
-        self.dot = LearnableTensorProduct(Rs_hidden, Rs_in, 1,
-                                          [(mul_out, 0)], partial(o3.selection_rule, lmax=0))
-
-    def forward(self, input):
-        output = input
-        output = self.tp(output, output)
-        return self.dot(output, input)
+        T = get_sparse_buffer(self, 'T')  # [out, in1 * in2]
+        kernel = (T.t() @ self.kernel().T).T.reshape(rs.dim(self.Rs_out), rs.dim(self.Rs_in1), rs.dim(self.Rs_in2))  # [out, in1, in2]
+        features = torch.einsum('kij,zi,zj->zk', kernel, features_1, features_2)
+        return features.reshape(*size, -1)

--- a/e3nn/tensor_product.py
+++ b/e3nn/tensor_product.py
@@ -9,7 +9,7 @@ from e3nn.util.sparse import get_sparse_buffer, register_sparse_buffer
 
 
 class LearnableTensorSquare(torch.nn.Module):
-    def __init__(self, Rs_in, Rs_out, allow_change_out=False):
+    def __init__(self, Rs_in, Rs_out, allow_change_output=False):
         super().__init__()
 
         self.Rs_in = rs.simplify(Rs_in)
@@ -22,7 +22,7 @@ class LearnableTensorSquare(torch.nn.Module):
         register_sparse_buffer(self, 'T', T)  # [out, in1 * in2]
 
         ls = [l for _, l, _ in Rs_ts]
-        if allow_change_out:
+        if allow_change_output:
             self.Rs_out = [(mul, l, p) for mul, l, p in self.Rs_out if l in ls]
         else:
             assert all(l in ls for _, l, _ in self.Rs_out)
@@ -50,7 +50,7 @@ class LearnableTensorSquare(torch.nn.Module):
 
 
 class LearnableTensorProduct(torch.nn.Module):
-    def __init__(self, Rs_in1, Rs_in2, Rs_out, allow_change_out=False):
+    def __init__(self, Rs_in1, Rs_in2, Rs_out, allow_change_output=False):
         super().__init__()
 
         self.Rs_in1 = rs.simplify(Rs_in1)
@@ -64,7 +64,7 @@ class LearnableTensorProduct(torch.nn.Module):
         register_sparse_buffer(self, 'T', T)  # [out, in1 * in2]
 
         ls = [l for _, l, _ in Rs_ts]
-        if allow_change_out:
+        if allow_change_output:
             self.Rs_out = [(mul, l, p) for mul, l, p in self.Rs_out if l in ls]
         else:
             assert all(l in ls for _, l, _ in self.Rs_out)

--- a/tests/tensor_product_test.py
+++ b/tests/tensor_product_test.py
@@ -1,10 +1,27 @@
 # pylint: disable=not-callable, no-member, invalid-name, line-too-long, wildcard-import, unused-wildcard-import, missing-docstring
-import unittest
+from e3nn.tensor_product import LearnableTensorSquare, LearnableTensorProduct
+from e3nn import rs
 
 
-class Tests(unittest.TestCase):
-    pass
+def test_learnable_tensor_square_normalization():
+    Rs_in = [1, 2, 3, 4]
+    Rs_out = [0, 2, 4, 5]
+
+    m = LearnableTensorSquare(Rs_in, Rs_out)
+    y = m(rs.randn(1000, Rs_in))
+
+    assert y.var().log10().abs() < 1.5, y.var().item()
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_learnable_tensor_product_normalization():
+    Rs_in1 = [2, 0, 4]
+    Rs_in2 = [2, 3]
+    Rs_out = [0, 2, 4, 5]
+
+    m = LearnableTensorProduct(Rs_in1, Rs_in2, Rs_out)
+
+    x1 = rs.randn(1000, Rs_in1)
+    x2 = rs.randn(1000, Rs_in2)
+    y = m(x1, x2)
+
+    assert y.var().log10().abs() < 1.5, y.var().item()


### PR DESCRIPTION
Simple and intuitive re-definition of
`LearnableTensorProduct(Rs_in1, Rs_in2, Rs_out)`

You set the inputs and output and it will learn a mapping using a linear combination of tensor products.

I removed `Bispectrum` since it look very specific and it not used in the repository. I think if you use it you have to define it in the project where you use it.