### PR TITLE
Unified `DataNeighbors` using newer ASE neighbor lists

### DIFF
--- a/e3nn/point/data_helpers.py
+++ b/e3nn/point/data_helpers.py
@@ -42,6 +42,7 @@ class DataNeighbors(tg.data.Data):
             **kwargs
         )
 
+
 class DataPeriodicNeighbors(DataNeighbors):
     def __init__(self, x, pos, lattice, r_max, self_interaction=True, **kwargs):
         super().__init__(

--- a/e3nn/point/data_helpers.py
+++ b/e3nn/point/data_helpers.py
@@ -24,13 +24,13 @@ class DataNeighbors(tg.data.Data):
         self_interaction (bool, optional): whether to include self edges for points. Defaults to ``True``.
         **kwargs (optional): other attributes to pass to the ``torch_geometric.data.Data`` constructor.
     """
-    def __init__(self, x, pos, r_max, cell = None, pbc = False, self_interaction=True, **kwargs):
+    def __init__(self, x, pos, r_max, cell=None, pbc=False, self_interaction=True, **kwargs):
         edge_index, edge_attr = _neighbor_list_and_relative_vec(
             pos,
             r_max,
-            self_interaction = self_interaction,
-            cell = cell,
-            pbc = pbc
+            self_interaction=self_interaction,
+            cell=cell,
+            pbc=pbc
         )
         if cell is not None:
             # For compatability: the old DataPeriodicNeighbors put the cell
@@ -39,7 +39,7 @@ class DataNeighbors(tg.data.Data):
         super().__init__(x=x, edge_index=edge_index, edge_attr=edge_attr, pos=pos, **kwargs)
 
     @classmethod
-    def from_ase(cls, atoms, r_max, features = None, **kwargs):
+    def from_ase(cls, atoms, r_max, features=None, **kwargs):
         """Build a ``DataNeighbors`` from an ``ase.Atoms`` object.
 
         Respects ``atoms``'s ``pbc`` and ``cell``.
@@ -53,14 +53,14 @@ class DataNeighbors(tg.data.Data):
             A ``DataNeighbors``.
         """
         if features is None:
-            _, species_ids = np.unique(atoms.get_atomic_numbers(), return_inverse = True)
-            features = torch.nn.functional.one_hot(torch.as_tensor(species_ids)).to(dtype = torch.get_default_dtype())
+            _, species_ids = np.unique(atoms.get_atomic_numbers(), return_inverse=True)
+            features = torch.nn.functional.one_hot(torch.as_tensor(species_ids)).to(dtype=torch.get_default_dtype())
         return cls(
-            x = features,
-            pos = torch.as_tensor(atoms.positions),
-            r_max = r_max,
-            cell = atoms.get_cell(complete = True),
-            pbc = atoms.pbc,
+            x=features,
+            pos=torch.as_tensor(atoms.positions),
+            r_max=r_max,
+            cell=atoms.get_cell(),
+            pbc=atoms.pbc,
             **kwargs
         )
 
@@ -73,8 +73,8 @@ class DataPeriodicNeighbors(DataNeighbors):
     """
     def __init__(self, x, pos, lattice, r_max, self_interaction=True, **kwargs):
         super().__init__(
-            x=x, pos=pos, cell=lattice, pbc = True, r_max=r_max,
-            self_interaction = self_interaction, **kwargs
+            x=x, pos=pos, cell=lattice, pbc=True, r_max=r_max,
+            self_interaction=self_interaction, **kwargs
         )
 
 
@@ -152,7 +152,7 @@ class DataEdgePeriodicNeighbors(tg.data.Data):
             Rs_in_edge=Rs_in_edge, edge_index_dict=edge_index_dict, **kwargs)
 
 
