### PR TITLE
Irreps improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Most recent change on the bottom.
 ### Added
 - Added `e3nn.set_optimization_defaults()` and `e3nn.get_optimization_defaults()`
 - Constructors for empty `Irreps`: `Irreps()` and `Irreps("")`
+- Additional tests, docs, and refactoring for `Irrep` and `Irreps`.
 
 ### Changed
 - Renamed `o3.spherical_harmonics` arguement `xyz` into `x`

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -75,7 +75,7 @@ class Irrep(tuple):
 
     @property
     def l(self) -> int:
-        r"""The dimension of the representation, :math:`l = 0, 1, \dots`."""
+        r"""The degree of the representation, :math:`l = 0, 1, \dots`."""
         return self[0]
 
     @property

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -83,10 +83,6 @@ class Irrep(tuple):
         r"""The parity of the representation, :math:`p = \pm 1`."""
         return self[1]
 
-    def __iter__(self):
-        yield self.l
-        yield self.p
-
     def __repr__(self):
         p = {+1: 'e', -1: 'o'}[self.p]
         return f"{self.l}{p}"

--- a/tests/o3/irreps_test.py
+++ b/tests/o3/irreps_test.py
@@ -20,6 +20,14 @@ def test_creation():
     o3.Irreps([(16, "3e"), '1e', (256, (1, -1))])
 
 
+def test_empty_irreps():
+    assert o3.Irreps() == o3.Irreps("") == o3.Irreps([])
+    assert len(o3.Irreps()) == 0
+    assert o3.Irreps().dim == 0
+    assert o3.Irreps().ls == []
+    assert o3.Irreps().num_irreps == 0
+
+
 def test_slice():
     irreps = o3.Irreps("16x1e + 3e + 2e + 5o")
     assert isinstance(irreps[2:], o3.Irreps)

--- a/tests/o3/irreps_test.py
+++ b/tests/o3/irreps_test.py
@@ -20,6 +20,44 @@ def test_creation():
     o3.Irreps([(16, "3e"), '1e', (256, (1, -1))])
 
 
+def test_properties():
+    irrep = o3.Irrep("3e")
+    assert irrep.l == 3
+    assert irrep.p == 1
+    assert irrep.dim == 7
+
+    assert o3.Irrep(repr(irrep)) == irrep
+
+    l, p = o3.Irrep("5o")
+    assert l == 5
+    assert p == -1
+
+    iterator = o3.Irrep.iterator(5)
+    assert len(list(iterator)) == 12
+
+    iterator = o3.Irrep.iterator()
+    for x in range(100):
+        irrep = next(iterator)
+        assert irrep.l == x//2
+        assert irrep.p in (-1, 1)
+        assert irrep.dim == 2 * (x // 2) + 1
+
+    irreps = o3.Irreps("4x1e + 6x2e + 12x2o")
+    assert o3.Irreps(repr(irreps)) == irreps
+
+def test_arithmetic():
+    assert 3 * o3.Irrep("6o") == o3.Irreps("3x6o")
+    products = list(o3.Irrep("1o") * o3.Irrep("2e"))
+    assert products == [o3.Irrep("1o"), o3.Irrep("2o"), o3.Irrep("3o")]
+
+    assert o3.Irrep("4o") + o3.Irrep("7e") == o3.Irreps("4o + 7e")
+
+    assert 2 * o3.Irreps("2x2e + 4x1o") == o3.Irreps("2x2e + 4x1o + 2x2e + 4x1o")
+    assert o3.Irreps("2x2e + 4x1o") * 2 == o3.Irreps("2x2e + 4x1o + 2x2e + 4x1o")
+
+    assert o3.Irreps("1o + 4o") + o3.Irreps("1o + 7e") == o3.Irreps("1o + 4o + 1o + 7e")
+
+
 def test_empty_irreps():
     assert o3.Irreps() == o3.Irreps("") == o3.Irreps([])
     assert len(o3.Irreps()) == 0
@@ -28,14 +66,22 @@ def test_empty_irreps():
     assert o3.Irreps().num_irreps == 0
 
 
-def test_slice():
+def test_getitem():
     irreps = o3.Irreps("16x1e + 3e + 2e + 5o")
-    assert isinstance(irreps[2:], o3.Irreps)
+    assert irreps[0] == (16, o3.Irrep("1e"))
+    assert irreps[3] == (1, o3.Irrep("5o"))
+    assert irreps[-1] == (1, o3.Irrep("5o"))
+
+    sliced = irreps[2:]
+    assert isinstance(sliced, o3.Irreps)
+    assert sliced == o3.Irreps("2e + 5o")
 
 
 def test_cat():
-    irreps = o3.Irreps("4x1e + 6x2e + 12x2o") + o3.Irreps("1x1e + 2x2e + 12x2o")
+    irreps = o3.Irreps("4x1e + 6x2e + 12x2o") + o3.Irreps("1x1e + 2x2e + 12x4o")
     assert len(irreps) == 6
+    assert irreps.ls == [1] * 4 + [2] * 6 + [2] * 12 + [1] * 1 + [2] * 2 + [4] * 12
+    assert irreps.lmax == 4
     assert irreps.num_irreps == 4 + 6 + 12 + 1 + 2 + 12
 
 

--- a/tests/o3/irreps_test.py
+++ b/tests/o3/irreps_test.py
@@ -45,6 +45,7 @@ def test_properties():
     irreps = o3.Irreps("4x1e + 6x2e + 12x2o")
     assert o3.Irreps(repr(irreps)) == irreps
 
+
 def test_arithmetic():
     assert 3 * o3.Irrep("6o") == o3.Irreps("3x6o")
     products = list(o3.Irrep("1o") * o3.Irrep("2e"))


### PR DESCRIPTION
## Description
- Minor improvements to Irrep/Irreps docs and implementation.
- Add test for empty Irreps.

This started as an attempt to change `Irrep` / `Irreps` so that they weren't subclassed from `tuple`, but that failed because of issues with TorchScript. These classes are too complex to be written as TorchScript-compatible classes, so instead I pivoted to making some minor improvements to the class's docs, implementation, and testing.

## Motivation and Context
Additional context in PR comments.

## How Has This Been Tested?
Existing tests pass, new tests added.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
