### PR TITLE
Ignore shared libraries built in place.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@ mutex
 *.jpeg
 
 *.npz
+
+# Ignore shared libraries built in the source directory
 e3nn/*.so
+e3nn/*.dylib

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mutex
 *.jpeg
 
 *.npz
+e3nn/*.so


### PR DESCRIPTION
I built e3nn with CUDA support "in-place", meaning that it puts the shared library `cuda_rsh.cpython-38-x86_64-linux-gnu.so` in the `e3nn` directory. This PR makes git ignore the built shared libraries in the source directory.
