### PR TITLE
Codegen File Cleanup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - swish, use `torch.nn.functional.silu` instead
 - `"cartesian_vectors"` for equivariance testing — since the 0.2.2 Euler angle convention change, L=1 irreps are equivalent
+### Fixed
+- Modules that generate code now clean up their temporary files
 
 ## [0.2.2] - 2021-02-09
 ### Changed

--- a/e3nn/nn/models/gate_points_2101.py
+++ b/e3nn/nn/models/gate_points_2101.py
@@ -298,7 +298,9 @@ class Network(torch.nn.Module):
         else:
             batch = data['pos'].new_zeros(data['pos'].shape[0], dtype=torch.long)
 
-        edge_src, edge_dst = radius_graph(data['pos'], self.max_radius, batch)
+        edge_index = radius_graph(data['pos'], self.max_radius, batch)
+        edge_src = edge_index[0]
+        edge_dst = edge_index[1]
         edge_vec = data['pos'][edge_src] - data['pos'][edge_dst]
         edge_sh = o3.spherical_harmonics(self.irreps_edge_attr, edge_vec, True, normalization='component')
         edge_length = edge_vec.norm(dim=1)

--- a/e3nn/util/eval_code.py
+++ b/e3nn/util/eval_code.py
@@ -3,7 +3,6 @@ Evaluate a python string as code
 """
 import importlib.machinery
 import importlib.util
-import os
 import tempfile
 import functools
 from typing import Dict
@@ -14,15 +13,13 @@ def eval_code(code):
     r"""
     save code in a temporary file and import it as a module
     """
-    new_file, filename = tempfile.mkstemp(text=True)
-
-    os.write(new_file, bytes(code, 'ascii'))
-    os.close(new_file)
-
-    loader = importlib.machinery.SourceFileLoader('main', filename)
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    mod = importlib.util.module_from_spec(spec)
-    loader.exec_module(mod)
+    with tempfile.NamedTemporaryFile() as new_file:
+        new_file.write(bytes(code, 'ascii'))
+        new_file.flush()
+        loader = importlib.machinery.SourceFileLoader('main', new_file.name)
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        mod = importlib.util.module_from_spec(spec)
+        loader.exec_module(mod)
     return mod
 
 


### PR DESCRIPTION
## Description
Use `tempfile.NamedTemporaryFile` in `eval_code` to ensure that temporary files contained generated code get cleaned up.

## Motivation and Context
The previous code used `tempfile.mkstemp()`, which does not clean up its created files at all and as a result can create many, many temporary files (two for each `TensorProduct`) that don't typically get cleaned up till system restart.

## How Has This Been Tested?
The `e3nn` test suite.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).