-def _neighbor_list_and_relative_vec(pos, r_max, self_interaction=True, cell = None, pbc = False):
+def _neighbor_list_and_relative_vec(pos, r_max, self_interaction=True, cell=None, pbc=False):
     """Create neighbor list and neighbor vectors based on radial cutoff.
 
     Create neighbor list (``edge_index``) and relative vectors
@@ -189,9 +189,9 @@ def _neighbor_list_and_relative_vec(pos, r_max, self_interaction=True, cell = No
         pbc,
         np.asarray(cell),
         np.asarray(pos),
-        cutoff = r_max,
-        self_interaction = self_interaction,
-        use_scaled_positions = False
+        cutoff=r_max,
+        self_interaction=self_interaction,
+        use_scaled_positions=False
     )
     edge_index = torch.vstack((
         torch.LongTensor(first_idex),
@@ -210,9 +210,9 @@ def _neighbor_list_and_relative_vec_lattice(pos, lattice, r_max, self_interactio
     return _neighbor_list_and_relative_vec(
         pos,
         r_max,
-        cell = lattice,
-        pbc = (True,)*3,
-        self_interaction = self_interaction
+        cell=lattice,
+        pbc=True,
+        self_interaction=self_interaction
     )
 
 

--- a/e3nn/point/data_helpers.py
+++ b/e3nn/point/data_helpers.py
@@ -1,25 +1,53 @@
 # pylint: disable=arguments-differ, redefined-builtin, missing-docstring, no-member, invalid-name, line-too-long, not-callable
 import collections
+from functools import partial
 
 import torch
 import torch_geometric as tg
-from ase import Atoms, neighborlist
+import numpy as np
+import ase.neighborlist
 from pymatgen.core.structure import Structure
 
 from e3nn import o3, rs
 from e3nn.tensor import SphericalTensor
+from e3nn.util.deprecation import deprecated
 
 
 class DataNeighbors(tg.data.Data):
-    def __init__(self, x, pos, r_max, self_interaction=True, **kwargs):
-        edge_index, edge_attr = _neighbor_list_and_relative_vec(pos, r_max, self_interaction)
+    def __init__(self, x, pos, r_max, cell = None, pbc = False, self_interaction=True, **kwargs):
+        edge_index, edge_attr = _neighbor_list_and_relative_vec(
+            pos,
+            r_max,
+            self_interaction = self_interaction,
+            cell = cell,
+            pbc = pbc
+        )
+        if cell is not None:
+            # For compatability: the old DataPeriodicNeighbors put the cell
+            # in the Data object as `lattice`.
+            kwargs['lattice'] = cell
         super().__init__(x=x, edge_index=edge_index, edge_attr=edge_attr, pos=pos, **kwargs)
 
+    @classmethod
+    def from_ase(cls, atoms, r_max, features = None, **kwargs):
+        if features is None:
+            _, species_ids = np.unique(atoms.get_atomic_numbers(), return_inverse = True)
+            features = torch.nn.functional.one_hot(torch.as_tensor(species_ids)).to(dtype = torch.get_default_dtype())
+        return cls(
+            x = features,
+            pos = atoms.positions,
+            r_max = r_max,
+            cell = atoms.get_cell(complete = True),
+            pbc = atoms.pbc,
+            **kwargs
+        )
 
-class DataPeriodicNeighbors(tg.data.Data):
+class DataPeriodicNeighbors(DataNeighbors):
     def __init__(self, x, pos, lattice, r_max, self_interaction=True, **kwargs):
-        edge_index, edge_attr = _neighbor_list_and_relative_vec_lattice(pos, lattice, r_max, self_interaction)
-        super().__init__(x=x, edge_index=edge_index, edge_attr=edge_attr, pos=pos, lattice=lattice, **kwargs)
+        super().__init__(
+            x=x, pos=pos, cell=lattice, pbc = True, r_max=r_max,
+            self_interaction = self_interaction, **kwargs
+        )
 
 
 class DataEdgeNeighbors(tg.data.Data):
@@ -96,7 +124,7 @@ class DataEdgePeriodicNeighbors(tg.data.Data):
             Rs_in_edge=Rs_in_edge, edge_index_dict=edge_index_dict, **kwargs)
 
 
-def _neighbor_list_and_relative_vec(pos, r_max, self_interaction=True):
+def _neighbor_list_and_relative_vec(pos, r_max, self_interaction=True, cell = None, pbc = False):
     """Create neighbor list and neighbor vectors based on radial cutoff.
 
     Create neighbor list (``edge_index``) and relative vectors
@@ -110,8 +138,10 @@ def _neighbor_list_and_relative_vec(pos, r_max, self_interaction=True):
     :math:`\\vec{r}_{source, target}`
 
     Args:
-        pos (torch.tensor shape [N, 3]): Positional coordinates.
+        pos (shape [N, 3]): Positional coordinate; Tensor or numpy array. If Tensor, must be detached & on CPU.
         r_max (float): Radial cutoff distance for neighbor finding.
+        cell (numpy shape [3, 3]): Cell for periodic boundary conditions. Ignored if ``pbc == False``.
+        pbc (bool or 3-tuple of bool): Whether the system is periodic in each of the three cell dimensions.
         self_interaction (bool): Whether or not to include self-edges in the neighbor list.
 
     Returns:
