### PR TITLE
Optimized code for `o3.Linear`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Most recent change on the bottom.
 
 ## [Unreleased]
+### Added
+- `e3nn.util.test.random_irreps` convinience function for writing tests
+
+### Changed
+- `o3.Linear` now has more efficient specialized code
+
 
 ## [0.2.5] - 2021-04-07
 ### Added

--- a/docs/api/o3/o3_tp.rst
+++ b/docs/api/o3/o3_tp.rst
@@ -38,13 +38,6 @@ In a fully connected tensor product, all possible paths are created. The outputs
 In the elementwise tensor product, the irreps are multiplied one by one. Note how the inputs have been split and how the multiplicities of the outputs match with the multiplicities of the input.
 
 
-.. jupyter-execute::
-
-    o3.Linear('5x0e + 4x1e', '6x0e + 7x1e').tp.visualize()
-
-The linear operation is a special case of a tensor product with a constant scalar ``1.0``.
-
-
 .. autoclass:: e3nn.o3.TensorProduct
     :members:
     :show-inheritance:

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -24,17 +24,22 @@ class Linear(CodeGenMixin, torch.nn.Module):
         representation of the output
 
     internal_weights : bool
-        see `TensorProduct`
+        whether the ``Linear`` should store its own weights. Defaults to ``True`` unless ``shared_weights`` is explicitly set to ``False``, for consistancy with ``TensorProduct``.
 
     shared_weights : bool
-        see `TensorProduct`
+        whether the ``Linear`` should be weighted individually for each input in a batch. Defaults to ``False``. Cannot be ``True`` if ``internal_weights`` is ``True``.
+
+    Attributes
+    ----------
+    weight_numel : int
+        the size of the weights for this ``Linear``
 
     Examples
     --------
     Linearly combines 4 scalars into 8 scalars and 16 vectors into 8 vectors.
 
     >>> lin = Linear("4x0e+16x1o", "8x0e+8x1o")
-    >>> lin.tp.weight_numel
+    >>> lin.weight_numel
     160
     """
     weight_numel: int

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -1,13 +1,18 @@
-from typing import Optional
+from typing import Optional, Tuple
+import math
 
 import torch
+from torch import fx
 
+import e3nn
 from e3nn import o3
+from e3nn.util.codegen import CodeGenMixin
 from e3nn.util.jit import compile_mode
+from ._tensor_product._codegen import _get_code, _sum_tensors
 
 
 @compile_mode('script')
-class Linear(torch.nn.Module):
+class Linear(CodeGenMixin, torch.nn.Module):
     r"""Linear operation equivariant to :math:`O(3)`
 
     Parameters
@@ -32,33 +37,65 @@ class Linear(torch.nn.Module):
     >>> lin.tp.weight_numel
     160
     """
+    weight_numel: int
+    internal_weights: bool
+    shared_weights: bool
+
     def __init__(
         self,
         irreps_in,
         irreps_out,
-        internal_weights=None,
-        shared_weights=None,
+        internal_weights: Optional[bool] = None,
+        shared_weights: Optional[bool] = None,
+        _optimize_einsums: Optional[bool] = None
     ):
         super().__init__()
 
-        irreps_in = o3.Irreps(irreps_in).simplify()
-        irreps_out = o3.Irreps(irreps_out).simplify()
+        # == Process arguments ==
+        if shared_weights is False and internal_weights is None:
+            internal_weights = False
 
-        instr = [
-            (i_in, 0, i_out, 'uvw', True, 1.0)
-            for i_in, (_, ir_in) in enumerate(irreps_in)
-            for i_out, (_, ir_out) in enumerate(irreps_out)
-            if ir_in == ir_out
-        ]
+        if shared_weights is None:
+            shared_weights = True
 
-        self.tp = o3.TensorProduct(irreps_in, "0e", irreps_out, instr, internal_weights=internal_weights, shared_weights=shared_weights)
+        if internal_weights is None:
+            internal_weights = True
 
-        self.output_mask = self.tp.output_mask
-        self.irreps_in = irreps_in
-        self.irreps_out = irreps_out
+        assert shared_weights or not internal_weights
+        self.internal_weights = internal_weights
+        self.shared_weights = shared_weights
+
+        self.irreps_in = o3.Irreps(irreps_in).simplify()
+        self.irreps_out = o3.Irreps(irreps_out).simplify()
+
+        opt_defaults = e3nn.get_optimization_defaults()
+        self._optimize_einsums = _optimize_einsums if _optimize_einsums is not None else opt_defaults['optimize_einsums']
+        del opt_defaults
+
+        # == Generate code ==
+        code, self.weight_numel = _codegen_linear(
+            self.irreps_in,
+            self.irreps_out,
+            shared_weights=shared_weights,
+            optimize_einsums=self._optimize_einsums
+        )
+        self._codegen_register({
+            "_compiled_main": code
+        })
+
+        # == Generate weights ==
+        if internal_weights and self.weight_numel > 0:
+            assert self.shared_weights, "Having internal weights impose shared weights"
+            self.weight = torch.nn.Parameter(torch.randn(self.weight_numel))
+        else:
+            # For TorchScript, there always has to be some kind of defined .weight
+            self.register_buffer('weight', torch.Tensor())
+
+        # TODO: what to do with this?
+        # self.output_mask = self.tp.output_mask
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.irreps_in} -> {self.irreps_out} | {self.tp.weight_numel} weights)"
+        return f"{self.__class__.__name__}({self.irreps_in} -> {self.irreps_out} | {self.weight_numel} weights)"
 
     def forward(self, features, weight: Optional[torch.Tensor] = None):
         """evaluate
