### PR TITLE
Weight view methods in `TensorProduct`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ Most recent change on the bottom.
 - Added `e3nn.set_optimization_defaults()` and `e3nn.get_optimization_defaults()`
 - Constructors for empty `Irreps`: `Irreps()` and `Irreps("")`
 - Additional tests, docs, and refactoring for `Irrep` and `Irreps`.
+- Added `TensorProduct.weight_views()` and `TensorProduct.weight_view_for_instruction()`
 
 ### Changed
 - Renamed `o3.spherical_harmonics` arguement `xyz` into `x`

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -454,7 +454,7 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         offset = sum(prod(ins.path_shape) for ins in self.instructions[:instruction])
         ins = self.instructions[instruction]
         weight = self._get_weights(weight)
-        return weight[offset:offset + prod(ins.path_shape)].reshape(ins.path_shape)
+        return weight[offset:offset + prod(ins.path_shape)].view(ins.path_shape)
 
     def weight_views(
         self,
@@ -481,7 +481,7 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         for ins_i, ins in enumerate(self.instructions):
             if ins.has_weight:
                 flatsize = prod(ins.path_shape)
-                this_weight = weight[offset:offset + flatsize].reshape(ins.path_shape)
+                this_weight = weight[offset:offset + flatsize].view(ins.path_shape)
                 offset += flatsize
                 if yield_instruction:
                     yield ins_i, ins, this_weight

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -151,6 +151,7 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
     ...         new_weight = torch.empty_like(weight)
     ...         new_weight.uniform_(-a, a)
     ...         weight[:] = new_weight
+    tensor(...)
     >>> n = 1_000
     >>> vars = module(irreps_1.randn(n, -1), irreps_2.randn(n, -1)).var(0)
     >>> assert vars.min() > 1 / 3

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -143,16 +143,14 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
     ...         if ir_out in ir_1 * ir_2
     ...     ]
     ... )
-    >>> ws = []
-    >>> for ins in module.instructions:
-    ...     if ins.has_weight:
-    ...         weight = torch.empty(ins.path_shape)
+    >>> with torch.no_grad():
+    ...     for weight in module.weight_views():
     ...         mul_1, mul_2, mul_out = weight.shape
     ...         # formula from torch.nn.init.xavier_uniform_
     ...         a = (6 / (mul_1 * mul_2 + mul_out))**0.5
-    ...         ws += [weight.uniform_(-a, a).view(-1)]
-    >>> with torch.no_grad():
-    ...     module.weight[:] = torch.cat(ws)
+    ...         new_weight = torch.empty_like(weight)
+    ...         new_weight.uniform_(-a, a)
+    ...         weight[:] = new_weight
     >>> n = 1_000
     >>> vars = module(irreps_1.randn(n, -1), irreps_2.randn(n, -1)).var(0)
     >>> assert vars.min() > 1 / 3
@@ -436,13 +434,60 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         self,
         instruction: int,
         weight: Optional[torch.Tensor] = None
-    ):
+    ) -> torch.Tensor:
+        r"""View of weights corresponding to ``instruction``.
+
+        Parameters
+        ----------
+        instruction : int
+            The index of the instruction to get a view on the weights for. ``self.instructions[instruction].has_weight`` must be ``True``.
+
+        weight : `torch.Tensor`, optional
+            like ``weight`` argument to ``forward()``
+
+        Returns
+        -------
+        A view on ``weight`` or this object's internal weights for the weights corresponding to the ``instruction``th instruction.
+        """
         if not self.instructions[instruction].has_weight:
             raise ValueError(f"Instruction {instruction} has no weights.")
         offset = sum(prod(ins.path_shape) for ins in self.instructions[:instruction])
         ins = self.instructions[instruction]
         weight = self._get_weights(weight)
         return weight[offset:offset + prod(ins.path_shape)].reshape(ins.path_shape)
+
+    def weight_views(
+        self,
+        weight: Optional[torch.Tensor] = None,
+        yield_instruction: bool = False
+    ):
+        r"""Iterator over weight views for each weighted instruction.
+
+        Parameters
+        ----------
+        weight : `torch.Tensor`, optional
+            like ``weight`` argument to ``forward()``
+
+        yield_instruction : `bool`, default False
+            Whether to also yield the corresponding instruction.
+
+        Yields
+        ------
+        If ``yield_instruction`` is ``True``, yields ``(instruction_index, instruction, weight_view)``.
+        Otherwise, yields ``weight_view``.
+        """
+        weight = self._get_weights(weight)
+        offset = 0
+        for ins_i, ins in enumerate(self.instructions):
+            if ins.has_weight:
+                flatsize = prod(ins.path_shape)
+                this_weight = weight[offset:offset + flatsize].reshape(ins.path_shape)
+                offset += flatsize
+                if yield_instruction:
+                    yield ins_i, ins, this_weight
+                else:
+                    yield this_weight
+        return
 
     def visualize(
         self,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Adds `weight_views` and `weight_view_for_instruction` to `TensorProduct`.

## Motivation and Context
This makes it easier to investigate/initialize the weights of a `TensorProduct` while hiding the specifics of the flattened weight storage from the user, enabling easier future changes if necessary.

## How Has This Been Tested?
e3nn test suite, some new tests

I updated the Xavier initialization doctest to use this and for some reason cannot get it to pass. The same code when run on its own produces no output and no errors.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).