@@ -119,87 +149,43 @@ def _neighbor_list_and_relative_vec(pos, r_max, self_interaction=True):
         edge_attr (torch.tensor shape [num_edges, 3]): Relative vectors corresponding to each edge.
 
     """
-    N, _ = pos.shape
-    assert _ == 3
-    atoms = Atoms(symbols=['H'] * N, positions=pos.cpu().detach().numpy())
-    nl = neighborlist.NeighborList(
-        [r_max / 2.] * N,  # NeighborList looks for intersecting spheres
-        self_interaction=self_interaction,
-        bothways=True,
-        skin=0.0,
+    if isinstance(pbc, bool):
+        pbc = (pbc,)*3
+    if cell is None:
+        # ASE will "complete" this correctly.
+        cell = np.zeros((3, 3))
+    cell = ase.geometry.complete_cell(cell)
+
+    first_idex, second_idex, displacements = ase.neighborlist.primitive_neighbor_list(
+        'ijD',
+        pbc,
+        np.asarray(cell),
+        np.asarray(pos),
+        cutoff = r_max,
+        self_interaction = self_interaction,
+        use_scaled_positions = False
     )
-    nl.update(atoms)
-
-    nei_list = []
-    geo_list = []
-
-    for i, p in enumerate(pos):
-        indices, _displacements = nl.get_neighbors(i)
-        if self_interaction:
-            assert indices[-1] == i
-            indices = indices[:-1]  # Remove extra self edge
-        nei_list.append(torch.LongTensor([[i, target] for target in indices]))
-        geo_list.append(pos[indices] - p)
-    edge_index = torch.cat(nei_list, dim=0).transpose(1, 0)
-    edge_attr = torch.cat(geo_list, dim=0)
+    edge_index = torch.vstack((
+        torch.LongTensor(first_idex),
+        torch.LongTensor(second_idex)
+    ))
+    edge_attr = torch.as_tensor(displacements)
     return edge_index, edge_attr
 
 
-def _neighbor_list_and_relative_vec_lattice(pos, lattice, r_max, self_interaction=True, r_min=1e-8):
+def _neighbor_list_and_relative_vec_lattice(pos, lattice, r_max, self_interaction=True):
     """Create neighbor list and neighbor vectors based on radial cutoff and periodic lattice.
 
