### PR TITLE
Some fixes for `device` on GPU

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `nn.Gate` was crashing when the number of scalars or gates was zero
+- `device` edge cases for `Gate` and `SphericalHarmonics`
 
 ## [0.2.3] - 2021-02-23
 ### Added

--- a/e3nn/math/normalize_activation.py
+++ b/e3nn/math/normalize_activation.py
@@ -20,6 +20,13 @@ def moment(f, n, dtype=None, device=None):
 class normalize2mom(torch.nn.Module):
     def __init__(self, f, dtype=None, device=None):
         super().__init__()
+
+        # Try to infer a device:
+        if device is None and isinstance(f, torch.nn.Module):
+            # Avoid circular import
+            from e3nn.util._argtools import _get_device
+            device = _get_device(f)
+
         cst = 1 / moment(f, 2, dtype=dtype, device=device) ** 0.5
 
         if abs(cst - 1) < 1e-4:

--- a/e3nn/math/normalize_activation.py
+++ b/e3nn/math/normalize_activation.py
@@ -19,6 +19,7 @@ def moment(f, n, dtype=None, device=None):
 @compile_mode('trace')
 class normalize2mom(torch.nn.Module):
     _is_id: bool
+    cst: float
 
     def __init__(self, f, dtype=None, device=None):
         super().__init__()
@@ -29,7 +30,8 @@ class normalize2mom(torch.nn.Module):
             from e3nn.util._argtools import _get_device
             device = _get_device(f)
 
-        cst = 1 / moment(f, 2, dtype=dtype, device=device) ** 0.5
+        with torch.no_grad():
+            cst = float(1 / moment(f, 2, dtype=dtype, device=device) ** 0.5)
 
         if abs(cst - 1) < 1e-4:
             self._is_id = True
@@ -37,7 +39,7 @@ class normalize2mom(torch.nn.Module):
             self._is_id = False
 
         self.f = f
-        self.register_buffer('cst', cst)
+        self.cst = cst
 
     def forward(self, x):
         if self._is_id:
@@ -49,10 +51,4 @@ class normalize2mom(torch.nn.Module):
         # No reason to trace this with more than one tiny input,
         # since f is assumed by `moment` to be an elementwise scalar
         # function
-        return [{
-            'forward': (torch.zeros(
-                size=(1,),
-                dtype=self.cst.dtype,
-                device=self.cst.device
-            ),)
-        }]
+        return [{'forward': (torch.zeros(size=(1,),),)}]

--- a/e3nn/math/normalize_activation.py
+++ b/e3nn/math/normalize_activation.py
@@ -31,7 +31,7 @@ class normalize2mom(torch.nn.Module):
             device = _get_device(f)
 
         with torch.no_grad():
-            cst = float(1 / moment(f, 2, dtype=dtype, device=device) ** 0.5)
+            cst = moment(f, 2, dtype=dtype, device=device).pow(-0.5).item()
 
         if abs(cst - 1) < 1e-4:
             self._is_id = True

--- a/e3nn/math/normalize_activation.py
+++ b/e3nn/math/normalize_activation.py
@@ -18,6 +18,8 @@ def moment(f, n, dtype=None, device=None):
 
 @compile_mode('trace')
 class normalize2mom(torch.nn.Module):
+    _is_id: bool
+
     def __init__(self, f, dtype=None, device=None):
         super().__init__()
 

--- a/e3nn/nn/gate.py
+++ b/e3nn/nn/gate.py
@@ -37,14 +37,15 @@ class Activation(torch.nn.Module):
         # normalize the second moment
         acts = [normalize2mom(act) if act is not None else None for act in acts]
 
+        from e3nn.util._argtools import _get_device
+
         irreps_out = []
         for (mul, (l_in, p_in)), act in zip(irreps_in, acts):
             if act is not None:
                 if l_in != 0:
                     raise ValueError("Activation: cannot apply an activation function to a non-scalar input.")
 
-                # act is a normalize2mom, so it has dtype and device
-                x = torch.linspace(0, 10, 256, dtype=act.cst.dtype, device=act.cst.device)
+                x = torch.linspace(0, 10, 256, device=_get_device(act))
 
                 a1, a2 = act(x), act(-x)
                 if (a1 - a2).abs().max() < 1e-5:

--- a/e3nn/nn/gate.py
+++ b/e3nn/nn/gate.py
@@ -64,7 +64,7 @@ class Activation(torch.nn.Module):
 
         self.irreps_in = irreps_in.simplify()
         self.irreps_out = o3.Irreps(irreps_out).simplify()
