### PR TITLE
Create global flake8 configuration.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,8 @@ jobs:
         pip install flake8
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82,E251,F811,E302,E261,E231,F401,F841,W293,W291,W605,W292,W391,E128,E305,W503,W504,E303,E125,E121,E123,E203,F541,E713 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 e3nn --count --exit-zero --statistics --ignore=E741,E743,E501,C901
+        # Stop the build if there are style issues, Python syntax errors, or undefined names
+        flake8 . --count --show-source --statistics
     - name: Install dependencies
       env:
         TORCH: "1.8.0"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JITable `o3.SphericalHarmonics` module version of `o3.spherical_harmonics`
 - `in_place` option for `e3nn.util.jit` compilation functions
 - New `@compile_mode("unsupported")` for modules that do not support TorchScript
+- flake8 settings have been added to `setup.cfg` for improved code style
 
 ### Changed
 - `o3.TensorProduct` now uses `torch.fx` to generate it's code

--- a/e3nn/nn/models/gate_points_2101.py
+++ b/e3nn/nn/models/gate_points_2101.py
@@ -50,16 +50,16 @@ class Convolution(torch.nn.Module):
         typical number of nodes convolved over
     """
     def __init__(
-            self,
-            irreps_in,
-            irreps_node_attr,
-            irreps_edge_attr,
-            irreps_out,
-            number_of_basis,
-            radial_layers,
-            radial_neurons,
-            num_neighbors
-                ) -> None:
+        self,
+        irreps_in,
+        irreps_node_attr,
+        irreps_edge_attr,
+        irreps_out,
+        number_of_basis,
+        radial_layers,
+        radial_neurons,
+        num_neighbors
+    ) -> None:
         super().__init__()
         self.irreps_in = o3.Irreps(irreps_in)
         self.irreps_node_attr = o3.Irreps(irreps_node_attr)
@@ -200,21 +200,21 @@ class Network(torch.nn.Module):
         typical number of nodes in a graph
     """
     def __init__(
-            self,
-            irreps_in,
-            irreps_hidden,
-            irreps_out,
-            irreps_node_attr,
-            irreps_edge_attr,
-            layers,
-            max_radius,
-            number_of_basis,
-            radial_layers,
-            radial_neurons,
-            num_neighbors,
-            num_nodes,
-            reduce_output=True,
-                ) -> None:
+        self,
+        irreps_in,
+        irreps_hidden,
+        irreps_out,
+        irreps_node_attr,
+        irreps_edge_attr,
+        layers,
+        max_radius,
+        number_of_basis,
+        radial_layers,
+        radial_neurons,
+        num_neighbors,
+        num_nodes,
+        reduce_output=True,
+    ) -> None:
         super().__init__()
         self.max_radius = max_radius
         self.number_of_basis = number_of_basis

--- a/e3nn/nn/models/gate_points_2102.py
+++ b/e3nn/nn/models/gate_points_2102.py
@@ -50,16 +50,16 @@ class Convolution(torch.nn.Module):
         typical number of nodes convolved over
     """
     def __init__(
-            self,
-            irreps_in,
-            irreps_node_attr,
-            irreps_edge_attr,
-            irreps_out,
-            number_of_edge_features,
-            radial_layers,
-            radial_neurons,
-            num_neighbors
-                ) -> None:
+        self,
+        irreps_in,
+        irreps_node_attr,
+        irreps_edge_attr,
+        irreps_out,
+        number_of_edge_features,
+        radial_layers,
+        radial_neurons,
+        num_neighbors
+    ) -> None:
         super().__init__()
         self.irreps_in = o3.Irreps(irreps_in)
         self.irreps_node_attr = o3.Irreps(irreps_node_attr)
@@ -203,21 +203,21 @@ class Network(torch.nn.Module):
         typical number of nodes in a graph
     """
     def __init__(
-            self,
-            irreps_in,
-            irreps_hidden,
-            irreps_out,
-            irreps_node_attr,
-            irreps_edge_attr,
-            layers,
-            max_radius,
-            number_of_basis,
-            radial_layers,
-            radial_neurons,
-            num_neighbors,
-            num_nodes,
-            reduce_output=True,
-                ) -> None:
+        self,
+        irreps_in,
+        irreps_hidden,
+        irreps_out,
+        irreps_node_attr,
+        irreps_edge_attr,
+        layers,
+        max_radius,
+        number_of_basis,
+        radial_layers,
+        radial_neurons,
+        num_neighbors,
+        num_nodes,
+        reduce_output=True,
+    ) -> None:
         super().__init__()
         self.max_radius = max_radius
         self.number_of_basis = number_of_basis