-    Create neighbor list (``edge_index``) and relative vectors
-    (``edge_attr``) based on radial cutoff.
-
-    Edges are given by the following convention:
-    - ``edge_index[0]`` is the *source* (convolution center).
-    - ``edge_index[1]`` is the *target* (neighbor).
-
-    Thus, ``edge_index`` has the same convention as the relative vectors:
-    :math:`\\vec{r}_{source, target}`
-
-    Relative vectors are given for the different images of the neighbor point within ``r_max``.
-
-    Args:
-        pos (torch.tensor shape [N, 3]): Positional coordinates.
-        lattice (torch.tensor shape [3, 3]): Lattice vectors.
-        r_max (float): Radial cutoff distance for neighbor finding.
-        self_interaction (bool): Whether or not to include self-edges in the neighbor list.
-        r_min (float): Numerical tolerance for determining if points coincide.
-
-    Returns:
-        edge_index (torch.tensor shape [2, num_edges]): List of edges.
-        edge_attr (torch.tensor shape [num_edges, 3]): Relative vectors corresponding to each edge.
-
+    Compatability wrapper around ``_neighbor_list_and_relative_vec``.
+    Prefer to use ``_neighbor_list_and_relative_vec`` directly in new code.
     """
-    N, _ = pos.shape
-    structure = Structure(lattice, ['H'] * N, pos, coords_are_cartesian=True)
-
-    nei_list = []
-    geo_list = []
-
-    neighbors = structure.get_all_neighbors(
+    return _neighbor_list_and_relative_vec(
+        pos,
         r_max,
-        include_index=True,
-        include_image=True,
-        numerical_tol=r_min
+        cell = lattice,
+        pbc = (True,)*3,
+        self_interaction = self_interaction
     )
-    for i, (site, neis) in enumerate(zip(structure, neighbors)):
-        indices, cart = zip(*[(n.index, n.coords) for n in neis])
-        cart = torch.tensor(cart)
-        indices = torch.LongTensor([[i, target] for target in indices])
-        dist = cart - torch.tensor(site.coords)
-        if self_interaction:
-            self_index = torch.LongTensor([[i, i]])
-            indices = torch.cat([self_index, indices], dim=0)
-            self_dist = pos.new_zeros(1, 3, dtype=dist.dtype)
-            dist = torch.cat([self_dist, dist], dim=0)
-        nei_list.append(indices)
-        geo_list.append(dist)
-
-    edge_index = torch.cat(nei_list, dim=0).transpose(1, 0)
-    edge_attr = torch.cat(geo_list, dim=0)
-    return edge_index, edge_attr
 
 
 def _initialize_edges(x, Rs_in, pos, edge_index_dict, lmax, self_edge=1., symmetric_edges=False):

--- a/e3nn/point/data_helpers.py
+++ b/e3nn/point/data_helpers.py
@@ -6,7 +6,6 @@ import torch
 import torch_geometric as tg
 import numpy as np
 import ase.neighborlist
-from pymatgen.core.structure import Structure
 
 from e3nn import o3, rs
 from e3nn.tensor import SphericalTensor

--- a/tests/point/data_helpers_test.py
+++ b/tests/point/data_helpers_test.py
@@ -39,6 +39,18 @@ def test_from_ase():
     assert data.x.shape == (len(atoms), 1) # one species
 
 
+def test_some_periodic():
+    import ase.build
+    # monolayer in xy,
+    atoms = ase.build.fcc111('Al', size=(3, 3, 1), vacuum = 0.0)
+    data = dh.DataNeighbors.from_ase(atoms, r_max = 2.9) # first shell dist is 2.864A
+    # Check number of neighbors:
+    _, neighbor_count = np.unique(data.edge_index[0].numpy(), return_counts = True)
+    assert (neighbor_count == 7).all() # 6 neighbors + self interaction
+    # Check not periodic in z
+    assert torch.allclose(data.edge_attr[:, 2], torch.zeros(data.num_edges))
+
+
 def test_relative_vecs():
     coords = torch.tensor([
         [0, 0, 0],

--- a/tests/point/data_helpers_test.py
+++ b/tests/point/data_helpers_test.py
@@ -6,10 +6,11 @@ from e3nn import rs
 
 torch.set_default_dtype(torch.float64)
 
+
 def edge_index_set_equiv(a, b):
     """Compare edge_index arrays in an unordered way."""
     # [[0, 1], [1, 0]] -> {(0, 1), (1, 0)}
-    a = a.numpy() # numpy gives ints when iterated, tensor gives non-identical scalar tensors.
+    a = a.numpy()  # numpy gives ints when iterated, tensor gives non-identical scalar tensors.
     b = b.numpy()
     return set(zip(a[0], a[1])) == set(zip(b[0], b[1]))
 
@@ -31,22 +32,22 @@ def test_from_ase():
     import ase.build
     # Non-periodic
     atoms = ase.build.molecule('CH3CHO')
-    data = dh.DataNeighbors.from_ase(atoms, r_max = 2.)
-    assert data.x.shape == (len(atoms), 3) # 3 species in this atoms
+    data = dh.DataNeighbors.from_ase(atoms, r_max=2.)
+    assert data.x.shape == (len(atoms), 3)  # 3 species in this atoms
     # periodic
     atoms = ase.build.bulk('Cu', 'fcc', a=3.6, cubic=True)
-    data = dh.DataNeighbors.from_ase(atoms, r_max = 2.5)
-    assert data.x.shape == (len(atoms), 1) # one species
+    data = dh.DataNeighbors.from_ase(atoms, r_max=2.5)
+    assert data.x.shape == (len(atoms), 1)  # one species
 
 
 def test_some_periodic():
     import ase.build
     # monolayer in xy,
-    atoms = ase.build.fcc111('Al', size=(3, 3, 1), vacuum = 0.0)
-    data = dh.DataNeighbors.from_ase(atoms, r_max = 2.9) # first shell dist is 2.864A
+    atoms = ase.build.fcc111('Al', size=(3, 3, 1), vacuum=0.0)
+    data = dh.DataNeighbors.from_ase(atoms, r_max=2.9)  # first shell dist is 2.864A
     # Check number of neighbors:
-    _, neighbor_count = np.unique(data.edge_index[0].numpy(), return_counts = True)
-    assert (neighbor_count == 7).all() # 6 neighbors + self interaction
+    _, neighbor_count = np.unique(data.edge_index[0].numpy(), return_counts=True)
+    assert (neighbor_count == 7).all()  # 6 neighbors + self interaction
     # Check not periodic in z
     assert torch.allclose(data.edge_attr[:, 2], torch.zeros(data.num_edges))
 
@@ -58,9 +59,9 @@ def test_relative_vecs():
     ])
     r_max = 2.5
     data = dh.DataNeighbors(
-        x = torch.zeros(size = (len(coords), 1)),
-        pos = coords,
-        r_max = r_max,
+        x=torch.zeros(size = (len(coords), 1)),
+        pos=coords,
+        r_max=r_max,
     )
     edge_index_true = torch.LongTensor([
         [0, 0, 1, 1],
@@ -88,10 +89,10 @@ def test_self_interaction():
     ])
     r_max = 2.5
     data_no_si = dh.DataNeighbors(
-        x = torch.zeros(size = (len(coords), 1)),
-        pos = coords,
-        r_max = r_max,
-        self_interaction = False,
+        x=torch.zeros(size = (len(coords), 1)),
+        pos=coords,
+        r_max=r_max,
+        self_interaction=False,
     )
     true_no_si = torch.LongTensor([
         [0, 1],
@@ -99,10 +100,10 @@ def test_self_interaction():
     ])
     assert edge_index_set_equiv(data_no_si.edge_index, true_no_si)
     data_si = dh.DataNeighbors(
-        x = torch.zeros(size = (len(coords), 1)),
-        pos = coords,
-        r_max = r_max,
-        self_interaction = True
+        x=torch.zeros(size = (len(coords), 1)),
+        pos=coords,
+        r_max=r_max,
+        self_interaction=True
     )
     true_si = torch.LongTensor([
         [0, 0, 1, 1],
@@ -129,11 +130,11 @@ def test_silicon_neighbors():
     ])
     assert edge_index_set_equiv(edge_index, edge_index_true)
     data = dh.DataNeighbors(
-        x = torch.zeros(size = (len(coords), 1)),
-        pos = coords,
-        r_max = r_max,
-        cell = lattice,
-        pbc = True,
+        x=torch.zeros(size = (len(coords), 1)),
+        pos=coords,
+        r_max=r_max,
+        cell=lattice,
+        pbc=True,
     )
     assert edge_index_set_equiv(data.edge_index, edge_index_true)
 

--- a/tests/point/data_helpers_test.py
+++ b/tests/point/data_helpers_test.py
@@ -59,7 +59,7 @@ def test_relative_vecs():
     ])
     r_max = 2.5
     data = dh.DataNeighbors(
-        x=torch.zeros(size = (len(coords), 1)),
+        x=torch.zeros(size=(len(coords), 1)),
         pos=coords,
         r_max=r_max,
     )
@@ -89,7 +89,7 @@ def test_self_interaction():
     ])
     r_max = 2.5
     data_no_si = dh.DataNeighbors(
-        x=torch.zeros(size = (len(coords), 1)),
+        x=torch.zeros(size=(len(coords), 1)),
         pos=coords,
         r_max=r_max,
         self_interaction=False,
@@ -100,7 +100,7 @@ def test_self_interaction():
     ])
     assert edge_index_set_equiv(data_no_si.edge_index, true_no_si)
     data_si = dh.DataNeighbors(
-        x=torch.zeros(size = (len(coords), 1)),
+        x=torch.zeros(size=(len(coords), 1)),
         pos=coords,
         r_max=r_max,
         self_interaction=True
@@ -130,7 +130,7 @@ def test_silicon_neighbors():
     ])
     assert edge_index_set_equiv(edge_index, edge_index_true)
     data = dh.DataNeighbors(
-        x=torch.zeros(size = (len(coords), 1)),
+        x=torch.zeros(size=(len(coords), 1)),
         pos=coords,
         r_max=r_max,
         cell=lattice,


### PR DESCRIPTION
This PR updates the `DataNeighbors` data helpers to improve a few things:

- Use the newer linear-scaling [ASE neighbor lists](https://wiki.fysik.dtu.dk/ase/ase/neighborlist.html) instead of the older, quadratic ones (which are used by default in the `ase.neighborlist.NeighborList` class)
- Use ASE consistently for both periodic and non-periodic systems (rather than using `pymatgen` for periodic systems)
- Expose ASE's support for partial periodic boundary conditions such as surfaces that are periodic in two-of-three cell vectors
- Avoid the allocation of intermediate `ase.Atoms`/`pymatgen.Structure` objects to improve dataloading efficiency
- Add `DataNeighbors.from_ase`
- Adds and updates relevant tests

I've concentrated all the neighbor finding into `DataNeighbors` and `_neighbor_list_and_relative_vec` by adding `cell` and `pbc` parameters (following ASE conventions); I've also rewritten `DataPeriodicNeighbors` and `_neighbor_list_and_relative_vec_lattice` as compatibility wrappers for the former. Whether those should be marked as deprecated is up to you. Also the cell is added to a `DataNeighbors` object as a property named `lattice` even though it's passed in as `cell` for backwards compatibility: I could change this to be consistent but I wanted to start out not breaking things.

The only break in compatibility should be the order of edges in periodic systems, since ASE and pymatgen return them in different orders, but that shouldn't matter. 

Thanks!