-        self.acts = acts
+        self.acts = torch.nn.ModuleList(acts)
 
     def forward(self, features, dim=-1):
         '''evaluate

--- a/e3nn/nn/gate.py
+++ b/e3nn/nn/gate.py
@@ -37,13 +37,14 @@ class Activation(torch.nn.Module):
         # normalize the second moment
         acts = [normalize2mom(act) if act is not None else None for act in acts]
 
-        x = torch.linspace(0, 10, 256)
-
         irreps_out = []
         for (mul, (l_in, p_in)), act in zip(irreps_in, acts):
             if act is not None:
                 if l_in != 0:
                     raise ValueError("Activation: cannot apply an activation function to a non-scalar input.")
+
+                # act is a normalize2mom, so it has dtype and device
+                x = torch.linspace(0, 10, 256, dtype=act.cst.dtype, device=act.cst.device)
 
                 a1, a2 = act(x), act(-x)
                 if (a1 - a2).abs().max() < 1e-5:

--- a/e3nn/o3/cartesian_spherical_harmonics.py
+++ b/e3nn/o3/cartesian_spherical_harmonics.py
@@ -25,7 +25,7 @@ class SphericalHarmonics(torch.nn.Module):
     _lmax: int
     _is_range_lmax: bool
     _prof_str: str
-    
+
     def __init__(
         self,
         l: Union[int, List[int], Irreps],
@@ -48,7 +48,7 @@ class SphericalHarmonics(torch.nn.Module):
         self._lmax = max(ls)
         self._is_range_lmax = ls == list(range(max(ls) + 1))
         self._prof_str = f'spherical_harmonics({ls})'
-        
+
         _lmax = 11
         if self._lmax > _lmax:
             raise NotImplementedError(f'spherical_harmonics maximum l implemented is {_lmax}, send us an email to ask for more')

--- a/e3nn/o3/cartesian_spherical_harmonics.py
+++ b/e3nn/o3/cartesian_spherical_harmonics.py
@@ -42,7 +42,7 @@ class SphericalHarmonics(torch.nn.Module):
         if irreps_in not in (Irreps("1x1o"), Irreps("1x1e")):
             raise ValueError(f"irreps_in for SphericalHarmonics must be either a vector (`1x1o`) or a psuedovector (`1x1e`), not `{irreps_in}`")
         self.irreps_in = irreps_in
-        input_p = irreps_in[0][1][1]
+        input_p = irreps_in[0].ir.p
 
         if isinstance(irreps_out, str):
             irreps_out = Irreps(irreps_out)

--- a/e3nn/o3/cartesian_spherical_harmonics.py
+++ b/e3nn/o3/cartesian_spherical_harmonics.py
@@ -13,12 +13,19 @@ from .irreps import Irreps
 from e3nn.util.jit import compile_mode
 
 
-@compile_mode('trace')
+@compile_mode('script')
 class SphericalHarmonics(torch.nn.Module):
     """JITable module version of ``e3nn.o3.spherical_harmonics``.
 
     Parameters are idential to ``e3nn.o3.spherical_harmonics``.
     """
+    normalize: bool
+    normalization: str
+    _ls_list: List[int]
+    _lmax: int
+    _is_range_lmax: bool
+    _prof_str: str
+    
     def __init__(
         self,
         l: Union[int, List[int], Irreps],
@@ -29,19 +36,49 @@ class SphericalHarmonics(torch.nn.Module):
         self.l = l
         self.normalize = normalize
         self.normalization = normalization
+        assert normalization in ['integral', 'component', 'norm']
+
+        if isinstance(l, Irreps):
+            ls = [l for mul, (l, p) in l for _ in range(mul)]
+        elif isinstance(l, int):
+            ls = [l]
+        else:
+            ls = list(l)
+        self._ls_list = ls
+        self._lmax = max(ls)
+        self._is_range_lmax = ls == list(range(max(ls) + 1))
+        self._prof_str = f'spherical_harmonics({ls})'
+        
+        _lmax = 11
+        if self._lmax > _lmax:
+            raise NotImplementedError(f'spherical_harmonics maximum l implemented is {_lmax}, send us an email to ask for more')
 
     def forward(self, xyz: torch.Tensor) -> torch.Tensor:
-        return spherical_harmonics(
-            self.l,
-            xyz,
-            self.normalize,
-            self.normalization
-        )
+        with torch.autograd.profiler.record_function(self._prof_str):
+            if self.normalize:
+                xyz = torch.nn.functional.normalize(xyz, dim=-1)  # forward 0's instead of nan for zero-radius
 
-    def _make_tracing_inputs(self, n: int):
-        return [{
-            'forward': (torch.ones(2, 3),)
-        }]
+            x, y, z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
+            sh = _spherical_harmonics(self._lmax, x, y, z)
+
+            if not self._is_range_lmax:
+                sh = torch.cat([
+                    sh[..., l*l:(l+1)*(l+1)]
+                    for l in self._ls_list
+                ], dim=-1)
+
+            if self.normalization == 'integral':
+                sh.mul_(torch.cat([
+                    (math.sqrt(2 * l + 1) / math.sqrt(4 * math.pi)) * torch.ones(2 * l + 1, dtype=sh.dtype, device=sh.device)
+                    for l in self._ls_list
+                ]))
+            elif self.normalization == 'component':
+                sh.mul_(torch.cat([
+                    math.sqrt(2 * l + 1) * torch.ones(2 * l + 1, dtype=sh.dtype, device=sh.device)
+                    for l in self._ls_list
+                ]))
+
+            return sh
 
 
 def spherical_harmonics(
@@ -116,38 +153,8 @@ def spherical_harmonics(
     wigner_3j
 
     """
-    if isinstance(l, Irreps):
-        ls = [l for mul, (l, p) in l for _ in range(mul)]
-    elif isinstance(l, int):
-        ls = [l]
-    else:
-        ls = list(l)
-
-    _lmax = 11
-    if max(ls) > _lmax:
-        raise NotImplementedError(f'spherical_harmonics maximum l implemented is {_lmax}, send us an email to ask for more')
-
-    assert normalization in ['integral', 'component', 'norm']
-
-    with torch.autograd.profiler.record_function(f'spherical_harmonics({ls})'):
-        if normalize:
-            xyz = torch.nn.functional.normalize(xyz, dim=-1)  # forward 0's instead of nan for zero-radius
-
-        x, y, z = xyz[..., 0], xyz[..., 1], xyz[..., 2]
-        sh = _spherical_harmonics(max(ls), x, y, z)
-
-        if not ls == list(range(max(ls) + 1)):
-            sh = torch.cat([
-                sh[..., l**2:(l+1)**2]
-                for l in ls
-            ], dim=-1)
-
-        if normalization == 'integral':
-            sh.mul_(torch.cat([math.sqrt(2 * l + 1) * sh.new_ones(2 * l + 1) / math.sqrt(4 * math.pi) for l in ls]))
-        if normalization == 'component':
-            sh.mul_(torch.cat([math.sqrt(2 * l + 1) * sh.new_ones(2 * l + 1) for l in ls]))
-
-        return sh
+    sh = SphericalHarmonics(l, normalize, normalization)
+    return sh(xyz)
 
 
 @torch.jit.script

--- a/e3nn/o3/cartesian_spherical_harmonics.py
+++ b/e3nn/o3/cartesian_spherical_harmonics.py
@@ -28,22 +28,26 @@ class SphericalHarmonics(torch.nn.Module):
 
     def __init__(
         self,
-        l: Union[int, List[int], Irreps],
+        irreps_out: Union[int, List[int], Irreps],
         normalize: bool,
         normalization='integral'
     ):
         super().__init__()
-        self.l = l
         self.normalize = normalize
         self.normalization = normalization
         assert normalization in ['integral', 'component', 'norm']
 
-        if isinstance(l, Irreps):
-            ls = [l for mul, (l, p) in l for _ in range(mul)]
-        elif isinstance(l, int):
-            ls = [l]
+        if isinstance(irreps_out, Irreps):
+            ls = [l for mul, (l, p) in irreps_out for _ in range(mul)]
+        elif isinstance(irreps_out, int):
+            ls = [irreps_out]
+            irreps_out = Irreps([(1, (irreps_out, 1))])
         else:
-            ls = list(l)
+            ls = list(irreps_out)
+            irreps_out = Irreps([(1, (l, 1)) for l in ls])
+        self.irreps_out = irreps_out
+        self.irreps_in = Irreps("1x1o")
+
         self._ls_list = ls
         self._lmax = max(ls)
         self._is_range_lmax = ls == list(range(max(ls) + 1))

--- a/e3nn/util/_argtools.py
+++ b/e3nn/util/_argtools.py
@@ -73,6 +73,15 @@ def _rand_args(irreps_in):
     return args_in
 
 
+def _get_device(mod: torch.nn.Module) -> torch.device:
+    # Try to a get a parameter
+    a_buf = next(mod.parameters(), None)
+    if a_buf is None:
+        # If there isn't one, try to get a buffer
+        a_buf = next(mod.buffers(), None)
+    return a_buf.device if a_buf is not None else 'cpu'
+
+
 def _to_device(args, device):
     if isinstance(args, torch.Tensor):
         return args.to(device=device)

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -132,7 +132,7 @@ def get_tracing_inputs(mod: torch.nn.Module, n: int = 1):
         Tracing inputs in the format of ``torch.jit.trace_module``: dicts mapping method names like ``'forward'`` to tuples of arguments.
     """
     # Avoid circular imports
-    from ._argtools import _get_io_irreps, _rand_args, _to_device
+    from ._argtools import _get_io_irreps, _rand_args, _to_device, _get_device
     # - Get inputs -
     if hasattr(mod, _MAKE_TRACING_INPUTS):
         # This returns a trace_module style dict of method names to test inputs
@@ -149,12 +149,7 @@ def get_tracing_inputs(mod: torch.nn.Module, n: int = 1):
         )
         trace_inputs = [{'forward': _rand_args(irreps_in)} for _ in range(n)]
     # - Put them on the right device -
-    # Try to a get a parameter
-    a_buf = next(mod.parameters(), None)
-    if a_buf is None:
-        # If there isn't one, try to get a buffer
-        a_buf = next(mod.buffers(), None)
-    device = a_buf.device if a_buf is not None else 'cpu'
+    device = _get_device(mod)
     # Move them
     trace_inputs = _to_device(trace_inputs, device)
     return trace_inputs

--- a/tests/o3/cartesian_spherical_harmonics_test.py
+++ b/tests/o3/cartesian_spherical_harmonics_test.py
@@ -10,6 +10,36 @@ def test_weird_call():
     o3.spherical_harmonics([4, 1, 2, 3, 3, 1, 0], torch.randn(2, 1, 2, 3), False)
 
 
+def test_weird_irreps():
+    # string input
+    o3.spherical_harmonics("0e + 1o", torch.randn(1, 3), False)
+
+    # Weird multipliciteis
+    irreps = o3.Irreps("1x0e + 4x1o + 3x2e")
+    out = o3.spherical_harmonics(irreps, torch.randn(7, 3), True)
+    assert out.shape[-1] == irreps.dim
+
+    # Bad parity
+    with pytest.raises(ValueError):
+        # L = 1 shouldn't be even for a vector input
+        o3.spherical_harmonics("1x0e + 4x1e + 3x2e", torch.randn(2, 3), True)
+
+    # Good parity but psuedovector input
+    _ = o3.SphericalHarmonics(
+        irreps_in="1e",
+        irreps_out="1x0e + 4x1e + 3x2e",
+        normalize=True
+    )
+
+    # Invalid input
+    with pytest.raises(ValueError):
+        _ = o3.SphericalHarmonics(
+            irreps_in="1e + 3o",  # invalid
+            irreps_out="1x0e + 4x1e + 3x2e",
+            normalize=True
+        )
+
+
 def test_zeros():
     assert torch.allclose(o3.spherical_harmonics([0, 1], torch.zeros(1, 3), False, normalization='norm'), torch.tensor([[1, 0, 0, 0.0]]))
 

--- a/tests/o3/cartesian_spherical_harmonics_test.py
+++ b/tests/o3/cartesian_spherical_harmonics_test.py
@@ -3,7 +3,7 @@ import math
 import pytest
 import torch
 from e3nn import o3
-from e3nn.util.test import assert_auto_jitable
+from e3nn.util.test import assert_auto_jitable, assert_equivariant
 
 
 def test_weird_call():
@@ -128,3 +128,4 @@ def test_module():
         sp_jit(xyz),
         o3.spherical_harmonics(l, xyz, normalize, normalization)
     )
+    assert_equivariant(sp)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Bureaucratic fixes for running on GPU:

- make `normalize2mom` respect current device
- make `Gate` keeps its activations as submodules so they `.to` with it
- add `_get_device`
- Make `spherical_harmonics` a wrapper for `SphericalHarmonics` 
- make `SphericalHarmonics` scriptable so that it doesn't trace and pick up tensors on the wrong device

## How Has This Been Tested?
e3nn test suite, our code's tests (which were failing before on GPU)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).