### PR TITLE
Try pip 20.3 with updated dependencies.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,14 +24,17 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=180 --statistics
     - name: Install dependencies
+      env:
+        TORCH: "1.7.0"
+        CUDA: "cpu"
       run: |
-        python -m pip install pip==20.2.4
+        python -m pip install --upgrade pip
         pip install wheel
-        pip install torch==1.7.0+cpu torchvision==0.8.1+cpu torchaudio==0.7.0 -f https://download.pytorch.org/whl/torch_stable.html
-        pip install torch-scatter==latest+cpu -f https://pytorch-geometric.com/whl/torch-1.7.0.html
-        pip install torch-sparse==latest+cpu -f https://pytorch-geometric.com/whl/torch-1.7.0.html
-        pip install torch-cluster==latest+cpu -f https://pytorch-geometric.com/whl/torch-1.7.0.html
-        pip install torch-spline-conv==latest+cpu -f https://pytorch-geometric.com/whl/torch-1.7.0.html
+        pip install torch==${TORCH} torchvision torchaudio -f https://download.pytorch.org/whl/cpu/torch_stable.html
+        pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
+        pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
+        pip install torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
+        pip install torch-spline-conv -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
         pip install .
     - name: Test with pytest
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,14 +24,17 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=180 --statistics
     - name: Install dependencies
+      env:
+        TORCH: "1.7.0"
+        CUDA: "cpu"
       run: |
-        python -m pip install pip==20.2.4
+        python -m pip install --upgrade pip
         pip install wheel
-        pip install torch==1.7.0+cpu torchvision==0.8.1+cpu torchaudio==0.7.0 -f https://download.pytorch.org/whl/torch_stable.html
-        pip install torch-scatter==latest+cpu -f https://pytorch-geometric.com/whl/torch-1.7.0.html
-        pip install torch-sparse==latest+cpu -f https://pytorch-geometric.com/whl/torch-1.7.0.html
-        pip install torch-cluster==latest+cpu -f https://pytorch-geometric.com/whl/torch-1.7.0.html
-        pip install torch-spline-conv==latest+cpu -f https://pytorch-geometric.com/whl/torch-1.7.0.html
+        pip install torch==${TORCH} torchvision torchaudio -f https://download.pytorch.org/whl/cpu/torch_stable.html
+        pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
+        pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
+        pip install torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
+        pip install torch-spline-conv -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
         pip install .
     - name: Test with pytest
       run: |


### PR DESCRIPTION
This updates CI to un-pin pip < 20.3. The dependencies have been fixed, as described in this issue: https://github.com/rusty1s/pytorch_geometric/issues/1876
