### PR TITLE
Avoids re-entrant file opening for Windows

### DIFF
--- a/e3nn/util/codegen/_eval.py
+++ b/e3nn/util/codegen/_eval.py
@@ -5,6 +5,7 @@ import importlib.machinery
 import importlib.util
 import tempfile
 import functools
+import os.path
 
 
 # Set a large but finite maximum size to prevent long-running or unusual client codes from growing memory use without bound.
@@ -13,10 +14,11 @@ def eval_code(code):
     r"""
     save code in a temporary file and import it as a module
     """
-    with tempfile.NamedTemporaryFile() as new_file:
-        new_file.write(bytes(code, 'ascii'))
-        new_file.flush()
-        loader = importlib.machinery.SourceFileLoader('main', new_file.name)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        new_filename = os.path.join(temp_dir, "__gencode.py")
+        with open(new_filename, 'w+b') as new_file:
+            new_file.write(bytes(code, 'ascii'))
+        loader = importlib.machinery.SourceFileLoader('main', new_filename)
         spec = importlib.util.spec_from_loader(loader.name, loader)
         mod = importlib.util.module_from_spec(spec)
         loader.exec_module(mod)


### PR DESCRIPTION
As per Mario Geiger and Alby M's suggestion, this uses a fixed filename for the temporary code, but in a temporary directory.