### PR TITLE
GroupKernel and DepthwiseConvolution

### DIFF
--- a/e3nn/kernel.py
+++ b/e3nn/kernel.py
@@ -136,6 +136,15 @@ class Kernel(torch.nn.Module):
         return kernel.reshape(*size, *kernel2.shape)
 
 
+class GroupKernel(torch.nn.Module):
+    def __init__(self, Rs_in, Rs_out, kernel, groups):
+        super().__init__()
+        self.kernels = [kernel(Rs_in, Rs_out) for i in range(groups)]
+
+    def forward(self, *args, **kwargs):
+        return torch.stack([ker(*args, **kwargs) for ker in self.kernels], dim=-3)  # [..., group, cout, cin]
+
+
 def kernel_fn_forward(Y, R, norm_coef, Rs_in, Rs_out, selection_rule, set_of_l_filters):
     """
     :param Y: tensor [batch, l_filter * m_filter]

--- a/e3nn/point/depthwise.py
+++ b/e3nn/point/depthwise.py
@@ -1,0 +1,42 @@
+# pylint: disable=arguments-differ, redefined-builtin, missing-docstring, no-member, invalid-name, line-too-long, not-callable
+import torch
+
+from e3nn import rs
+from e3nn.non_linearities import GatedBlock
+from e3nn.non_linearities.rescaled_act import swish, sigmoid
+from e3nn.linear import Linear
+
+
+class DepthwiseConvolution(torch.nn.Module):
+    def __init__(self, Rs_in, Rs_out, Rs_mid, groups, convolution, linear=Linear, scalar_activation=swish, gate_activation=sigmoid):
+        super().__init__()
+
+        act_in = GatedBlock(groups * Rs_mid, scalar_activation, gate_activation)
+        self.lin_in = linear(Rs_in, act_in.Rs_in)
+        self.act_in = act_in
+
+        act_mid = GatedBlock(Rs_mid, scalar_activation, gate_activation)
+        self.conv = convolution(Rs_mid, act_mid.Rs_in)
+        self.act_mid = act_mid
+
+        act_out = GatedBlock(Rs_out, scalar_activation, gate_activation)
+        self.lin_out = linear(groups * Rs_mid, act_out.Rs_in)
+        self.act_out = act_out
+
+        self.groups = groups
+
+    def forward(self, features, *args, **kwargs):
+        """
+        :param features: tensor [..., point, channel]
+        :return:         tensor [..., point, channel]
+        """
+        features = self.lin_in(features)
+        features = self.act_in(features)
+
+        features = self.conv(features, *args, **kwargs, groups=self.groups)
+        features = self.act_mid(features.reshape(-1, rs.dim(self.act_mid.Rs_in))).reshape(*features.shape[:-1], -1)
+
+        features = self.lin_out(features)
+        features = self.act_out(features)
+
+        return features

--- a/e3nn/point/depthwise.py
+++ b/e3nn/point/depthwise.py
@@ -8,19 +8,19 @@ from e3nn.linear import Linear
 
 
 class DepthwiseConvolution(torch.nn.Module):
-    def __init__(self, Rs_in, Rs_out, Rs_mid, groups, convolution, linear=Linear, scalar_activation=swish, gate_activation=sigmoid):
+    def __init__(self, Rs_in, Rs_out, Rs_mid1, Rs_mid2, groups, convolution, linear=Linear, scalar_activation=swish, gate_activation=sigmoid):
         super().__init__()
 
-        act_in = GatedBlock(groups * Rs_mid, scalar_activation, gate_activation)
+        act_in = GatedBlock(groups * Rs_mid1, scalar_activation, gate_activation)
         self.lin_in = linear(Rs_in, act_in.Rs_in)
         self.act_in = act_in
 
-        act_mid = GatedBlock(Rs_mid, scalar_activation, gate_activation)
-        self.conv = convolution(Rs_mid, act_mid.Rs_in)
+        act_mid = GatedBlock(Rs_mid2, scalar_activation, gate_activation)
+        self.conv = convolution(Rs_mid1, act_mid.Rs_in)
         self.act_mid = act_mid
 
         act_out = GatedBlock(Rs_out, scalar_activation, gate_activation)
-        self.lin_out = linear(groups * Rs_mid, act_out.Rs_in)
+        self.lin_out = linear(groups * Rs_mid2, act_out.Rs_in)
         self.act_out = act_out
 
         self.groups = groups

--- a/e3nn/point/message_passing.py
+++ b/e3nn/point/message_passing.py
@@ -31,4 +31,6 @@ class Convolution(tg.nn.MessagePassing):
         x_j = x_j.view(N, groups, cin)  # Rs_tp1
         if k.shape[0] == 0:  # https://github.com/pytorch/pytorch/issues/37628
             return torch.zeros(0, groups * cout)
+        if k.dim() == 4 and k.shape[1] == groups:  # kernel has group dimension
+           return torch.einsum('egij,egj->egi', k, x_j).reshape(N, groups * cout)
         return torch.einsum('eij,egj->egi', k, x_j).reshape(N, groups * cout)

--- a/e3nn/point/operations.py
+++ b/e3nn/point/operations.py
@@ -8,9 +8,9 @@ class Convolution(torch.nn.Module):
         self.kernel = kernel
 
     def forward(self, features, geometry, out_geometry=None, n_norm=1,
-                custom_backward_conv=False, custom_backward_kernel=False, r_eps=0):
+                custom_backward_conv=False, custom_backward_kernel=False, r_eps=0, groups=1):
         """
