### PR TITLE
`o3.Norm`/`NormActivation`: specialized code and gradient fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Most recent change on the bottom.
 
 ## [Unreleased]
+### Added
+- `o3.Norm` now has specialized code
+
+### Fixed
+- No more NaN gradients of `o3.Norm`/`nn.NormActivation` at zero when using `epsilon`
 
 ## [0.2.7] - 2021-04-14
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Most recent change on the bottom.
 ## [Unreleased]
 ### Added
 - `o3.Norm` now has specialized code
+- `squared` option to `o3.Norm`
 
 ### Fixed
 - No more NaN gradients of `o3.Norm`/`nn.NormActivation` at zero when using `epsilon`

--- a/e3nn/nn/_normact.py
+++ b/e3nn/nn/_normact.py
@@ -54,13 +54,10 @@ class NormActivation(torch.nn.Module):
         self.irreps_in = o3.Irreps(irreps_in)
         self.irreps_out = o3.Irreps(irreps_in)
 
-        if normalize:
-            if epsilon is None:
-                epsilon = 1e-8
-            elif not epsilon > 0:
-                raise ValueError(f"epsilon {epsilon} is invalid, must be strictly positive.")
-        elif epsilon is not None:
-            raise ValueError("Using epsilon when normalize = False makes no sense.")
+        if epsilon is None:
+            epsilon = 1e-8
+        elif not epsilon > 0:
+            raise ValueError(f"epsilon {epsilon} is invalid, must be strictly positive.")
 
         self.norm = o3.Norm(irreps_in, epsilon=epsilon)
         self.scalar_nonlinearity = scalar_nonlinearity

--- a/e3nn/o3/_norm.py
+++ b/e3nn/o3/_norm.py
@@ -12,15 +12,12 @@ from ._tensor_product._codegen import _get_code
 
 @compile_mode('script')
 class Norm(CodeGenMixin, torch.nn.Module):
-    r"""Norm operation
+    r"""Norm of each irrep in a direct sum of irreps.
 
     Parameters
     ----------
     irreps_in : `Irreps`
         representation of the input
-
-    normalization : {'component', 'norm'}
-        see `TensorProduct`
 
     Examples
     --------
@@ -45,7 +42,7 @@ class Norm(CodeGenMixin, torch.nn.Module):
         return f"{self.__class__.__name__}({self.irreps_in})"
 
     def forward(self, features):
-        """evaluate
+        """Compute norms of irreps in ``features``.
 
         Parameters
         ----------

--- a/e3nn/o3/_norm.py
+++ b/e3nn/o3/_norm.py
@@ -2,7 +2,8 @@ from typing import Tuple, Optional
 
 import torch
 from torch import fx
-import torch_scatter
+# This import appears to be unused but is needed to register `torch_scatter` with PyTorch
+import torch_scatter  # noqa: F401
 
 from e3nn import o3
 from e3nn.util.codegen import CodeGenMixin

--- a/e3nn/o3/_norm.py
+++ b/e3nn/o3/_norm.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import Tuple
 
 import torch
 from torch import fx
