### PR TITLE
Fix GPU device issue in equivariance testing

### DIFF
--- a/e3nn/util/_argtools.py
+++ b/e3nn/util/_argtools.py
@@ -12,10 +12,11 @@ def _transform(dat, irreps_dat, rot_mat, translation=0.):
         if irreps is None:
             out.append(a)
         elif irreps == 'cartesian_points':
-            out.append((a @ rot_mat.T) + translation)
+            translation = torch.as_tensor(translation, device=a.device)
+            out.append((a @ rot_mat.T.to(a.device)) + translation)
         else:
             # For o3.Irreps
-            out.append(a @ irreps.D_from_matrix(rot_mat).T)
+            out.append(a @ irreps.D_from_matrix(rot_mat).T.to(a.device))
     return out
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Make `_argtools._transform`, which is used internally by `equivariance_error`, automatically move the translation + rotation tensors to the same device as the data being transformed.

## Motivation and Context
Make equivariance testing posible on GPU.

## How Has This Been Tested?
- e3nn tests
- use in code

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).