-        :param features:     tensor [batch,  in_point, channel]
+        :param features:     tensor [batch,  in_point, groups * channel]
         :param geometry:     tensor [batch,  in_point, xyz]
         :param out_geometry: tensor [batch, out_point, xyz]
         :param n_norm: Divide kernel by sqrt(n_norm) before passing to convolution.
@@ -25,10 +25,15 @@ class Convolution(torch.nn.Module):
         ra = out_geometry.unsqueeze(2)  # [batch, a, 1, xyz]
         k = self.kernel(rb - ra, custom_backward=custom_backward_kernel, r_eps=r_eps)  # [batch, a, b, i, j]
         k.div_(n_norm ** 0.5)
+
+        features = features.reshape(*features.shape[:2], groups, features.shape[2] // groups)  # [batch, b, goup, j]
+
         if custom_backward_conv:
-            return ConvolutionEinsumFn.apply(k, features)  # [batch, point, channel]
+            features = ConvolutionEinsumFn.apply(k, features)  # [batch, point, groups, channel]
         else:
-            return torch.einsum("zabij,zbj->zai", (k, features))  # [batch, point, channel]
+            features = torch.einsum("zabij,zbgj->zagi", k, features)  # [batch, point, groups, channel]
+
+        return features.reshape(*features.shape[:2], groups * features.shape[3])  # [batch, point, groups * channel]
 
 
 class ConvolutionEinsumFn(torch.autograd.Function):
@@ -37,16 +42,16 @@ class ConvolutionEinsumFn(torch.autograd.Function):
     def forward(ctx, k, features):
         """
         :param k:        tensor [batch, out_point, in_point, l_out * mul_out * m_out, l_in * mul_in * m_in]
-        :param features: tensor [batch, in_point, l_in * mul_in * m_in]
+        :param features: tensor [batch, in_point, group, l_in * mul_in * m_in]
         """
         ctx.save_for_backward(k, features)
-        return torch.einsum("zabij,zbj->zai", k, features)  # [batch, point, channel]
+        return torch.einsum("zabij,zbgj->zagi", k, features)  # [batch, point, channel]
 
     @staticmethod
     def backward(ctx, grad_output):  # pragma: no cover
         k, features = ctx.saved_tensors
         del ctx
-        grad_k = torch.einsum("zai,zbj->zabij", grad_output, features)
+        grad_k = torch.einsum("zagi,zbgj->zabij", grad_output, features)
         grad_features = torch.einsum("zabij,zai->zbj", k, grad_output)
         return grad_k, grad_features
 

--- a/e3nn/point/operations.py
+++ b/e3nn/point/operations.py
@@ -30,6 +30,8 @@ class Convolution(torch.nn.Module):
 
         if custom_backward_conv:
             features = ConvolutionEinsumFn.apply(k, features)  # [batch, point, groups, channel]
+        elif k.dim() == 6 and k.shape[-3] == groups:
+            features = torch.einsum("zabgij,zbgj->zagi", k, features)
         else:
             features = torch.einsum("zabij,zbgj->zagi", k, features)  # [batch, point, groups, channel]
 

--- a/tests/point/depthwise_tests.py
+++ b/tests/point/depthwise_tests.py
@@ -1,6 +1,4 @@
 # pylint: disable=not-callable, no-member, invalid-name, line-too-long, wildcard-import, unused-wildcard-import, missing-docstring
-from functools import partial
-
 import torch
 
 from e3nn import o3, rs
@@ -21,12 +19,6 @@ def test_equivariance():
     Rs_mid1 = [(5, 0), (1, 1)]
     Rs_mid2 = [(5, 0), (1, 1), (1, 2)]
     Rs_out = [(5, 1), (3, 2)]
-
-    Rs_in = rs.convention(Rs_in)
-    Rs_out = rs.convention(Rs_out)
-    Rs_mid1 = rs.convention(Rs_mid1)
-    Rs_mid2 = rs.convention(Rs_mid2)
-    print(Rs_in, Rs_out)
 
     convolution = lambda Rs_in, Rs_out: Convolution(Kernel(Rs_in, Rs_out, ConstantRadialModel))
     groups = 4

--- a/tests/point/depthwise_tests.py
+++ b/tests/point/depthwise_tests.py
@@ -48,7 +48,7 @@ def test_equivariance():
         ])
     print(features.shape, edge_index.shape, edge_r.shape, size)
     out1 = mp(features, edge_index, edge_r, size=size)
