### PR TITLE
Fix `NormActivation` NaN gradients; `squared` for `Norm`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Most recent change on the bottom.
 
 ## [Unreleased]
+### Added
+- `squared` option to `o3.Norm`
+
+### Fixed
+- No more NaN gradients of `o3.Norm`/`nn.NormActivation` at zero when using `epsilon`
 
 ## [0.2.7] - 2021-04-14
 ### Added

--- a/e3nn/nn/_normact.py
+++ b/e3nn/nn/_normact.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 import torch
 
 from e3nn import o3
@@ -7,30 +9,21 @@ from e3nn.util.jit import compile_mode
 @compile_mode('trace')
 class NormActivation(torch.nn.Module):
     r"""Norm-based activation function
-
     Applies a scalar nonlinearity to the norm of each irrep and ouputs a (normalized) version of that irrep multiplied by the scalar output of the scalar nonlinearity.
-
-
     Parameters
     ----------
     irreps_in : `Irreps`
         representation of the input
-
     scalar_nonlinearity : callable
         scalar nonlinearity such as ``torch.sigmoid``
-
     normalize : bool
         whether to normalize the input features before multiplying them by the scalars from the nonlinearity
-
-    epsilon : float
-        when ``normalize`ing, norms smaller than ``epsilon`` will be clamped to ``epsilon`` to avoid division by zero
-
+    epsilon : float, optional
+        when ``normalize``ing, norms smaller than ``epsilon`` will be clamped up to ``epsilon`` to avoid division by zero and NaN gradients. Not allowed when ``normalize`` is False.
     bias : bool
         whether to apply a learnable additive bias to the inputs of the ``scalar_nonlinearity``
-
     Examples
     --------
-
     >>> n = NormActivation("2x1e", torch.sigmoid)
     >>> feats = torch.ones(1, 2*3)
     >>> print(feats.reshape(1, 2, 3).norm(dim=-1))
@@ -40,18 +33,36 @@ class NormActivation(torch.nn.Module):
     >>> print(n(feats).reshape(1, 2, 3).norm(dim=-1))
     tensor([[0.8497, 0.8497]])
     """
-    def __init__(self,
-                 irreps_in,
-                 scalar_nonlinearity,
-                 normalize=True,
-                 epsilon=1e-8,
-                 bias=False):
+    epsilon: Optional[float]
+    _eps_squared: float
+
+    def __init__(
+        self,
+        irreps_in,
+        scalar_nonlinearity: Callable,
+        normalize: bool = True,
+        epsilon: Optional[float] = None,
+        bias: bool = False
+    ):
         super().__init__()
         self.irreps_in = o3.Irreps(irreps_in)
         self.irreps_out = o3.Irreps(irreps_in)
-        self.norm = o3.Norm(irreps_in)
+
+        if epsilon is None and normalize:
+            epsilon = 1e-8
+        elif epsilon is not None and not normalize:
+            raise ValueError("epsilon and normalize = False don't make sense together")
+        elif not epsilon > 0:
+            raise ValueError(f"epsilon {epsilon} is invalid, must be strictly positive.")
+        self.epsilon = epsilon
+        if self.epsilon is not None:
+            self._eps_squared = epsilon * epsilon
+        else:
+            self._eps_squared = 0.0  # doesn't matter
+
+        # if we have an epsilon, use squared and do the sqrt ourselves
+        self.norm = o3.Norm(irreps_in, squared=(epsilon is not None))
         self.scalar_nonlinearity = scalar_nonlinearity
-        self.register_buffer('epsilon', torch.as_tensor(epsilon))
         self.normalize = normalize
         self.bias = bias
         if self.bias:
@@ -64,31 +75,28 @@ class NormActivation(torch.nn.Module):
 
     def forward(self, features):
         '''evaluate
-
         Parameters
         ----------
         features : `torch.Tensor`
             tensor of shape ``(..., irreps_in.dim)``
-
         Returns
         -------
         `torch.Tensor`
             tensor of shape ``(..., irreps_in.dim)``
         '''
         norms = self.norm(features)
+        if self._eps_squared > 0:
+            # See TFN for the original version of this approach:
+            # https://github.com/tensorfieldnetworks/tensorfieldnetworks/blob/master/tensorfieldnetworks/utils.py#L22
+            norms[norms < self._eps_squared] = self._eps_squared
+            norms = norms.sqrt()
 
-        # Apply nonlinearity
+        nonlin_arg = norms
+        if self.bias:
+            nonlin_arg = nonlin_arg + self.biases
+
+        scalings = self.scalar_nonlinearity(nonlin_arg)
         if self.normalize:
-            epsilon_norms = norms.clone()
-            epsilon_norms[epsilon_norms < self.epsilon] = self.epsilon
-            nonlin_arg = epsilon_norms
-            if self.bias:
-                nonlin_arg = nonlin_arg + self.biases
-            scalings = self.scalar_nonlinearity(nonlin_arg) / epsilon_norms
-        else:
-            nonlin_arg = norms
-            if self.bias:
-                nonlin_arg = nonlin_arg + self.biases
-            scalings = self.scalar_nonlinearity(nonlin_arg)
+            scalings = scalings / norms
 
         return self.scalar_multiplier(scalings, features)

