### PR TITLE
Fix ExtractIr docs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Most recent change on the bottom.
 - Constructors for empty `Irreps`: `Irreps()` and `Irreps("")`
 - Additional tests, docs, and refactoring for `Irrep` and `Irreps`.
 - Added `TensorProduct.weight_views()` and `TensorProduct.weight_view_for_instruction()`
+- Fix Docs for ExtractIr
 
 ### Changed
 - Renamed `o3.spherical_harmonics` arguement `xyz` into `x`

--- a/e3nn/nn/_extract.py
+++ b/e3nn/nn/_extract.py
@@ -82,7 +82,7 @@ class ExtractIr(torch.nn.Module):
         irreps_in : `Irreps`
             representation of the input
 
-        ir : list of `Irrep`
+        ir : `Irrep`
             representation to extract
         """
         super().__init__()


### PR DESCRIPTION
Fix docs for ```ExtractIr```

## Description

Docs currently ask for 

```
        ir : list of `Irrep`
            representation to extract
```

but the code convert this to a `Irrep`: 

```
ir = o3.Irrep(ir)
```

So if one actually passes a list of `Irrep` it fails: 

```
>>> from e3nn.nn import ExtractIr
>>> from e3nn import o3
>>> irs = o3.Irreps('0e + 1o')
>>> ir = [o3.Irreps('0e')]
>>> extract_ir = ExtractIr(irreps_in=irs, ir=ir)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/simonbatzner1/Desktop/Research/Research/Research_Code/e3nn/e3nn/nn/_extract.py", line 89, in __init__
    ir = o3.Irrep(ir)
  File "/Users/simonbatzner1/Desktop/Research/Research/Research_Code/e3nn/e3nn/o3/_irreps.py", line 72, in __new__
    assert isinstance(l, int) and l >= 0, l
AssertionError: [1x0e]
```

instead it should just be a `Irrep`: 

```
>>> ir = o3.Irrep('0e')
>>> extract_ir = ExtractIr(irreps_in=irs, ir=ir)
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [ x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [ x] I have updated the documentation (if relevant).
- [ x] I have added tests that cover my changes (if relevant).
- [ x] All new and existing tests passed.
- [ x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).