### PR TITLE
Fix opt_einsum RNG bug

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ Most recent change on the bottom.
 - Variances are now provided to `o3.TensorProduct` through explicit `in1_var`, `in2_var`, `out_var` parameters
 - Submodules define `__all__`; documentation uses shorter module names for the classes/methods.
 
+### Fixed
+ - Enabling/disabling einsum optimization no longer affects PyTorch RNG state.
+
 ### Removed
 - Variances can no longer be provided to `o3.TensorProduct` in the list-of-tuple format for `irreps_in1`, etc.
 

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -349,13 +349,17 @@ def codegen_tensor_product(
             #         \- this is the `memory_limit` option in opt_einsum
             # TODO: allow user to choose opt_einsum parameters?
             #
-            # We use float32 to save memory, since optimize_einsums doesn't look at traced dtypes
+            # We use float32 and zeros to save memory and time, since opt_einsum_fx looks only at traced shapes, not values or dtypes.
             batchdim = 4
             example_inputs = (
-                irreps_in1.randn(batchdim, -1, dtype=torch.float32),
-                irreps_in2.randn(batchdim, -1, dtype=torch.float32),
-                torch.randn(1 if shared_weights else batchdim, flat_weight_index, dtype=torch.float32),
-                torch.randn(sum(w3j_dim(*k) for k in w3j), dtype=torch.float32)
+                torch.zeros((batchdim, irreps_in1.dim), dtype=torch.float32),
+                torch.zeros((batchdim, irreps_in2.dim), dtype=torch.float32),
+                torch.zeros(
+                    1 if shared_weights else batchdim,
+                    flat_weight_index,
+                    dtype=torch.float32
+                ),
+                torch.zeros(sum(w3j_dim(*k) for k in w3j), dtype=torch.float32)
             )
 
             graph_out = jitable(optimize_einsums_full(graph_out, example_inputs))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Previously, `_codegen` used `torch.randn` to build example inputs when calling `opt_einsum_fx`. This affects the PyTorch RNG state and causes results to change depending on whether einsum optimization is enabled.

This PR replaces those `randn` calls with `zeros` (which should also be faster) to avoid contaminating the RNG state; a global optimization option should never substantively affect results.

## How Has This Been Tested?
e3nn test suite (locally, with opt_einsum_fx instaled), reproducability testing with our networks.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).