### PR TITLE
Clarify Rs_sh / sh in tetris example.

### DIFF
--- a/examples/point/tetris_torch_geo.py
+++ b/examples/point/tetris_torch_geo.py
@@ -41,7 +41,7 @@ def get_dataset():
     return tetris, labels
 
 
-def forward(f, shapes, Rs_sh, lmax, device):
+def forward(f, shapes, Rs_sh, device):
     r_max = 1.1
     x = torch.ones(4, 1)
     batch = Batch.from_data_list([DataNeighbors(x, shape, r_max, self_interaction=False) for shape in shapes])
@@ -83,7 +83,7 @@ def main():
 
     wall = time.perf_counter()
     for step in range(100):
-        out = forward(f, tetris, Rs_sh, lmax, device)
+        out = forward(f, tetris, Rs_sh, device)
 
         acc = out.cpu().round().eq(labels).double().mean().item()
 

--- a/examples/point/tetris_torch_geo.py
+++ b/examples/point/tetris_torch_geo.py
@@ -41,12 +41,13 @@ def get_dataset():
     return tetris, labels
 
 
-def forward(f, shapes, lmax, device):
+def forward(f, shapes, Rs_sh, lmax, device):
     r_max = 1.1
     x = torch.ones(4, 1)
     batch = Batch.from_data_list([DataNeighbors(x, shape, r_max, self_interaction=False) for shape in shapes])
     batch = batch.to(device)
-    sh = rsh.spherical_harmonics_xyz(list(range(lmax + 1)), batch.edge_attr, 'component')
+    # Pre-compute the spherical harmonics and re-use them in each convolution
+    sh = rsh.spherical_harmonics_xyz(Rs_sh, batch.edge_attr, 'component')
     out = f(batch.x, batch.edge_index, batch.edge_attr, sh=sh, n_norm=3)
     out = scatter_add(out, batch.batch, dim=0)
     out = torch.tanh(out)
@@ -82,13 +83,13 @@ def main():
 
     wall = time.perf_counter()
     for step in range(100):
-        out = forward(f, tetris, lmax, device)
+        out = forward(f, tetris, Rs_sh, lmax, device)
 
         acc = out.cpu().round().eq(labels).double().mean().item()
 
         with torch.no_grad():
             shapes, _ = get_dataset()
-            r_out = forward(f, shapes, lmax, device)
+            r_out = forward(f, shapes, Rs_sh, lmax, device)
 
         loss = (out - labels.to(device=out.device)).pow(2).mean()
         optimizer.zero_grad()


### PR DESCRIPTION
Hi, I have a question and a potential solution for my question in this PR.

https://github.com/e3nn/e3nn/blob/4c12f848c07e5d1b149ff9a68f525c7e2e6f885b/examples/point/tetris_torch_geo.py#L49
https://github.com/e3nn/e3nn/blob/4c12f848c07e5d1b149ff9a68f525c7e2e6f885b/examples/point/tetris_torch_geo.py#L65

I was modeling my code on this `tetris_torch_geo.py` example.
I tried to change `Rs_sh` in my code, but the tensors were not correctly-sized until I made `sh` match.
I am guessing that `sh` is defined here (and not left as `None`, which is handled in `WTPConv.forward` based on `Rs_sh`) because it's being pre-calculated and re-used in each convolution layer.

If my understanding is correct, I'd like to add a code comment that mentions the use of pre-computation, and perhaps use `Rs_sh` directly in the expression for `sh` so that the choice of representations can be
changed in just one place (`Rs_sh`) and the correspondence is clearer.

Let me know what you think. Thanks!
