### PR TITLE
`SphericalHarmonics` module

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `o3.TensorProduct`: also broadcast the `weight` argument
 - simple e3nn models can be saved/loaded with `torch.save()`/`torch.load()`
 - JITable `o3.SphericalHarmonics` module version of `o3.spherical_harmonics`
+- `in_place` option for `e3nn.util.jit` compilation functions
 
 ### Changed
 - in `soft_one_hot_linspace` the argument `base` is renamed into `basis`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `o3.TensorProduct`: is jit scriptable
 - `o3.TensorProduct`: also broadcast the `weight` argument
 - simple e3nn models can be saved/loaded with `torch.save()`/`torch.load()`
+- JITable `o3.SphericalHarmonics` module version of `o3.spherical_harmonics`
 
 ### Changed
 - in `soft_one_hot_linspace` the argument `base` is renamed into `basis`

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -221,7 +221,7 @@ def assert_auto_jitable(
         The traced TorchScript function.
     """
     # Prevent pytest from showing this function in the traceback
-    #__tracebackhide__ = True
+    __tracebackhide__ = True
 
     if get_compile_mode(func) is None:
         raise ValueError("assert_auto_jitable is only for modules marked with @compile_mode")

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -5,7 +5,7 @@ import warnings
 import torch
 
 from e3nn import o3
-from e3nn.util.jit import compile, get_tracing_inputs, get_compile_mode
+from e3nn.util.jit import compile, get_tracing_inputs, get_compile_mode, _MAKE_TRACING_INPUTS
 from ._argtools import _get_args_in, _get_io_irreps, _transform
 
 
@@ -221,7 +221,7 @@ def assert_auto_jitable(
         The traced TorchScript function.
     """
     # Prevent pytest from showing this function in the traceback
-    __tracebackhide__ = True
+    #__tracebackhide__ = True
 
     if get_compile_mode(func) is None:
         raise ValueError("assert_auto_jitable is only for modules marked with @compile_mode")
@@ -236,7 +236,8 @@ def assert_auto_jitable(
         )
 
     # Confirm that it rejects incorrect shapes
-    if strict_shapes:
+    # This check only makes sense if all inputs are Tensors with irreps; otherwise we can't know how to modify the arguments or that our modifications make them wrong.
+    if strict_shapes and not hasattr(func, _MAKE_TRACING_INPUTS):
         try:
             all_bad_args = get_tracing_inputs(func, n=1)[0]
         except ValueError:

--- a/tests/o3/cartesian_spherical_harmonics_test.py
+++ b/tests/o3/cartesian_spherical_harmonics_test.py
@@ -3,6 +3,7 @@ import math
 import pytest
 import torch
 from e3nn import o3
+from e3nn.util.test import assert_auto_jitable
 
 
 def test_weird_call():
@@ -114,3 +115,16 @@ def test_recurrence_relation(float_tolerance, l):
     )
 
     assert (a - b).abs().max() < 100*float_tolerance
+
+
+def test_module():
+    l = o3.Irreps("0e + 1o + 3o")
+    normalize = True
+    normalization = 'integral'
+    sp = o3.SphericalHarmonics(l, normalize, normalization)
+    sp_jit = assert_auto_jitable(sp)
+    xyz = torch.randn(11, 3)
+    assert torch.allclose(
+        sp_jit(xyz),
+        o3.spherical_harmonics(l, xyz, normalize, normalization)
+    )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
TorchScript can't handle direct calls to `o3.spherical_harmonics` because of the irreps parameter/irreps handing and control flow inside of it. It can, however, be traced without issue. This PR makes doing that simpler.

Unrelatedly, this PR adds an `in_place` argument to the `e3nn.util.jit` compilation functions. Because they recursively compile submodules, they currently affect the module that is passed to them. This addition maintains this behavior (`in_place = True` by default) but allows the user to choose to have a copy of the module made first.

## Motivation and Context
Some modules should be `@compile_mode('script')` but want to call `spherical_harmonics` and currently can't. By making it a submodule with appropriate compilation decorators, tracing through `spherical_harominics` inside of a script-mode module is handled by `e3nn.util.jit`.

## How Has This Been Tested?
New test, e3nn test suite.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).