### PR TITLE
Spherical tensor returns 0 when given an empty list of vectors to convert

### DIFF
--- a/e3nn/io/spherical_tensor.py
+++ b/e3nn/io/spherical_tensor.py
@@ -80,6 +80,11 @@ class SphericalTensor(o3.Irreps):
         tensor([1.0000, 5.0000])
         """
         assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"
+
+        # empty set of vectors returns a 0 spherical tensor
+        if len(vectors) == 0:
+            return torch.zeros(size=(o3.Irreps.spherical_harmonics(self.lmax).dim,))
+
         vectors = vectors.reshape(-1, 3)
         radii = vectors.norm(dim=1)  # [batch]
         vectors = vectors[radii > 0]  # [batch, 3]
@@ -102,6 +107,11 @@ class SphericalTensor(o3.Irreps):
         TODO rename this function?
         """
         assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"
+
+        # empty set of vectors returns a 0 spherical tensor
+        if len(vectors) == 0:
+            return torch.zeros(size=(o3.Irreps.spherical_harmonics(self.lmax).dim,))
+
         vectors = vectors.reshape(-1, 3)
         radii = vectors.norm(dim=1)
         sh = o3.spherical_harmonics(self, vectors, normalize=True)

--- a/e3nn/io/spherical_tensor.py
+++ b/e3nn/io/spherical_tensor.py
@@ -79,11 +79,11 @@ class SphericalTensor(o3.Irreps):
         >>> x.signal_xyz(d, p)
         tensor([1.0000, 5.0000])
         """
-        assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"
-
         # empty set of vectors returns a 0 spherical tensor
         if len(vectors) == 0:
             return torch.zeros(size=(o3.Irreps.spherical_harmonics(self.lmax).dim,))
+
+        assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"
 
         vectors = vectors.reshape(-1, 3)
         radii = vectors.norm(dim=1)  # [batch]
@@ -106,11 +106,12 @@ class SphericalTensor(o3.Irreps):
 
         TODO rename this function?
         """
-        assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"
-
         # empty set of vectors returns a 0 spherical tensor
         if len(vectors) == 0:
             return torch.zeros(size=(o3.Irreps.spherical_harmonics(self.lmax).dim,))
+
+
+        assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"
 
         vectors = vectors.reshape(-1, 3)
         radii = vectors.norm(dim=1)
@@ -127,6 +128,9 @@ class SphericalTensor(o3.Irreps):
 
         TODO rename this function?
         """
+        if len(positions) == 0:
+            return torch.zeros(size=(o3.Irreps.spherical_harmonics(self.lmax).dim,))
+
         positions = positions.reshape(-1, 3)
         values = values.reshape(-1)
         positions /= positions.norm(dim=1, keepdim=True)

--- a/e3nn/io/spherical_tensor.py
+++ b/e3nn/io/spherical_tensor.py
@@ -110,7 +110,6 @@ class SphericalTensor(o3.Irreps):
         if len(vectors) == 0:
             return torch.zeros(size=(o3.Irreps.spherical_harmonics(self.lmax).dim,))
 
-
         assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"
 
         vectors = vectors.reshape(-1, 3)


### PR DESCRIPTION
## Description

These three functions now return a tensor of correct dimension of zeros when given an empty list of vectors to convert

* from_geometry_adjusted
* from_geometry_global_rescale
* from_samples_on_s2

It's just a simple check if the list of vectors is empty, if yes, it returns a torch.Tensor of 0's with the dimension of the SphericalTensor. 

## Motivation and Context

Previously it broke for empty lists. 

## How Has This Been Tested?

I ran pytest on the tests directory 
I ran flake8 on my files 
I tested that all three actually gives 0-tensors. 

## Checklist:
- [ x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x ] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).