### PR TITLE
Add Bessel Basis

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `in_place` option for `e3nn.util.jit` compilation functions
 - New `@compile_mode("unsupported")` for modules that do not support TorchScript
 - flake8 settings have been added to `setup.cfg` for improved code style
+- `basis='bessel'` option to `math.soft_one_hot_linspace`
 
 ### Changed
 - `o3.TensorProduct` now uses `torch.fx` to generate it's code

--- a/e3nn/math/soft_one_hot.py
+++ b/e3nn/math/soft_one_hot.py
@@ -37,7 +37,7 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
         number of basis functions :math:`N`
 
     basis : {'gaussian', 'cosine', 'fourier', 'bessel', 'smooth_finite'}
-        choice of basis family
+        choice of basis family; note that due to the 1/x term, 'bessel' basis does not satisfy the normalization of other basis choices
 
     endpoint : bool
         if ``endpoint=False`` then for all :math:`x` outside of the interval defined by ``(start, end)``, :math:`\forall i, \; f_i(x) \approx 0`

--- a/e3nn/math/soft_one_hot.py
+++ b/e3nn/math/soft_one_hot.py
@@ -127,14 +127,12 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
             return torch.sin(math.pi * i * x) / math.sqrt(0.25 + number / 2) * (0 < x) * (x < 1)
 
     if basis == 'bessel':
-        x = x[..., None]
-        x_ = x - start
+        x = x[..., None] - start
         c = (end - start)
-        bessel_roots = torch.arange(1, number+1, dtype=x.dtype, device=x.device) * math.pi
-        out =  math.sqrt(2 / c) * torch.sin(bessel_roots * x_ / c) / x_
+        bessel_roots = torch.arange(1, number + 1, dtype=x.dtype, device=x.device) * math.pi
+        out =  math.sqrt(2 / c) * torch.sin(bessel_roots * x / c) / x
 
         if endpoint:
             return out
-
         else:
-            return out * ((x_ / c) < 1)
+            return out * ((x / c) < 1)

--- a/e3nn/math/soft_one_hot.py
+++ b/e3nn/math/soft_one_hot.py
@@ -21,6 +21,7 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
         \sum_{i=1}^N y_i^2 \approx 1
 
     See the last plot below.
+    Note that ``bessel`` basis cannot be normalized.
 
     Parameters
     ----------
@@ -37,7 +38,7 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
         number of basis functions :math:`N`
 
     basis : {'gaussian', 'cosine', 'fourier', 'bessel', 'smooth_finite'}
-        choice of basis family; note that due to the 1/x term, 'bessel' basis does not satisfy the normalization of other basis choices
+        choice of basis family; note that due to the :math:`1/x` term, ``bessel`` basis does not satisfy the normalization of other basis choices
 
     endpoint : bool
         if ``endpoint=False`` then for all :math:`x` outside of the interval defined by ``(start, end)``, :math:`\forall i, \; f_i(x) \approx 0`
@@ -128,9 +129,9 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
 
     if basis == 'bessel':
         x = x[..., None] - start
-        c = (end - start)
+        c = end - start
         bessel_roots = torch.arange(1, number + 1, dtype=x.dtype, device=x.device) * math.pi
-        out =  math.sqrt(2 / c) * torch.sin(bessel_roots * x / c) / x
+        out = math.sqrt(2 / c) * torch.sin(bessel_roots * x / c) / x
 
         if endpoint:
             return out

--- a/e3nn/math/soft_one_hot.py
+++ b/e3nn/math/soft_one_hot.py
@@ -36,7 +36,7 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
     number : int
         number of basis functions :math:`N`
 
-    basis : {'gaussian', 'cosine', 'fourier', 'smooth_finite'}
+    basis : {'gaussian', 'cosine', 'fourier', 'bessel', 'smooth_finite'}
         choice of basis family
 
     endpoint : bool
@@ -84,6 +84,14 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
 
     .. jupyter-execute::
 
+        plt.plot(x, soft_one_hot_linspace(x, -0.5, 1.5, 3, 'bessel', endpoint=False));
+
+    .. jupyter-execute::
+
+        plt.plot(x, soft_one_hot_linspace(x, -0.5, 1.5, 3, 'bessel', endpoint=True));
+
+    .. jupyter-execute::
+
         for basis in ['gaussian', 'cosine', 'fourier', 'smooth_finite']:
             for endpoint in [False, True]:
                 y = soft_one_hot_linspace(x, -0.5, 1.5, 4, basis, endpoint)
@@ -117,3 +125,16 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
         else:
             i = torch.arange(1, number + 1, dtype=x.dtype, device=x.device)
             return torch.sin(math.pi * i * x) / math.sqrt(0.25 + number / 2) * (0 < x) * (x < 1)
+
+    if basis == 'bessel':
+        x = x[..., None]
+        x_ = x - start
+        c = (end - start)
+        bessel_roots = torch.arange(1, number+1, dtype=x.dtype, device=x.device) * math.pi
+        out =  math.sqrt(2 / c) * torch.sin(bessel_roots * x_ / c) / x_
+
+        if endpoint:
+            return out
+
+        else:
+            return out * ((x_ / c) < 1)

--- a/e3nn/math/soft_one_hot.py
+++ b/e3nn/math/soft_one_hot.py
@@ -135,4 +135,4 @@ def soft_one_hot_linspace(x, start, end, number, basis='gaussian', endpoint=True
         if endpoint:
             return out
         else:
-            return out * ((x / c) < 1)
+            return out * ((x / c) < 1) * (0 < x)

--- a/tests/math/soft_one_hot_test.py
+++ b/tests/math/soft_one_hot_test.py
@@ -4,7 +4,7 @@ import torch
 from e3nn.math import soft_one_hot_linspace
 
 
-@pytest.mark.parametrize('basis', ['gaussian', 'cosine', 'fourier'])
+@pytest.mark.parametrize('basis', ['gaussian', 'cosine', 'fourier', 'bessel'])
 def test_zero_out(basis):
     x1 = torch.linspace(-2.0, -1.1, 20)
     x2 = torch.linspace(2.1, 3.0, 20)


### PR DESCRIPTION
Add Bessel Basis to ```math.soft_one_hot_linspace```

## Description

Added ```bessel``` as an option for basis in ```math.soft_one_hot_linspace```, as proposed in [1]. Note that due to the 1/x behavior of Bessel it cannot be properly normalized. I added this to the docstring. The is some ambiguity whether or not to let the denominator in the basis be ```1/x``` or ```1/(x/c``` where ```c=end-start``` is the length of the interval the basis is computed over. Following [1] I went with the former. 

[1] https://arxiv.org/abs/2003.03123

## Motivation and Context

Bessel Basis performs well in practice. 

## How Has This Been Tested?

I ran pytest tests and add the Bessel basis to the soft_one_hot_tests

## Screenshots

<img width="1023" alt="Screen Shot 2021-03-21 at 13 07 43" src="https://user-images.githubusercontent.com/24858197/111915896-75956180-8a46-11eb-99d5-7de5d2c55ce5.png">

<img width="1039" alt="Screen Shot 2021-03-21 at 13 07 45" src="https://user-images.githubusercontent.com/24858197/111915895-73cb9e00-8a46-11eb-9aca-8aa8830c8c18.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [ x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [x ] I have updated the documentation (if relevant).
- [ x] I have added tests that cover my changes (if relevant).
- [x ] All new and existing tests passed.
- [x ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).