@@ -76,5 +113,126 @@ class Linear(torch.nn.Module):
         `torch.Tensor`
             tensor of shape ``(..., irreps_out.dim)``
         """
-        ones = torch.ones(features.shape[:-1] + (1,), dtype=features.dtype, device=features.device)
-        return self.tp(features, ones, weight)
+        if weight is None:
+            assert self.internal_weights, "Weights must be provided when internal_weights = False"
+            weight = self.weight
+        return self._compiled_main(features, weight)
+
+
+def _codegen_linear(
+    irreps_in: o3.Irreps,
+    irreps_out: o3.Irreps,
+    shared_weights: bool = False,
+    optimize_einsums: bool = True,
+) -> Tuple[str, int]:
+    graph_out = fx.Graph()
+
+    # = Function definitions =
+    x = fx.Proxy(graph_out.placeholder('x', torch.Tensor))
+    ws = fx.Proxy(graph_out.placeholder('w', torch.Tensor))
+
+    size = x.shape[:-1]
+    outsize = size + (irreps_out.dim,)
+
+    # = Short-circut for zero dimensional =
+    if irreps_in.dim == 0 or irreps_out.dim == 0:
+        out = x.new_zeros(outsize)
+
+        graph_out.output(out.node, torch.Tensor)
+        # Short circut
+        # 0 is weight_numel
+        return _get_code(graph_out), 0
+
+    x = x.reshape(-1, irreps_in.dim)
+    batch_out = x.shape[0]
+
+    weight_numel = sum(
+        mul_in * mul_out
+        for mul_in, ir_in in irreps_in
+        for mul_out, ir_out in irreps_out
+        if ir_in == ir_out
+    )
+    if weight_numel > 0:
+        ws = ws.reshape(-1, weight_numel)
+
+    # = extract individual input irreps =
+    x_list = [
+        x[:, i].reshape(batch_out, mul_ir.mul, mul_ir.ir.dim)
+        for i, mul_ir in zip(irreps_in.slices(), irreps_in)
+    ]
+
+    z = '' if shared_weights else 'z'
+
+    flat_weight_index = 0
+
+    out_list = []
+
+    instr = [
+        (i_in, i_out)
+        for i_in, (_, ir_in) in enumerate(irreps_in)
+        for i_out, (_, ir_out) in enumerate(irreps_out)
+        if ir_in == ir_out
+    ]
+
+    for i_in, i_out in instr:
+        mul_ir_in = irreps_in[i_in]
+        mul_ir_out = irreps_out[i_out]
+
+        # Short-circut for empty irreps
+        if mul_ir_in.dim == 0 or mul_ir_out.dim == 0:
+            continue
+
+        # Extract the weight from the flattened weight tensor
+        path_nweight = mul_ir_in.mul*mul_ir_out.mul
+        w = ws[
+            :,
+            flat_weight_index:flat_weight_index + path_nweight
+        ].reshape(
+            (() if shared_weights else (-1,)) + (mul_ir_out.mul, 1, mul_ir_out.mul)
+        )
+        flat_weight_index += path_nweight
+
+        ein_out = torch.einsum(f"{z}uvw,zui->zwi", w, x_list[i_in])
+        # TODO: this makes the results the same as the old one, but is it really a good initialization for a Linear?
+        ein_out = math.sqrt(1.0 / mul_ir_in.mul) * ein_out
+
+        out_list += [ein_out.reshape(batch_out, mul_ir_out.dim)]
+
+    # = Return the result =
+    out = torch.cat([
+        _sum_tensors(
+            [out for (_, i_out_ins), out in zip(instr, out_list) if i_out_ins == i_out],
+            shape=(batch_out, mul_ir_out.dim),
+            like=x
+        )
+        for i_out, mul_ir_out in enumerate(irreps_out)
+    ], dim=1)
+
+    out = out.reshape(outsize)
+
+    graph_out.output(out.node, torch.Tensor)
+
+    # check graphs
+    graph_out.lint()
+
+    # TODO: when eliminate_dead_code() is in PyTorch stable, use that
+    if optimize_einsums:
+        try:
+            from opt_einsum_fx import optimize_einsums_full, jitable
+        except ImportError:
+            # opt_einsum_fx is not installed
+            pass
+        else:
+            # See _tensor_product/_codegen.py for notes
+            batchdim = 4
+            example_inputs = (
+                torch.zeros((batchdim, irreps_in.dim), dtype=torch.float32),
+                torch.zeros(
+                    1 if shared_weights else batchdim,
+                    flat_weight_index,
+                    dtype=torch.float32
+                ),
+            )
+            graph_out = jitable(optimize_einsums_full(graph_out, example_inputs))
+
+    return _get_code(graph_out), weight_numel

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -194,8 +194,8 @@ def _codegen_linear(
 
         ein_out = torch.einsum(f"{z}uw,zui->zwi", w, x_list[i_in])
         # TODO: this makes the results the same as the old one, but is it really a good initialization for a Linear?
-        alpha = math.sqrt(mul_ir_in.mul * sum(1 if i_out_this == i_out else 0 for _, i_out_this in instr))
-        ein_out = ein_out / alpha
+        alpha = 1.0 / math.sqrt(mul_ir_in.mul * sum(1 if i_out_this == i_out else 0 for _, i_out_this in instr))
+        ein_out = alpha * ein_out
 
         out_list += [ein_out.reshape(batch_out, mul_ir_out.dim)]
 

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -1,3 +1,4 @@
+from typing import List, Union
 import random
 import itertools
 import warnings
@@ -43,6 +44,74 @@ try:
         torch.set_default_dtype(old_dtype)
 except ImportError:
     pass
+
+
+def random_irreps(
+    n: int = 1,
+    lmax: int = 4,
+    mul_min: int = 0,
+    mul_max: int = 5,
+    len_min: int = 0,
+    len_max: int = 4,
+    clean: bool = False,
+    allow_empty: bool = True
+):
+    r"""Generate random irreps parameters for testing.
+
+    Parameters
+    ----------
+        n : int, optional
+            How many to generate; defaults to 1.
+        lmax : int, optional
+            The maximum L to generate (inclusive); defaults to 4.
+        mul_min : int, optional
+            The smallest multiplicity to generate, defaults to 0.
+        mul_max : int, optional
+            The largest multiplicity to generate, defaults to 5.
+        len_min : int, optional
+            The smallest number of irreps to generate, defaults to 0.
+        len_max : int, optional
+            The largest number of irreps to generate, defaults to 4.
+        clean : bool, optional
+            If ``True``, only ``o3.Irreps`` objects will be returned. If ``False`` (the default), ``Irreps``-like objects like strings and lists of tuples can be returned.
+        allow_empty : bool, optional
+            Whether to allow generating empty ``Irreps``.
+    Returns
+    -------
+        An irreps-like object if ``n == 1`` or a list of them if ``n > 1``
+    """
+    assert n >= 1
+    assert lmax >= 0
+    assert mul_min >= 0
+    assert mul_max >= mul_min
+
+    out = []
+    for _ in range(n):
+        this_irreps = []
+        for _ in range(random.randint(len_min, len_max)):
+            this_irreps.append((
+                random.randint(mul_min, mul_max),
+                (random.randint(0, lmax), random.choice((1, -1)))
+            ))
+        if not allow_empty and all(m == 0 for m, _ in this_irreps):
+            this_irreps[-1] = (random.randint(1, mul_max), this_irreps[-1][1])
+        this_irreps = o3.Irreps(this_irreps)
+
+        if clean:
+            outtype = "irreps"
+        else:
+            outtype = random.choice(("irreps", "str", "list"))
+        if outtype == "irreps":
+            out.append(this_irreps)
+        elif outtype == "str":
+            out.append(repr(this_irreps))
+        elif outtype == "list":
+            out.append([(mul_ir.mul, (mul_ir.ir.l, mul_ir.ir.p)) for mul_ir in this_irreps])
+
+    if n == 1:
+        return out[0]
+    else:
+        return out
 
 
 def assert_equivariant(

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -1,4 +1,3 @@
-from typing import List, Union
 import random
 import itertools
 import warnings

--- a/tests/defaults_test.py
+++ b/tests/defaults_test.py
@@ -2,17 +2,23 @@ import e3nn
 
 
 def test_opt_defaults():
-    a = e3nn.o3.Linear("4x1o", "4x1o")
-    assert a.tp._specialized_code
-    assert a.tp._optimize_einsums
+    a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
+    b = e3nn.o3.Linear("4x1o", "4x1o")
+    assert a._specialized_code
+    assert a._optimize_einsums
+    assert b._optimize_einsums
     old_defaults = e3nn.get_optimization_defaults()
     try:
         e3nn.set_optimization_defaults(optimize_einsums=False)
-        a = e3nn.o3.Linear("4x1o", "4x1o")
-        assert a.tp._specialized_code
-        assert not a.tp._optimize_einsums
+        a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
+        b = e3nn.o3.Linear("4x1o", "4x1o")
+        assert a._specialized_code
+        assert not a._optimize_einsums
+        assert not b._optimize_einsums
     finally:
         e3nn.set_optimization_defaults(**old_defaults)
-    a = e3nn.o3.Linear("4x1o", "4x1o")
-    assert a.tp._specialized_code
-    assert a.tp._optimize_einsums
+    a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
+    b = e3nn.o3.Linear("4x1o", "3x1o")
+    assert a._specialized_code
+    assert a._optimize_einsums
+    assert b._optimize_einsums

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -69,3 +69,10 @@ def test_linear_like_tp(irreps_in, irreps_out):
             torch.float64: 1e-10
         }[torch.get_default_dtype()]
     )
+
+
+def test_output_mask():
+    irreps_in = o3.Irreps("1e + 2e")
+    irreps_out = o3.Irreps("3e + 5x2o")
+    m = o3.Linear(irreps_in, irreps_out)
+    assert torch.all(m.output_mask == torch.zeros(m.irreps_out.dim, dtype=torch.bool))

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -51,11 +51,11 @@ def test_linear():
 
 def test_linear_like_tp():
     """Test that Linear gives the same results as the corresponding TensorProduct."""
-    irreps_in = o3.Irreps("1e + 2e + 3x3o")
-    irreps_out = o3.Irreps("1e + 2e + 3x3o")
+    irreps_in = o3.Irreps("1e + 2e + 4x1e + 3x3o")
+    irreps_out = o3.Irreps("1e + 2e + 3x3o + 3x1e")
     m = o3.Linear(irreps_in, irreps_out)
     m_true = SlowLinear(irreps_in, irreps_out)
     with torch.no_grad():
         m_true.tp.weight[:] = m.weight
-    inp = torch.randn(3, irreps_in.dim)
+    inp = torch.randn(4, irreps_in.dim)
     assert torch.allclose(m(inp), m_true(inp))

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -1,0 +1,61 @@
+from typing import Optional
+
+import torch
+
+from e3nn import o3
+from e3nn.util.test import assert_equivariant, assert_auto_jitable
+
+
+class SlowLinear(torch.nn.Module):
+    r"""Inefficient implimentation of Linear relying on TensorProduct.
+    """
+    def __init__(
+        self,
+        irreps_in,
+        irreps_out,
+        internal_weights=None,
+        shared_weights=None,
+    ):
+        super().__init__()
+
+        irreps_in = o3.Irreps(irreps_in).simplify()
+        irreps_out = o3.Irreps(irreps_out).simplify()
+
+        instr = [
+            (i_in, 0, i_out, 'uvw', True, 1.0)
+            for i_in, (_, ir_in) in enumerate(irreps_in)
+            for i_out, (_, ir_out) in enumerate(irreps_out)
+            if ir_in == ir_out
+        ]
+
+        self.tp = o3.TensorProduct(irreps_in, "0e", irreps_out, instr, internal_weights=internal_weights, shared_weights=shared_weights)
+
+        self.output_mask = self.tp.output_mask
+        self.irreps_in = irreps_in
+        self.irreps_out = irreps_out
+
+    def forward(self, features, weight: Optional[torch.Tensor] = None):
+        ones = torch.ones(features.shape[:-1] + (1,), dtype=features.dtype, device=features.device)
+        return self.tp(features, ones, weight)
+
+
+def test_linear():
+    irreps_in = o3.Irreps("1e + 2e + 3x3o")
+    irreps_out = o3.Irreps("1e + 2e + 3x3o")
+    m = o3.Linear(irreps_in, irreps_out)
+    m(torch.randn(irreps_in.dim))
+
+    assert_equivariant(m)
+    assert_auto_jitable(m)
+
+
+def test_linear_like_tp():
+    """Test that Linear gives the same results as the corresponding TensorProduct."""
+    irreps_in = o3.Irreps("1e + 2e + 3x3o")
+    irreps_out = o3.Irreps("1e + 2e + 3x3o")
+    m = o3.Linear(irreps_in, irreps_out)
+    m_true = SlowLinear(irreps_in, irreps_out)
+    with torch.no_grad():
+        m_true.tp.weight[:] = m.weight
+    inp = torch.randn(3, irreps_in.dim)
+    assert torch.allclose(m(inp), m_true(inp))

--- a/tests/o3/tensor_product_sub_test.py
+++ b/tests/o3/tensor_product_sub_test.py
@@ -2,7 +2,7 @@ import torch
 
 from e3nn import o3
 from e3nn.nn import Identity
-from e3nn.o3 import FullyConnectedTensorProduct, Linear, FullTensorProduct, Norm
+from e3nn.o3 import FullyConnectedTensorProduct, FullTensorProduct, Norm
 from e3nn.util.test import assert_equivariant, assert_auto_jitable
 
 
@@ -27,17 +27,6 @@ def test_id():
 
     assert_equivariant(m)
     assert_auto_jitable(m, strict_shapes=False)
-
-
-def test_linear():
-    irreps_in = o3.Irreps("1e + 2e + 3x3o")
-    irreps_out = o3.Irreps("1e + 2e + 3x3o")
-    m = Linear(irreps_in, irreps_out)
-    print(m)
-    m(torch.randn(irreps_in.dim))
-
-    assert_equivariant(m)
-    assert_auto_jitable(m)
 
 
 def test_full():


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Optimized code for `o3.Linear` to avoid allocation/contraction with a tensor of ones of equal size to the features. This approximately halves the forward memory & compute requirements of `o3.Linear`.

## Motivation
Simple CPU benchmark:
```python
from torch.utils.benchmark import Timer
ir = "16x0o + 16x0e + 16x1o + 16x1e + 16x2o + 16x2e"
l_slow = SlowLinear(ir, ir)
l = Linear(ir, ir)
n = 2000
inps = [l.irreps_in.randn(200, -1) for _ in range(n + 100)]
inps_iter_fast = iter(inps)
inps_iter_slow = iter(inps)
t_slow = Timer(stmt="out = l_slow(next(inps_iter_slow))", globals={'l_slow': l_slow, 'inps_iter_slow': inps_iter_slow})
t_slow.timeit(n)
# <torch.utils.benchmark.utils.common.Measurement object at 0x7f76cecde340>
# out = l_slow(next(inps_iter_slow))
#  986.27 us
#  1 measurement, 2000 runs , 1 thread
t_fast = Timer(stmt="out = l(next(inps_iter_fast))", globals={'l': l, 'inps_iter_fast': inps_iter_fast})
t_fast.timeit(n)
# <torch.utils.benchmark.utils.common.Measurement object at 0x7f76c9fbe310>
# out = l(next(inps_iter_fast))
#  677.11 us
#  1 measurement, 2000 runs , 1 thread
```
Approximately one-third speedup.

Previous tests have shown that `.expand`ed ones in `Linear` would get allocated to contiguous tensors, so the memory gain is real.

## How Has This Been Tested?
- New tests
- e3nn test suite
- Reproduced old results with a real model
- ~10-15% speedup of a real-world model that includes `Linear`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).