### PR TITLE
Various fixes to network and data_helpers

### DIFF
--- a/e3nn/networks.py
+++ b/e3nn/networks.py
@@ -124,15 +124,9 @@ class GatedConvParityNetwork(torch.nn.Module):
         if 'n_norm' not in kwargs:
             kwargs['n_norm'] = N
 
-        if self.feature_product:
-            for ts, conv, act in self.layers[:-1]:
-                output = ts(output)
-                output = conv(output, *args, **kwargs)
-                output = act(output)
-        else:
-            for conv, act in self.layers[:-1]:
-                output = conv(output, *args, **kwargs)
-                output = act(output)
+        for conv, act in self.layers[:-1]:
+            output = conv(output, *args, **kwargs)
+            output = act(output)
 
         layer = self.layers[-1]
         output = layer(output, *args, **kwargs)

--- a/e3nn/networks.py
+++ b/e3nn/networks.py
@@ -112,21 +112,31 @@ class GatedConvParityNetwork(torch.nn.Module):
             block = torch.nn.ModuleList([conv, act])
             modules.append(block)
 
-        self.firstlayers = torch.nn.ModuleList(modules)
+        self.layers = torch.nn.ModuleList(modules)
 
         K = partial(K, allow_unused_inputs=True)
-        self.conv = convolution(K(Rs, Rs_out))
+        self.layers.append(convolution(K(Rs, Rs_out)))
+        self.feature_product = feature_product
 
-    def forward(self, features, geometry, n_norm=None):
-        if n_norm is None:
-            n_norm = geometry.shape[1]
+    def forward(self, input, *args, **kwargs):
+        output = input
+        N = args[0].shape[-2]
+        if 'n_norm' not in kwargs:
+            kwargs['n_norm'] = N
 
-        for conv, act in self.firstlayers:
-            features = conv(features, geometry, n_norm=n_norm)
-            features = act(features)
+        if self.feature_product:
+            for ts, conv, act in self.layers[:-1]:
+                output = ts(output)
+                output = conv(output, *args, **kwargs)
+                output = act(output)
+        else:
+            for conv, act in self.layers[:-1]:
+                output = conv(output, *args, **kwargs)
+                output = act(output)
 
-        features = self.conv(features, geometry, n_norm=n_norm)
-        return features
+        layer = self.layers[-1]
+        output = layer(output, *args, **kwargs)
+        return output
 
 
 class S2Network(torch.nn.Module):

--- a/e3nn/point/data_helpers.py
+++ b/e3nn/point/data_helpers.py
@@ -26,7 +26,7 @@ def neighbor_list_and_relative_vec(pos, r_max, self_interaction=True):
     N, _ = pos.shape
     atoms = Atoms(symbols=['H'] * N, positions=pos)
     nl = neighborlist.NeighborList(
-        [r_max] * N,
+        [r_max / 2.] * N,  # NeighborList looks for intersecting spheres
         self_interaction=self_interaction,
         bothways=True,
     )

--- a/e3nn/point/data_helpers.py
+++ b/e3nn/point/data_helpers.py
@@ -25,7 +25,6 @@ def neighbor_list_and_relative_vec(pos, r_max, self_interaction=True):
     """
     N, _ = pos.shape
     atoms = Atoms(symbols=['H'] * N, positions=pos)
-    print(r_max / 2.)
     nl = neighborlist.NeighborList(
         [r_max / 2.] * N,  # NeighborList looks for intersecting spheres
         self_interaction=self_interaction,

--- a/e3nn/point/data_helpers.py
+++ b/e3nn/point/data_helpers.py
@@ -25,10 +25,12 @@ def neighbor_list_and_relative_vec(pos, r_max, self_interaction=True):
     """
     N, _ = pos.shape
     atoms = Atoms(symbols=['H'] * N, positions=pos)
+    print(r_max / 2.)
     nl = neighborlist.NeighborList(
         [r_max / 2.] * N,  # NeighborList looks for intersecting spheres
         self_interaction=self_interaction,
         bothways=True,
+        skin=0.0,
     )
     nl.update(atoms)
 

--- a/tests/tensor/spherical_tensor_test.py
+++ b/tests/tensor/spherical_tensor_test.py
@@ -85,8 +85,8 @@ def test_plot():
     coords = coords[coords.norm(2, -1) > 0]
     sph = SphericalTensor.from_geometry(coords, lmax)
 
-    n = 16
-    r, f = sph.plot(n=n)
+    res = 16
+    r, f = sph.plot(res=res)
     assert r.shape[2] == 3
     assert f.shape[:2] == r.shape[:2]
 


### PR DESCRIPTION
Make `GatedParityConvNetwork` take general arguements (so it can be used with `e3nn.point.message_passing.Convolution`.

Correct `e3nn.point.data_helpers.neighbor_list_and_relative_vec` to give neighbors within distance D (previously was 2 * D + skin, set skin == 0.0 and divide sphere radius by 2).