### PR TITLE
Use x, y instead of x1, x2 to match the math.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `normalize2mom` is now a `torch.nn.Module`
 - rename arguments `set_ir_...` into `filter_ir_...`
 - Renamed `e3nn.nn.Gate` argument `irreps_nonscalars` to `irreps_gated`
+- Renamed `e3nn.o3.TensorProduct` arguments `x1, x2` to `x, y`
 
 ### Fixed
 - `nn.Gate` was crashing when the number of scalars or gates was zero

--- a/e3nn/o3/tensor_product/tensor_product.py
+++ b/e3nn/o3/tensor_product/tensor_product.py
@@ -341,14 +341,14 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
             return weight
 
     @torch.jit.export
-    def right(self, x2, weight: Optional[torch.Tensor] = None):
+    def right(self, y, weight: Optional[torch.Tensor] = None):
         r"""evaluate partially :math:`w x \cdot \otimes y`
 
         It returns an operator in the form of a matrix.
 
         Parameters
         ----------
-        x2 : `torch.Tensor`
+        y : `torch.Tensor`
             tensor of shape ``(..., irreps_in2.dim)``
 
         weight : `torch.Tensor` or list of `torch.Tensor`, optional
@@ -363,21 +363,21 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         `torch.Tensor`
             tensor of shape ``(..., irreps_in1.dim, irreps_out.dim)``
         """
-        assert x2.shape[-1] == self._in2_dim, "Incorrect last dimension for x2"
+        assert y.shape[-1] == self._in2_dim, "Incorrect last dimension for y"
 
         with torch.autograd.profiler.record_function(self._profiling_str):
             real_weight = self._get_weights(weight)
-            return self._compiled_main_right(x2, real_weight, self._wigner_buf)
+            return self._compiled_main_right(y, real_weight, self._wigner_buf)
 
-    def forward(self, x1, x2, weight: Optional[torch.Tensor] = None):
+    def forward(self, x, y, weight: Optional[torch.Tensor] = None):
         r"""evaluate :math:`w x \otimes y`
 
         Parameters
         ----------
-        x1 : `torch.Tensor`
+        x : `torch.Tensor`
             tensor of shape ``(..., irreps_in1.dim)``
 
-        x2 : `torch.Tensor`
+        y : `torch.Tensor`
             tensor of shape ``(..., irreps_in2.dim)``
 
         weight : `torch.Tensor` or list of `torch.Tensor`, optional
@@ -392,12 +392,12 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         `torch.Tensor`
             tensor of shape ``(..., irreps_out.dim)``
         """
-        assert x1.shape[-1] == self._in1_dim, "Incorrect last dimension for x1"
-        assert x2.shape[-1] == self._in2_dim, "Incorrect last dimension for x2"
+        assert x.shape[-1] == self._in1_dim, "Incorrect last dimension for x"
+        assert y.shape[-1] == self._in2_dim, "Incorrect last dimension for y"
 
         with torch.autograd.profiler.record_function(self._profiling_str):
             real_weight = self._get_weights(weight)
-            return self._compiled_main_out(x1, x2, real_weight, self._wigner_buf)
+            return self._compiled_main_out(x, y, real_weight, self._wigner_buf)
 
     def visualize(self):  # pragma: no cover
         import numpy as np


### PR DESCRIPTION
## Description
Matches argument names for tensor products with the equations below them. I chose to match the code to the equations instead of the other way around because there were more equations than lines of code, but the other way would also be viable if that is preferred.

(Please feel free to reject this PR if you don't think it's an improvement!)

## Motivation and Context
Improves consistency in terminology.

## How Has This Been Tested?
Tests passed locally.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