--- a/e3nn/nn/models/v2103/conv_points_in_out.py
+++ b/e3nn/nn/models/v2103/conv_points_in_out.py
@@ -45,17 +45,17 @@ class Convolution(torch.nn.Module):
         typical number of nodes convolved over
     """
     def __init__(
-            self,
-            irreps_node_input,
-            irreps_node_output,
-            irreps_node_attr_input,
-            irreps_node_attr_output,
-            irreps_edge_attr,
-            num_edge_scalar_attr,
-            radial_layers,
-            radial_neurons,
-            num_neighbors
-                ) -> None:
+        self,
+        irreps_node_input,
+        irreps_node_output,
+        irreps_node_attr_input,
+        irreps_node_attr_output,
+        irreps_edge_attr,
+        num_edge_scalar_attr,
+        radial_layers,
+        radial_neurons,
+        num_neighbors
+    ) -> None:
         super().__init__()
         self.irreps_node_input = o3.Irreps(irreps_node_input)
         self.irreps_node_attr_input = o3.Irreps(irreps_node_attr_input)

--- a/e3nn/nn/models/v2103/gate_points_message_passing.py
+++ b/e3nn/nn/models/v2103/gate_points_message_passing.py
@@ -59,16 +59,16 @@ class MessagePassing(torch.nn.Module):
         first layer and hidden layers but not the output layer
     """
     def __init__(
-            self,
-            irreps_node_input,
-            irreps_node_hidden,
-            irreps_node_output,
-            irreps_node_attr,
-            irreps_edge_attr,
-            layers,
-            fc_neurons,
-            num_neighbors,
-                ) -> None:
+        self,
+        irreps_node_input,
+        irreps_node_hidden,
+        irreps_node_output,
+        irreps_node_attr,
+        irreps_edge_attr,
+        layers,
+        fc_neurons,
+        num_neighbors,
+    ) -> None:
         super().__init__()
         self.num_neighbors = num_neighbors
 

--- a/e3nn/nn/models/v2103/gate_points_networks.py
+++ b/e3nn/nn/models/v2103/gate_points_networks.py
@@ -16,16 +16,16 @@ from .gate_points_message_passing import MessagePassing
 
 class SimpleNetwork(torch.nn.Module):
     def __init__(
-            self,
-            irreps_in,
-            irreps_out,
-            max_radius,
-            num_neighbors,
-            num_nodes,
-            mul=50,
-            layers=3,
-            lmax=2,
-                ) -> None:
+        self,
+        irreps_in,
+        irreps_out,
+        max_radius,
+        num_neighbors,
+        num_nodes,
+        mul=50,
+        layers=3,
+        lmax=2,
+    ) -> None:
         super().__init__()
 
         self.lmax = lmax
@@ -89,18 +89,18 @@ class SimpleNetwork(torch.nn.Module):
 
 class NetworkForAGraphWithAttributes(torch.nn.Module):
     def __init__(
-            self,
-            irreps_node_input,
-            irreps_node_attr,
-            irreps_edge_attr,
-            irreps_node_output,
-            max_radius,
-            num_neighbors,
-            num_nodes,
-            mul=50,
-            layers=3,
-            lmax=2,
-                ) -> None:
+        self,
+        irreps_node_input,
+        irreps_node_attr,
+        irreps_edge_attr,
+        irreps_node_output,
+        max_radius,
+        num_neighbors,
+        num_nodes,
+        mul=50,
+        layers=3,
+        lmax=2,
+    ) -> None:
         super().__init__()
 
         self.lmax = lmax