--- a/e3nn/o3/_norm.py
+++ b/e3nn/o3/_norm.py
@@ -14,8 +14,7 @@ class Norm(torch.nn.Module):
         representation of the input
 
     squared : bool, optional
-        Whether to return the squared norm. ``False`` by default, i.e. the norm itself (sqrt of squared norm) is returned. Setting this to ``True`` in situations where the extra power of two doesn't matter can help avoid NaNs in gradients from square
-        roots.
+        Whether to return the squared norm. ``False`` by default, i.e. the norm itself (sqrt of squared norm) is returned.
 
     Examples
     --------

--- a/e3nn/o3/_norm.py
+++ b/e3nn/o3/_norm.py
@@ -4,17 +4,18 @@ from e3nn import o3
 from e3nn.util.jit import compile_mode
 
 
-@compile_mode('script')
+@compile_mode('trace')
 class Norm(torch.nn.Module):
-    r"""Norm operation
+    r"""Norm of each irrep in a direct sum of irreps.
 
     Parameters
     ----------
     irreps_in : `Irreps`
         representation of the input
 
-    normalization : {'component', 'norm'}
-        see `TensorProduct`
+    squared : bool, optional
+        Whether to return the squared norm. ``False`` by default, i.e. the norm itself (sqrt of squared norm) is returned. Setting this to ``True`` in situations where the extra power of two doesn't matter can help avoid NaNs in gradients from square
+        roots.
 
     Examples
     --------
@@ -24,9 +25,12 @@ class Norm(torch.nn.Module):
     >>> norm(torch.randn(17 * 3)).shape
     torch.Size([17])
     """
+    squared: bool
+
     def __init__(
         self,
         irreps_in,
+        squared: bool = False
     ):
         super().__init__()
 
@@ -48,12 +52,13 @@ class Norm(torch.nn.Module):
 
         self.irreps_in = irreps_in
         self.irreps_out = irreps_out.simplify()
+        self.squared = squared
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.irreps_in})"
 
     def forward(self, features):
-        """evaluate
+        """Compute norms of irreps in ``features``.
 
         Parameters
         ----------
@@ -65,4 +70,9 @@ class Norm(torch.nn.Module):
         `torch.Tensor`
             tensor of shape ``(..., irreps_out.dim)``
         """
-        return self.tp(features, features).sqrt()
+        out = self.tp(features, features)
+        if self.squared:
+            return out
+        else:
+            # ReLU fixes gradients at zero
+            return out.relu().sqrt()

--- a/tests/o3/norm_test.py
+++ b/tests/o3/norm_test.py
@@ -1,0 +1,34 @@
+import pytest
+
+import torch
+
+from e3nn import o3
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps
+
+
+@pytest.mark.parametrize(
+    "irreps_in", ["", "5x0e", "1e + 2e + 4x1e + 3x3o"] + random_irreps(n=4)
+)
+@pytest.mark.parametrize("squared", [True, False])
+def test_norm(irreps_in, squared):
+    m = o3.Norm(irreps_in, squared=squared)
+    m(torch.randn(m.irreps_in.dim))
+    if m.irreps_in.dim == 0:
+        return
+    assert_equivariant(m)
+    assert_auto_jitable(m)
+
+
+@pytest.mark.parametrize("squared", [True, False])
+def test_grad(squared):
+    """Confirm has zero grad at zero"""
+    irreps_in = o3.Irreps("2x0e + 3x0o")
+    norm = o3.Norm(irreps_in, squared=squared)
+    with torch.autograd.set_detect_anomaly(True):
+        inp = torch.zeros(norm.irreps_in.dim, requires_grad=True)
+        out = norm(inp)
+        grads = torch.autograd.grad(
+            outputs=out.sum(),
+            inputs=inp,
+        )[0]
+        assert torch.allclose(grads, torch.zeros(1))

--- a/tests/o3/norm_test.py
+++ b/tests/o3/norm_test.py
@@ -32,3 +32,17 @@ def test_grad(squared):
             inputs=inp,
         )[0]
         assert torch.allclose(grads, torch.zeros(1))
+
+
+@pytest.mark.parametrize("squared", [True, False])
+def test_vector_norm(squared):
+    n = 10
+    batch = 3
+    irreps_in = o3.Irreps([(n, (1, -1))])
+    vecs = torch.randn(batch, n, 3)
+    norm_mod = o3.Norm(irreps_in, squared=squared)
+    norms = norm_mod(vecs.reshape(batch, -1))
+    norms_true = vecs.norm(dim=-1)
+    if squared:
+        norms_true.square_()
+    assert torch.allclose(norms_true, norms.reshape(batch, n))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
- Corrected `epsilon` in `NormActivation` to avoid gradient NaNs
- Option to return squared norms in `o3.Norm`.
- ReLU trick from @mariogeiger to avoid gradient issues in `o3.Norm` at zero

## Motivation and Context
This updated option now correctly reproduces `norm_with_epsilon` from TFN (https://github.com/tensorfieldnetworks/tensorfieldnetworks/blob/master/tensorfieldnetworks/utils.py#L22) and avoids, to the extend possible with norm nonlinearities, the gradient/asymptote issues at zero.

## How Has This Been Tested?

- e3nn test suite
- new tests
- resolved issue in real world network

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).