### PR TITLE
Extra specialized code

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Most recent change on the bottom.
 
 ### Fixed
 - Fixed an issue with `Activation` (used by `Gate`). It was only applying the first activation function provided. `Activation('0e+0e', [act1, act2])` was equivalent to `Activation('2x0e', [act1])`. Solved by removing the `.simplify()` applied to `self.irreps_in`.
+- `Gate` will not accept non-scalar `irreps_gates` or `irreps_scalars`
 
 ## [0.2.6] - 2021-04-12
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Most recent change on the bottom.
 
 ## [Unreleased]
+### Added
+- `uuu` connection mode in `o3.TensorProduct` now has specialized code
+
 ### Fixed
 - Fixed an issue with `Activation` (used by `Gate`). It was only applying the first activation function provided. `Activation('0e+0e', [act1, act2])` was equivalent to `Activation('2x0e', [act1])`. Solved by removing the `.simplify()` applied to `self.irreps_in`.
 

--- a/e3nn/nn/_gate.py
+++ b/e3nn/nn/_gate.py
@@ -87,10 +87,12 @@ class Gate(torch.nn.Module):
         irreps_gates = o3.Irreps(irreps_gates)
         irreps_gated = o3.Irreps(irreps_gated)
 
-        if irreps_gates.lmax > 0:
+        if len(irreps_gates) > 0 and irreps_gates.lmax > 0:
             raise ValueError(f"Gate scalars must be scalars, instead got irreps_gates = {irreps_gates}")
-        if irreps_scalars.lmax > 0:
+        if len(irreps_scalars) > 0 and irreps_scalars.lmax > 0:
             raise ValueError(f"Scalars must be scalars, instead got irreps_scalars = {irreps_scalars}")
+        if irreps_gates.num_irreps != irreps_gated.num_irreps:
+            raise ValueError(f"There are {irreps_gated.num_irreps} irreps in irreps_gated, but a different number ({irreps_gates.num_irreps}) of gate scalars in irreps_gates")
 
         self.sc = _Sortcut(irreps_scalars, irreps_gates, irreps_gated)
         self.irreps_scalars, self.irreps_gates, self.irreps_gated = self.sc.irreps_outs

--- a/e3nn/nn/_gate.py
+++ b/e3nn/nn/_gate.py
@@ -87,6 +87,11 @@ class Gate(torch.nn.Module):
         irreps_gates = o3.Irreps(irreps_gates)
         irreps_gated = o3.Irreps(irreps_gated)
 
+        if irreps_gates.lmax > 0:
+            raise ValueError(f"Gate scalars must be scalars, instead got irreps_gates = {irreps_gates}")
+        if irreps_scalars.lmax > 0:
+            raise ValueError(f"Scalars must be scalars, instead got irreps_scalars = {irreps_scalars}")
+
         self.sc = _Sortcut(irreps_scalars, irreps_gates, irreps_gated)
         self.irreps_scalars, self.irreps_gates, self.irreps_gated = self.sc.irreps_outs
         self._irreps_in = self.sc.irreps_in

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -565,6 +565,8 @@ class Irreps(tuple):
 
     @property
     def lmax(self) -> int:
