### PR TITLE
test of depthwise with message_passing.Convolution

### DIFF
--- a/e3nn/point/depthwise.py
+++ b/e3nn/point/depthwise.py
@@ -8,19 +8,19 @@ from e3nn.linear import Linear
 
 
 class DepthwiseConvolution(torch.nn.Module):
-    def __init__(self, Rs_in, Rs_out, Rs_mid, groups, convolution, linear=Linear, scalar_activation=swish, gate_activation=sigmoid):
+    def __init__(self, Rs_in, Rs_out, Rs_mid1, Rs_mid2, groups, convolution, linear=Linear, scalar_activation=swish, gate_activation=sigmoid):
         super().__init__()
 
-        act_in = GatedBlock(groups * Rs_mid, scalar_activation, gate_activation)
+        act_in = GatedBlock(groups * Rs_mid1, scalar_activation, gate_activation)
         self.lin_in = linear(Rs_in, act_in.Rs_in)
         self.act_in = act_in
 
-        act_mid = GatedBlock(Rs_mid, scalar_activation, gate_activation)
-        self.conv = convolution(Rs_mid, act_mid.Rs_in)
+        act_mid = GatedBlock(Rs_mid2, scalar_activation, gate_activation)
+        self.conv = convolution(Rs_mid1, act_mid.Rs_in)
         self.act_mid = act_mid
 
         act_out = GatedBlock(Rs_out, scalar_activation, gate_activation)
-        self.lin_out = linear(groups * Rs_mid, act_out.Rs_in)
+        self.lin_out = linear(groups * Rs_mid2, act_out.Rs_in)
         self.act_out = act_out
 
         self.groups = groups

--- a/tests/point/depthwise_tests.py
+++ b/tests/point/depthwise_tests.py
@@ -1,0 +1,64 @@
+# pylint: disable=not-callable, no-member, invalid-name, line-too-long, wildcard-import, unused-wildcard-import, missing-docstring
+import itertools
+from functools import partial
+
+import pytest
+import torch
+
+from e3nn import o3, rs
+from e3nn.kernel import Kernel
+from e3nn.point.message_passing import Convolution
+from e3nn.radial import ConstantRadialModel
+from e3nn.point.depthwise import DepthwiseConvolution
+
+def test_equivariance():
+    torch.set_default_dtype(torch.float64)
+
+    n_edge = 3
+    n_source = 4
+    n_target = 2
+
+    Rs_in = [(3, 0), (0, 1)]
+    Rs_mid1 = [(5, 0), (1, 1)]
+    Rs_mid2 = [(5, 0), (1, 1), (1, 2)]
+    Rs_out = [(5, 1), (3, 2)]
+
+    Rs_in = rs.convention(Rs_in)
+    Rs_out = rs.convention(Rs_out)
+    Rs_mid1 = rs.convention(Rs_mid1)
+    Rs_mid2 = rs.convention(Rs_mid2)
+    print(Rs_in, Rs_out)
+
+    convolution = lambda Rs_in, Rs_out: Convolution(Kernel(Rs_in, Rs_out, ConstantRadialModel))
+    groups = 4
+    mp = DepthwiseConvolution(Rs_in, Rs_out, Rs_mid1, Rs_mid2, groups, convolution)
+
+    features = rs.randn(n_target, Rs_in)
+
+    r_source = torch.randn(n_source, 3)
+    r_target = torch.randn(n_target, 3)
+
+    edge_index = torch.stack([
+        torch.randint(n_source, size=(n_edge,)),
+        torch.randint(n_target, size=(n_edge,)),
+    ])
+    size = (n_target, n_source)
+
+    if n_edge == 0:
+        edge_r = torch.zeros(0, 3)
+    else:
+        edge_r = torch.stack([
+            r_target[j] - r_source[i]
+            for i, j in edge_index.T
+        ])
+    print(features.shape, edge_index.shape, edge_r.shape, size)
+    out1 = mp(features, edge_index, edge_r, size=size)
+
+    angles = o3.rand_angles()
+    D_in = rs.rep(Rs_in, *angles)
+    D_out = rs.rep(Rs_out, *angles)
+    R = o3.rot(*angles)
+
+    out2 = mp(features @ D_in.T, edge_index, edge_r @ R.T, size=size) @ D_out
+
+    assert (out1 - out2).abs().max() < 1e-10

--- a/tests/point/depthwise_tests.py
+++ b/tests/point/depthwise_tests.py
@@ -1,8 +1,6 @@
 # pylint: disable=not-callable, no-member, invalid-name, line-too-long, wildcard-import, unused-wildcard-import, missing-docstring
-import itertools
 from functools import partial
 
-import pytest
 import torch
 
 from e3nn import o3, rs
@@ -10,6 +8,7 @@ from e3nn.kernel import Kernel
 from e3nn.point.message_passing import Convolution
 from e3nn.radial import ConstantRadialModel
 from e3nn.point.depthwise import DepthwiseConvolution
+
 
 def test_equivariance():
     torch.set_default_dtype(torch.float64)


### PR DESCRIPTION
also added `Rs_mid1` and `Rs_mid2`. note that I also had to add scalars to the `Rs_mid1` and `Rs_mid2` so that GatedBlock would be happy.