-    out1_groups = mp_groups(features, edge_index, edge_r, size=size) 
+    out1_groups = mp_groups(features, edge_index, edge_r, size=size)
 
     angles = o3.rand_angles()
     D_in = rs.rep(Rs_in, *angles)

--- a/tests/point/depthwise_tests.py
+++ b/tests/point/depthwise_tests.py
@@ -1,0 +1,63 @@
+# pylint: disable=not-callable, no-member, invalid-name, line-too-long, wildcard-import, unused-wildcard-import, missing-docstring
+from functools import partial
+
+import torch
+
+from e3nn import o3, rs
+from e3nn.kernel import Kernel
+from e3nn.point.message_passing import Convolution
+from e3nn.radial import ConstantRadialModel
+from e3nn.point.depthwise import DepthwiseConvolution
+
+
+def test_equivariance():
+    torch.set_default_dtype(torch.float64)
+
+    n_edge = 3
+    n_source = 4
+    n_target = 2
+
+    Rs_in = [(3, 0), (0, 1)]
+    Rs_mid1 = [(5, 0), (1, 1)]
+    Rs_mid2 = [(5, 0), (1, 1), (1, 2)]
+    Rs_out = [(5, 1), (3, 2)]
+
+    Rs_in = rs.convention(Rs_in)
+    Rs_out = rs.convention(Rs_out)
+    Rs_mid1 = rs.convention(Rs_mid1)
+    Rs_mid2 = rs.convention(Rs_mid2)
+    print(Rs_in, Rs_out)
+
+    convolution = lambda Rs_in, Rs_out: Convolution(Kernel(Rs_in, Rs_out, ConstantRadialModel))
+    groups = 4
+    mp = DepthwiseConvolution(Rs_in, Rs_out, Rs_mid1, Rs_mid2, groups, convolution)
+
+    features = rs.randn(n_target, Rs_in)
+
+    r_source = torch.randn(n_source, 3)
+    r_target = torch.randn(n_target, 3)
+
+    edge_index = torch.stack([
+        torch.randint(n_source, size=(n_edge,)),
+        torch.randint(n_target, size=(n_edge,)),
+    ])
+    size = (n_target, n_source)
+
+    if n_edge == 0:
+        edge_r = torch.zeros(0, 3)
+    else:
+        edge_r = torch.stack([
+            r_target[j] - r_source[i]
+            for i, j in edge_index.T
+        ])
+    print(features.shape, edge_index.shape, edge_r.shape, size)
+    out1 = mp(features, edge_index, edge_r, size=size)
+
+    angles = o3.rand_angles()
+    D_in = rs.rep(Rs_in, *angles)
+    D_out = rs.rep(Rs_out, *angles)
+    R = o3.rot(*angles)
+
+    out2 = mp(features @ D_in.T, edge_index, edge_r @ R.T, size=size) @ D_out
+
+    assert (out1 - out2).abs().max() < 1e-10