+        if len(self) == 0:
+            raise ValueError("Cannot get lmax of empty Irreps")
         return max(self.ls)
 
     def __repr__(self):

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -202,10 +202,14 @@ def _codegen_linear(
 
         # Extract the weight from the flattened weight tensor
         path_nweight = mul_ir_in.mul*mul_ir_out.mul
-        w = ws[
-            :,
-            flat_weight_index:flat_weight_index + path_nweight
-        ].reshape(
+        if len(instr) == 1:
+            w = ws
+        else:
+            w = ws[
+                :,
+                flat_weight_index:flat_weight_index + path_nweight
+            ]
+        w = w.reshape(
             (() if shared_weights else (-1,)) + (mul_ir_in.mul, mul_ir_out.mul)
         )
         flat_weight_index += path_nweight

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -241,7 +241,6 @@ def codegen_tensor_product(
                     ein_out = torch.einsum(f"{z}uv,zui,zv->zui", w_out, x1_out, x2_out.reshape(batch_out, mul_ir_in2.dim))
                     ein_right = torch.einsum(f"{z}uv,ij,uw,zv->zuiwj", w_right, i1_right, e1_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
                 elif specialized_code and mul_ir_out.ir.l == 0:
-                    exp = {'component': 1, 'norm': -1}[normalization]
                     ein_out = torch.einsum(f"{z}uv,zui,zvi->zu", w_out, x1_out, x2_out) / sqrt(mul_ir_in1.ir.dim)**exp
                     ein_right = torch.einsum(f"{z}uv,uw,zvi->zuiw", w_right, e1_right, x2_right) / sqrt(mul_ir_in1.ir.dim)**exp
                 else:

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -207,17 +207,6 @@ def codegen_tensor_product(
             if specialized_code and key == (0, 0, 0):
                 ein_out = torch.einsum(f"{z}uvw,zu,zv->zw", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out.reshape(batch_out, mul_ir_in2.dim))
                 ein_right = torch.einsum(f"{z}uvw,zv->zuw", w_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
-            elif specialized_code and key == (1, 1, 1) and normalization == "component":
-                cross_x1_out = x1_out.reshape(batch_out, mul_ir_in1.mul, 1, 3)
-                cross_x2_out = x2_out.reshape(batch_out, 1, mul_ir_in2.mul, 3)
-                cross_x1_out, cross_x2_out = torch.broadcast_tensors(cross_x1_out, cross_x2_out)
-                ein_out = torch.einsum(
-                    f"{z}uvw,zuvi->zwi",
-                    w_out,
-                    torch.cross(cross_x1_out, cross_x2_out, dim=3)
-                ) / sqrt(2)
-                # For cross product, use the general case right()
-                ein_right = torch.einsum(f"{z}uvw,ijk,zvj->zuiwk", w_right, w3j_right, x2_right)
             elif specialized_code and mul_ir_in1.ir.l == 0:
                 ein_out = torch.einsum(f"{z}uvw,zu,zvj->zwj", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out)
                 ein_right = torch.einsum(f"{z}uvw,zvi->zuwi", w_right, x2_right)
@@ -236,17 +225,6 @@ def codegen_tensor_product(
                 if specialized_code and key == (0, 0, 0):
                     ein_out = torch.einsum(f"{z}uv,zu,zv->zu", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out.reshape(batch_out, mul_ir_in2.dim))
                     ein_right = torch.einsum(f"{z}uv,uw,zv->zuw", w_right, e1_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
-                elif specialized_code and key == (1, 1, 1) and normalization == "component":
-                    cross_x1_out = x1_out.reshape(batch_out, mul_ir_in1.mul, 1, 3)
-                    cross_x2_out = x2_out.reshape(batch_out, 1, mul_ir_in2.mul, 3)
-                    cross_x1_out, cross_x2_out = torch.broadcast_tensors(cross_x1_out, cross_x2_out)
-                    ein_out = torch.einsum(
-                        f"{z}uv,zuvi->zui",
-                        w_out,
-                        torch.cross(cross_x1_out, cross_x2_out, dim=3)
-                    ) / sqrt(2)
-                    # For cross product, use the general case right()
-                    ein_right = torch.einsum(f"{z}uv,ijk,uw,zvj->zuiwk", w_right, w3j_right, e1_right, x2_right)
                 elif specialized_code and mul_ir_in1.ir.l == 0:
                     ein_out = torch.einsum(f"{z}uv,zu,zvj->zuj", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out)
                     ein_right = torch.einsum(f"{z}uv,uw,zvi->zuwi", w_right, e1_right, x2_right)

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -60,6 +60,20 @@ def test_linear():
     assert_auto_jitable(m)
 
 
+def test_single_out():
+    l1 = o3.Linear("5x0e", "5x0e")
+    l2 = o3.Linear("5x0e", "5x0e + 3x0o")
+    with torch.no_grad():
+        l1.weight[:] = l2.weight
+    x = torch.randn(3, 5)
+    out1 = l1(x)
+    out2 = l2(x)
+    assert out1.shape == (3, 5)
+    assert out2.shape == (3, 8)
+    assert torch.allclose(out1, out2[:, :5])
+    assert torch.all(out2[:, 5:] == 0)
+
+
 # We want to be sure to test a multiple-same L case and a single irrep case
 @pytest.mark.parametrize(
     "irreps_in", ["5x0e", "1e + 2e + 4x1e + 3x3o"] + random_irreps(n=4)

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -9,8 +9,8 @@ from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irrep
 
 
 class SlowLinear(torch.nn.Module):
-    r"""Inefficient implimentation of Linear relying on TensorProduct.
-    """
+    r"""Inefficient implimentation of Linear relying on TensorProduct."""
+
     def __init__(
         self,
         irreps_in,
@@ -24,20 +24,29 @@ class SlowLinear(torch.nn.Module):
         irreps_out = o3.Irreps(irreps_out).simplify()
 
         instr = [
-            (i_in, 0, i_out, 'uvw', True, 1.0)
+            (i_in, 0, i_out, "uvw", True, 1.0)
             for i_in, (_, ir_in) in enumerate(irreps_in)
             for i_out, (_, ir_out) in enumerate(irreps_out)
             if ir_in == ir_out
         ]
 
-        self.tp = o3.TensorProduct(irreps_in, "0e", irreps_out, instr, internal_weights=internal_weights, shared_weights=shared_weights)
+        self.tp = o3.TensorProduct(
+            irreps_in,
+            "0e",
+            irreps_out,
+            instr,
+            internal_weights=internal_weights,
+            shared_weights=shared_weights,
+        )
 
         self.output_mask = self.tp.output_mask
         self.irreps_in = irreps_in
         self.irreps_out = irreps_out
 
     def forward(self, features, weight: Optional[torch.Tensor] = None):
-        ones = torch.ones(features.shape[:-1] + (1,), dtype=features.dtype, device=features.device)
+        ones = torch.ones(
+            features.shape[:-1] + (1,), dtype=features.dtype, device=features.device
+        )
         return self.tp(features, ones, weight)
 
 
@@ -51,9 +60,13 @@ def test_linear():
     assert_auto_jitable(m)
 
 
-# We want to be sure to test a multiple-same L case
-@pytest.mark.parametrize("irreps_in", ["1e + 2e + 4x1e + 3x3o"] + random_irreps(n=4))
-@pytest.mark.parametrize("irreps_out", ["1e + 2e + 3x3o + 3x1e"] + random_irreps(n=4))
+# We want to be sure to test a multiple-same L case and a single irrep case
+@pytest.mark.parametrize(
+    "irreps_in", ["5x0e", "1e + 2e + 4x1e + 3x3o"] + random_irreps(n=4)
+)
+@pytest.mark.parametrize(
+    "irreps_out", ["5x0e", "1e + 2e + 3x3o + 3x1e"] + random_irreps(n=4)
+)
 def test_linear_like_tp(irreps_in, irreps_out):
     """Test that Linear gives the same results as the corresponding TensorProduct."""
     m = o3.Linear(irreps_in, irreps_out)
@@ -64,10 +77,7 @@ def test_linear_like_tp(irreps_in, irreps_out):
     assert torch.allclose(
         m(inp),
         m_true(inp),
-        atol={
-            torch.float32: 1e-7,
-            torch.float64: 1e-10
-        }[torch.get_default_dtype()]
+        atol={torch.float32: 1e-7, torch.float64: 1e-10}[torch.get_default_dtype()],
     )
 
 

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -125,6 +125,26 @@ def test_empty_irreps():
     assert out.shape == (2, 2, 4)
 
 
+def test_single_out():
+    tp1 = TensorProduct(
+        "5x0e", "5x0e", "5x0e",
+        [(0, 0, 0, "uvw", True, 1.0)]
+    )
+    tp2 = TensorProduct(
+        "5x0e", "5x0e", "5x0e + 3x0o",
+        [(0, 0, 0, "uvw", True, 1.0)]
+    )
+    with torch.no_grad():
+        tp2.weight[:] = tp1.weight
+    x1, x2 = torch.randn(3, 5), torch.randn(3, 5)
+    out1 = tp1(x1, x2)
+    out2 = tp2(x1, x2)
+    assert out1.shape == (3, 5)
+    assert out2.shape == (3, 8)
+    assert torch.allclose(out1, out2[:, :5])
+    assert torch.all(out2[:, 5:] == 0)
+
+
 def test_empty_inputs():
     tp = FullyConnectedTensorProduct('0e + 1e', '0e + 1e', '0e + 1e')
     out = tp(torch.randn(2, 1, 0, 1, 4), torch.randn(1, 2, 0, 3, 4))

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -105,27 +105,34 @@ def test_specialized_code(normalization, mode, weighted, float_tolerance):
         irreps_in2 = irreps_in1
         irreps_out = irreps_in1
 
-    tps = []
-    for sc in [False, True]:
-        torch.manual_seed(0)
-        ins = [
-            (0, 0, 0, mode, weighted, 1.0),
+    ins = [
+        (0, 0, 0, mode, weighted, 1.0),
 
-            (0, 1, 1, mode, weighted, 1.0),
-            (1, 0, 1, mode, weighted, 1.0),
-            (1, 1, 0, mode, weighted, 1.0),
+        (0, 1, 1, mode, weighted, 1.0),
+        (1, 0, 1, mode, weighted, 1.0),
+        (1, 1, 0, mode, weighted, 1.0),
 
-            (1, 1, 1, mode, weighted, 1.0),
+        (1, 1, 1, mode, weighted, 1.0),
 
-            (0, 2, 2, mode, weighted, 1.0),
-            (2, 0, 2, mode, weighted, 1.0),
-            (2, 2, 0, mode, weighted, 1.0),
+        (0, 2, 2, mode, weighted, 1.0),
+        (2, 0, 2, mode, weighted, 1.0),
+        (2, 2, 0, mode, weighted, 1.0),
 
-            (2, 1, 1, mode, weighted, 1.0),
-        ]
-        tps += [TensorProduct(irreps_in1, irreps_in2, irreps_out, ins, normalization=normalization, _specialized_code=sc)]
+        (2, 1, 1, mode, weighted, 1.0),
+    ]
+    tp1 = TensorProduct(
+        irreps_in1, irreps_in2, irreps_out,
+        ins, normalization=normalization,
+        _specialized_code=False
+    )
+    tp2 = TensorProduct(
+        irreps_in1, irreps_in2, irreps_out,
+        ins, normalization=normalization,
+        _specialized_code=True
+    )
+    with torch.no_grad():
+        tp2.weight[:] = tp1.weight
 
-    tp1, tp2 = tps
     x = irreps_in1.randn(3, -1)
     y = irreps_in2.randn(3, -1)
     assert (tp1(x, y) - tp2(x, y)).abs().max() < float_tolerance

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -87,7 +87,9 @@ def test(float_tolerance, l1, p1, l2, p2, lo, po, mode, weight):
     [
         ('uvw', True),
         ('uvu', True),
+        ('uvu', False),
         ('uvv', True),
+        ('uvv', False),
         ('uuu', True),
         ('uuu', False)
     ]

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -145,6 +145,23 @@ def test_single_out():
     assert torch.all(out2[:, 5:] == 0)
 
 
+def test_specialized_wigners():
+    """If all paths use specialized code, there should be no wigners"""
+    tp = FullyConnectedTensorProduct(
+        "5x0e + 3x0o",
+        "4x0e", "4x0e + 1x3o",
+        _specialized_code=True
+    )
+    assert torch.numel(tp._wigner_buf) == 0
+    tp = FullyConnectedTensorProduct(
+        "5x0e + 3x0o",
+        "4x0e", "4x0e + 1x3o",
+        _specialized_code=False
+    )
+    # There should only be the 0x0->0 wigner
+    assert torch.numel(tp._wigner_buf) == 1
+
+
 def test_empty_inputs():
     tp = FullyConnectedTensorProduct('0e + 1e', '0e + 1e', '0e + 1e')
     out = tp(torch.randn(2, 1, 0, 1, 4), torch.randn(1, 2, 0, 3, 4))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Specialized code for some special cases:
- No `torch.cat` copy if `len(irreps_out)` is 1 (TensorProduct and Linear)
- No view creation if `len(irreps_in) == 1` (Linear)
- Specialized code for `uuu`
- Specialized cross-product code for `uuu`
- Specialized code for unweighted `uvv`

Some benchmarks:
For a `Gate`-like elementwise tensor product with scalars, specialized code for `uuu` (opt einsum is on):
```
python examples/tensor_product_benchmark.py -n 5000 --elementwise --specialized-code False --opt-ein True --irreps-in2 32x0e

  221.65 us
  1 measurement, 5000 runs , 1 thread
 
--specialized-code True

  139.54 us
  1 measurement, 5000 runs , 1 thread
```
For a `uuu` cross product:
```
python examples/tensor_product_benchmark.py -n 1000 --elementwise --irreps 32x1o --irreps-out 32x1e --specialized-code False

  254.56 us
  1 measurement, 1000 runs , 1 thread
 
--specialized-code True

  224.24 us
  1 measurement, 1000 runs , 1 thread
```
Benchmark results showed that `torch.cross` for `uvw` and `uvv` is much faster _without_ `opt_einsum_fx`, but somewhat slower with, so I left them out.

**Also**, removed unused Wigner matrices from `TensorProduct` — previously all W3Js would be made and passed along even if they were unused due to specialized code.

Added `right()` to specialized code and optimization tests.

Removed global RNG state modification from specialized code test.

Added `ElementwiseTensorProduct` to the benchmark script.

Confirm that gates and scalars in `Gate` are actually scalars; better errors if they are not.

## How Has This Been Tested?
e3nn test suite, repro tests on real-world network.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).