--- a/e3nn/nn/models/v2103/points_convolution.py
+++ b/e3nn/nn/models/v2103/points_convolution.py
@@ -32,14 +32,14 @@ class Convolution(torch.nn.Module):
         typical number of nodes convolved over
     """
     def __init__(
-            self,
-            irreps_node_input,
-            irreps_node_attr,
-            irreps_edge_attr,
-            irreps_node_output,
-            fc_neurons,
-            num_neighbors
-                ) -> None:
+        self,
+        irreps_node_input,
+        irreps_node_attr,
+        irreps_edge_attr,
+        irreps_node_output,
+        fc_neurons,
+        num_neighbors
+    ) -> None:
         super().__init__()
         self.irreps_node_input = o3.Irreps(irreps_node_input)
         self.irreps_node_attr = o3.Irreps(irreps_node_attr)

--- a/e3nn/o3/cartesian_spherical_harmonics.py
+++ b/e3nn/o3/cartesian_spherical_harmonics.py
@@ -488,11 +488,13 @@ def _generate_spherical_harmonics(lmax, device=None):  # pragma: no cover
             )
             for cij in o3.wigner_3j(l+1, 1, l, device=device)
         ]
+
         def sub(p, names, polynormz):
             p = p.subs(x, 0).subs(y, 0).subs(z, 1)
             for n, c in zip(names, polynormz):
                 p = p.subs(n, c)
             return p
+
         polynormz = [
             sub(p, names, polynormz)
             for p in polynomials

--- a/e3nn/o3/irreps.py
+++ b/e3nn/o3/irreps.py
@@ -65,7 +65,7 @@ class Irrep(tuple):
                     'o': -1,
                     'y': (-1)**l,
                 }[name[-1]]
-            except:
+            except Exception:
                 raise ValueError(f"unable to convert string \"{name}\" into an Irrep")
 
         if isinstance(l, tuple) and p is None:
@@ -327,7 +327,7 @@ class Irreps(tuple):
 
                     assert isinstance(mul, int) and mul >= 0
                     out.append(_MulIr(mul, ir))
-            except:
+            except Exception:
                 raise ValueError(f"unable to convert string \"{irreps}\" into an Irreps")
         else:
             for mul_ir in irreps:

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -21,11 +21,13 @@ def compile_mode(mode: str):
     """
     if mode not in _VALID_MODES:
         raise ValueError("Invalid compile mode")
+
     def decorator(obj):
         if not (inspect.isclass(obj) and issubclass(obj, torch.nn.Module)):
             raise TypeError("@e3nn.util.jit.compile_mode can only decorate classes derived from torch.nn.Module")
         setattr(obj, _E3NN_COMPILE_MODE, mode)
         return obj
+
     return decorator
 
 