--- a/tests/point/message_passing_test.py
+++ b/tests/point/message_passing_test.py
@@ -52,11 +52,12 @@ def test_equivariance(Rs_in, Rs_out, n_source, n_target, n_edge):
 
     out2 = mp(features @ D_in.T, edge_index, edge_r @ R.T, size=size) @ D_out
     out2_groups = mp(features2 @ D_in_groups.T, edge_index, edge_r @ R.T, size=size, groups=groups) @ D_out_groups
-    out2_kernel_groups = mp_group(features2 @ D_in_groups.T, edge_index, edge_r @ R.T, size=size, groups=groups) @ D_out_groups 
+    out2_kernel_groups = mp_group(features2 @ D_in_groups.T, edge_index, edge_r @ R.T, size=size, groups=groups) @ D_out_groups
 
     assert (out1 - out2).abs().max() < 1e-10
     assert (out1_groups - out2_groups).abs().max() < 1e-10
     assert (out1_kernel_groups - out2_kernel_groups).abs().max() < 1e-10
+
 
 def test_flow():
     """

--- a/tests/point/message_passing_test.py
+++ b/tests/point/message_passing_test.py
@@ -1,11 +1,12 @@
 # pylint: disable=not-callable, no-member, invalid-name, line-too-long, wildcard-import, unused-wildcard-import, missing-docstring
 import itertools
+from functools import partial
 
 import pytest
 import torch
 
 from e3nn import o3, rs
-from e3nn.kernel import Kernel
+from e3nn.kernel import Kernel, GroupKernel
 from e3nn.point.message_passing import Convolution
 from e3nn.radial import ConstantRadialModel
 
@@ -16,6 +17,7 @@ def test_equivariance(Rs_in, Rs_out, n_source, n_target, n_edge):
 
     mp = Convolution(Kernel(Rs_in, Rs_out, ConstantRadialModel))
     groups = 4
+    mp_group = Convolution(GroupKernel(Rs_in, Rs_out, partial(Kernel, RadialModel=ConstantRadialModel), groups))
 
     features = rs.randn(n_target, Rs_in)
     features2 = rs.randn(n_target, Rs_in * groups)
@@ -39,6 +41,7 @@ def test_equivariance(Rs_in, Rs_out, n_source, n_target, n_edge):
     print(features.shape, edge_index.shape, edge_r.shape, size)
     out1 = mp(features, edge_index, edge_r, size=size)
     out1_groups = mp(features2, edge_index, edge_r, size=size, groups=groups)
+    out1_kernel_groups = mp_group(features2, edge_index, edge_r, size=size, groups=groups)
 
     angles = o3.rand_angles()
     D_in = rs.rep(Rs_in, *angles)
@@ -49,10 +52,11 @@ def test_equivariance(Rs_in, Rs_out, n_source, n_target, n_edge):
 
     out2 = mp(features @ D_in.T, edge_index, edge_r @ R.T, size=size) @ D_out
     out2_groups = mp(features2 @ D_in_groups.T, edge_index, edge_r @ R.T, size=size, groups=groups) @ D_out_groups
+    out2_kernel_groups = mp_group(features2 @ D_in_groups.T, edge_index, edge_r @ R.T, size=size, groups=groups) @ D_out_groups 
 
     assert (out1 - out2).abs().max() < 1e-10
     assert (out1_groups - out2_groups).abs().max() < 1e-10
-
+    assert (out1_kernel_groups - out2_kernel_groups).abs().max() < 1e-10
 
 def test_flow():
     """


### PR DESCRIPTION
Add ability to use "groups" for convolution and the ability to have either a single `Kernel` applied to each group OR use a `GroupKernel` which applies a different `Kernel` to each group. The goal of `DepthwiseConvolution` is to use groups to drastically shrink the amount of terms in the Kernel tensor product. `DepthwiseConvolution` can be used with both `Kernel` or `GroupKernel` as `Convolution` type modules will detect whether a group dimension is present in the given kernel output.