### PR TITLE
Fix `NormActivation` on GPU

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `e3nn.math.reduce.reduce_tensor` in favor of `e3nn.o3.ReducedTensorProducts`
 - swish, use `torch.nn.functional.silu` instead
 - `"cartesian_vectors"` for equivariance testing — since the 0.2.2 Euler angle convention change, L=1 irreps are equivalent
+### Fixed
+- `NormActivation` now works on GPU
 
 ## [0.2.2] - 2021-02-09
 ### Changed

--- a/e3nn/nn/normact.py
+++ b/e3nn/nn/normact.py
@@ -51,7 +51,7 @@ class NormActivation(torch.nn.Module):
         self.irreps_out = o3.Irreps(irreps_in)
         self.norm = o3.Norm(irreps_in)
         self.scalar_nonlinearity = scalar_nonlinearity
-        self.epsilon = torch.as_tensor(epsilon)
+        self.register_buffer('epsilon', torch.as_tensor(epsilon))
         self.normalize = normalize
         self.bias = bias
         if self.bias:


### PR DESCRIPTION
## Description
Fix `NormActivation` on GPU by making `epsilon` a buffer.

## How Has This Been Tested?
e3nn test suite (CPU), running a model that uses it on GPU (thanks @simonbatzner).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).