@@ -120,7 +122,7 @@ def compile(
 def get_tracing_inputs(
     mod: torch.nn.Module,
     n: int = 1,
-    device: Optional[torch.device] =  None
+    device: Optional[torch.device] = None
 ):
     """Get random tracing inputs for ``mod``.
 

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -22,6 +22,7 @@ try:
     # If pytest is available, define an e3nn pytest plugin
     # See https://docs.pytest.org/en/stable/fixture.html#using-fixtures-from-other-projects
     import pytest
+
     @pytest.fixture(scope='session', autouse=True, params=['float32', 'float64'])
     def float_tolerance(request):
         """Run all tests with various PyTorch default dtypes.
@@ -93,8 +94,8 @@ def assert_equivariant(
 
     if len(problems) != 0:
         errstr = (
-            "Largest componentwise equivariance error was too large for: " + \
-            '; '.join("(parity_k={:d}, did_translate={}) -> error={:.3e}".format(int(k[0]), bool(k[1]), float(v)) for k, v in problems.items())
+            "Largest componentwise equivariance error was too large for: "
+            "; ".join("(parity_k={:d}, did_translate={}) -> error={:.3e}".format(int(k[0]), bool(k[1]), float(v)) for k, v in problems.items())
         )
         assert len(problems) == 0, errstr
 

--- a/examples/tensor_product_benchmark.py
+++ b/examples/tensor_product_benchmark.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-logging.basicConfig(level=logging.DEBUG)
 
 import torch
 from torch.utils.benchmark import Timer
@@ -9,15 +8,18 @@ from e3nn.o3 import Irreps, FullyConnectedTensorProduct
 from e3nn.util.jit import compile
 
 
+logging.basicConfig(level=logging.DEBUG)
+
+
 # https://stackoverflow.com/a/15008806/1008938
 def t_or_f(arg):
     ua = str(arg).upper()
     if 'TRUE'.startswith(ua):
-       return True
+        return True
     elif 'FALSE'.startswith(ua):
-       return False
+        return False
     else:
-       raise ValueError(str(arg))
+        raise ValueError(str(arg))
 
 
 def main():

--- a/examples/tensor_product_profile.py
+++ b/examples/tensor_product_profile.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-logging.basicConfig(level=logging.DEBUG)
 
 import torch
 
@@ -8,15 +7,18 @@ from e3nn.o3 import Irreps, FullyConnectedTensorProduct
 from e3nn.util.jit import compile
 
 
+logging.basicConfig(level=logging.DEBUG)
+
+
 # https://stackoverflow.com/a/15008806/1008938
 def t_or_f(arg):
     ua = str(arg).upper()
     if 'TRUE'.startswith(ua):
-       return True
+        return True
     elif 'FALSE'.startswith(ua):
-       return False
+        return False
     else:
-       raise ValueError(str(arg))
+        raise ValueError(str(arg))
 
 
 def main():
@@ -72,6 +74,7 @@ def main():
     print("starting...")
 
     called_num = [0]
+
     def trace_handler(p):
         print(p.key_averages().table(sort_by="self_cuda_time_total", row_limit=-1))
         p.export_chrome_trace("test_trace_" + str(called_num[0]) + ".json")

--- a/examples/tetris_gate.py
+++ b/examples/tetris_gate.py
@@ -172,6 +172,7 @@ def profile():
     optim = torch.optim.Adam(f.parameters(), lr=1e-2)
 
     called_num = [0]
+
     def trace_handler(p):
         print(p.key_averages().table(sort_by="self_cuda_time_total", row_limit=-1))
         p.export_chrome_trace("test_trace_" + str(called_num[0]) + ".json")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 127
+select = E,F,W,C
+ignore = E226,E501,E741,E743,C901
+exclude = .eggs,*.egg,build,dist,docs/_build
+per-file-ignores =
+    e3nn/o3/cartesian_spherical_harmonics.py: E226

--- a/tests/math/linalg_test.py
+++ b/tests/math/linalg_test.py
@@ -7,8 +7,10 @@ from e3nn import o3
 def test_intertwiners():
     G = SO3()
     A = torch.randn(9, 9)
+
     def rep(q):
         return A @ G.rep(4)(q) @ A.T
+
     B = intertwiners(G, G.rep(4), rep, dtype=torch.get_default_dtype())
     assert torch.allclose(A, B)
 

--- a/tests/nn/models/gate_points_2101_test.py
+++ b/tests/nn/models/gate_points_2101_test.py
@@ -58,6 +58,7 @@ def test_convolution_jit(network):
 
 def test_gate_points_2101_equivariant(network):
     f, random_graph = network
+
     # -- Test equivariance: --
     def wrapper(pos, x, z):
         data = Data(pos=pos, x=x, z=z, batch=torch.zeros(pos.shape[0], dtype=torch.long))

--- a/tests/nn/models/gate_points_2102_test.py
+++ b/tests/nn/models/gate_points_2102_test.py
@@ -57,6 +57,7 @@ def test_convolution_jit(network):
 
 def test_gate_points_2102_equivariant(network):
     f, random_graph = network
+
     # -- Test equivariance: --
     def wrapper(pos, x, z):
         data = Data(pos=pos, x=x, z=z, batch=torch.zeros(pos.shape[0], dtype=torch.long))

--- a/tests/util/test_jit.py
+++ b/tests/util/test_jit.py
@@ -79,7 +79,7 @@ def test_compilation():
 
     class Supermod(torch.nn.Module):
         def forward(self, x):
-            return x* 2.
+            return x * 2.
 
     @compile_mode('trace')
     class ChildMod(Supermod):


### PR DESCRIPTION
## Description
While working on #227, I noticed that the flake8 configuration used by CI is not stored in the typical place for package/tool configurations (either `setup.cfg` or `.flake8`; [flake8 does not support `pyproject.toml`](https://gitlab.com/pycqa/flake8/-/issues/428)).
I talked with @mariogeiger and we decided to create a package-wide configuration for flake8 that developers can use locally, without needing to copy all the settings from the CI config.
This means that users/developers can simply run `flake8` in the repository root, to check for style issues.

While doing this, I also simplified the flake8 rules from the CI configuration and fixed the small number of issues that appeared. Nothing major has changed -- just normalized style.

## Motivation and Context
One note for context: I have found from working with other packages that it's good to specify a settings like `select = E,F,W,C` for whatever top-level categories of errors that should be checked.
If this is left at the default setting, then users who have flake8 plugins installed will see errors from those plugins even if the code style is compliant for plain flake8 without those plugins installed.
For example, my output of `flake8 --help` shows my plugins:

```
Installed plugins: flake8-bugbear: 20.1.4, mccabe: 0.6.1, naming: 0.11.1, pycodestyle: 2.7.0, pyflakes: 2.3.0, rst-docstrings: 0.0.14
```

Without the setting for `select = E,F,W,C`, I get tons of errors like `N806` from the `naming` plugin, `RST303` errors for unknown directives from `rst-docstrings`, etc., so it's better to just select the basic error classes and ignore user plugins.

## How Has This Been Tested?
I ran flake8 locally until the number of included/ignored rules had been reduced to a reasonably minimal set. :)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
