### PR TITLE
Fix typo (there are three conditions instead of two).

### DIFF
--- a/e3nn/nn/gate.py
+++ b/e3nn/nn/gate.py
@@ -137,7 +137,7 @@ class Gate(torch.nn.Module):
     ``act_scalars``, and :math:`g_j`, :math:`\phi_j`, and :math:`y_j` are
     from ``irreps_gates``, ``act_gates``, and ``irreps_gated``.
 
-    The parameters passed in should adhere to two conditions:
+    The parameters passed in should adhere to the following conditions:
 
     1. ``len(irreps_scalars) == len(act_scalars)``.
     2. ``len(irreps_gates) == len(act_gates)``.


### PR DESCRIPTION
Fixes a typo from #227.