### PR TITLE
Ignore *.so (cuda libraries built in-place).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _build
 build
 dist
 .ipynb_checkpoints
+*.so


### PR DESCRIPTION
## Description
Tiny change to `.gitignore` that will make my life as a developer easier.

This ignores `*.so` so that CUDA libraries built in-place are ignored by git.

## Motivation and Context
Small quality of life enhancement.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