@@ -113,7 +113,7 @@ def _codegen_norm(irreps_in: o3.Irreps, squared: bool) -> Tuple[str, torch.Tenso
     out = fx.Proxy(out)
 
     if not squared:
-        out = torch.sqrt(out)
+        out = out.relu().sqrt()
 
     # = Return the result =
     out = out.reshape(outsize)

--- a/tests/nn/normact_test.py
+++ b/tests/nn/normact_test.py
@@ -103,6 +103,7 @@ def test_norm_activation_equivariant(do_bias, nonlin):
 @pytest.mark.parametrize('do_bias', [True, False])
 @pytest.mark.parametrize('nonlin', [torch.tanh, torch.sigmoid])
 def test_zeros(do_bias, nonlin):
+    """Confirm that `epsilon` gives non-NaN grads"""
     irreps_in = e3nn.o3.Irreps("2x0e + 3x0o")
     norm_act = NormActivation(
         irreps_in=irreps_in,

--- a/tests/nn/normact_test.py
+++ b/tests/nn/normact_test.py
@@ -98,3 +98,23 @@ def test_norm_activation_equivariant(do_bias, nonlin):
 
     assert_equivariant(norm_act)
     assert_auto_jitable(norm_act)
+
+
+@pytest.mark.parametrize('do_bias', [True, False])
+@pytest.mark.parametrize('nonlin', [torch.tanh, torch.sigmoid])
+def test_zeros(do_bias, nonlin):
+    irreps_in = e3nn.o3.Irreps("2x0e + 3x0o")
+    norm_act = NormActivation(
+        irreps_in=irreps_in,
+        scalar_nonlinearity=nonlin,
+        bias=do_bias,
+        normalize=True,
+    )
+    with torch.autograd.set_detect_anomaly(True):
+        inp = torch.zeros(norm_act.irreps_in.dim, requires_grad=True)
+        out = norm_act(inp)
+        grads = torch.autograd.grad(
+            outputs=out.sum(),
+            inputs=inp,
+        )[0]
+        assert torch.all(torch.isfinite(grads))

--- a/tests/o3/norm_test.py
+++ b/tests/o3/norm_test.py
@@ -1,0 +1,61 @@
+import pytest
+
+import torch
+
+from e3nn import o3
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps
+
+
+class SlowNorm(torch.nn.Module):
+    r"""Slow norm using TensorProduct"""
+    def __init__(self, irreps_in):
+        super().__init__()
+
+        irreps_in = o3.Irreps(irreps_in).simplify()
+        irreps_out = o3.Irreps([(mul, "0e") for mul, _ in irreps_in])
+
+        instr = [
+            (i, i, i, 'uuu', False, ir.dim)
+            for i, (mul, ir) in enumerate(irreps_in)
+        ]
+
+        self.tp = o3.TensorProduct(
+            irreps_in,
+            irreps_in,
+            irreps_out,
+            instr,
+            normalization='component'
+        )
+
+        self.irreps_in = irreps_in
+        self.irreps_out = irreps_out.simplify()
+
+    def forward(self, features):
+        return self.tp(features, features).sqrt()
+
+
+@pytest.mark.parametrize(
+    "irreps_in", ["", "5x0e", "1e + 2e + 4x1e + 3x3o"] + random_irreps(n=4)
+)
+@pytest.mark.parametrize("batchdim", [(4,), (1,), tuple(), (5, 3, 7)])
+def test_norm_like_tp(irreps_in, batchdim):
+    """Test that Norm gives the same results as the corresponding TensorProduct."""
+    m = o3.Norm(irreps_in)
+    m_true = SlowNorm(irreps_in)
+    inp = torch.randn(batchdim + (m.irreps_in.dim,))
+    out = m(inp)
+    out_true = m_true(inp)
+    assert out.shape == out_true.shape
+    assert torch.allclose(
+        out,
+        out_true,
+        atol={torch.float32: 1e-8, torch.float64: 1e-10}[torch.get_default_dtype()],
+    )
+
+
+def test_norm():
+    irreps_in = o3.Irreps("1e + 2e + 3x3o")
+    m = o3.Norm(irreps_in)
+    m(torch.randn(irreps_in.dim))
+    assert_equivariant(m)
+    assert_auto_jitable(m)

--- a/tests/o3/norm_test.py
+++ b/tests/o3/norm_test.py
@@ -65,3 +65,17 @@ def test_norm():
     m(torch.randn(irreps_in.dim))
     assert_equivariant(m)
     assert_auto_jitable(m)
+
+
+def test_grad():
+    """Confirm has zero grad at zero"""
+    irreps_in = o3.Irreps("2x0e + 3x0o")
+    norm = o3.Norm(irreps_in)
+    with torch.autograd.set_detect_anomaly(True):
+        inp = torch.zeros(norm.irreps_in.dim, requires_grad=True)
+        out = norm(inp)
+        grads = torch.autograd.grad(
+            outputs=out.sum(),
+            inputs=inp,
+        )[0]
+        assert torch.allclose(grads, torch.zeros(1))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
- Specialized code for `o3.Norm` that avoids both einsums and concatenations (uses `segment_csr` for fast sums)
- `epsilon` option in `o3.Norm` for avoiding gradient NaNs when feature has norm zero
- Use the above `epsilon` in `NormActivation` to avoid gradient NaNs
- Option to return squared norms in `o3.Norm`.

## Motivation and Context
This updated option now correctly reproduces `norm_with_epsilon` from TFN (https://github.com/tensorfieldnetworks/tensorfieldnetworks/blob/master/tensorfieldnetworks/utils.py#L22) and avoids, to the extend possible with norm nonlinearities, the gradient/asymptote issues at zero.

## How Has This Been Tested?

- e3nn test suite
- new tests
- resolved issue in real world network

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).