### PR TITLE
Fix trace compile with dtypes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ Most recent change on the bottom.
 
 ### Fixed
 - No more NaN gradients of `o3.Norm`/`nn.NormActivation` at zero when using `epsilon`
+- Modules with `@compile_mode('trace')` can now be compiled when their dtype and the current default dtype are different
 
 ## [0.2.7] - 2021-04-14
 ### Added

--- a/e3nn/util/_argtools.py
+++ b/e3nn/util/_argtools.py
@@ -97,14 +97,41 @@ def _get_device(mod: torch.nn.Module) -> torch.device:
     return a_buf.device if a_buf is not None else 'cpu'
 
 
-def _to_device(args, device):
+def _get_floating_dtype(mod: torch.nn.Module) -> torch.dtype:
+    """Guess floating dtype for module.
+
+    Assumes no mixed precision.
+    """
+    FLOATING_DTYPES = [torch.float32, torch.float64]
+    # Try to a get a parameter
+    a_buf = None
+    for buf in mod.parameters():
+        if buf.dtype in FLOATING_DTYPES:
+            a_buf = buf
+            break
+    if a_buf is None:
+        # If there isn't one, try to get a buffer
+        for buf in mod.buffers():
+            if buf.dtype in FLOATING_DTYPES:
+                a_buf = buf
+                break
+    return a_buf.dtype if a_buf is not None else torch.get_default_dtype()
+
+
+def _to_device_dtype(args, device=None, dtype=None):
+    kwargs = {}
+    if device is not None:
+        kwargs['device'] = device
+    if dtype is not None:
+        kwargs['dtype'] = dtype
+
     if isinstance(args, torch.Tensor):
-        return args.to(device=device)
+        return args.to(**kwargs)
     elif isinstance(args, tuple):
-        return tuple(_to_device(e, device) for e in args)
+        return tuple(_to_device_dtype(e, **kwargs) for e in args)
     elif isinstance(args, list):
-        return [_to_device(e, device) for e in args]
+        return [_to_device_dtype(e, **kwargs) for e in args]
     elif isinstance(args, dict):
-        return{k: _to_device(v, device) for k, v in args.items()}
+        return{k: _to_device_dtype(v, **kwargs) for k, v in args.items()}
     else:
-        raise TypeError("Only (nested) dict/tuple/lists of Tensors can be moved to a device.")
+        raise TypeError("Only (nested) dict/tuple/lists of Tensors can be moved to a device/dtype.")

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -122,7 +122,8 @@ def compile(
 def get_tracing_inputs(
     mod: torch.nn.Module,
     n: int = 1,
-    device: Optional[torch.device] = None
+    device: Optional[torch.device] = None,
+    dtype: Optional[torch.dtype] = None
 ):
     """Get random tracing inputs for ``mod``.
 
@@ -136,7 +137,9 @@ def get_tracing_inputs(
         n : int, default = 1
             A hint for how many inputs are wanted. Usually n will be returned, but modules don't necessarily have to.
         device : torch.device
-            The device to do tracing on.
+            The device to do tracing on. If `None` (default), will be guessed.
+        dtype : torch.dtype
+            The dtype to trace with. If `None` (default), will be guessed.
 
     Returns
     -------
@@ -144,7 +147,7 @@ def get_tracing_inputs(
         Tracing inputs in the format of ``torch.jit.trace_module``: dicts mapping method names like ``'forward'`` to tuples of arguments.
     """
     # Avoid circular imports
-    from ._argtools import _get_io_irreps, _rand_args, _to_device, _get_device
+    from ._argtools import _get_io_irreps, _rand_args, _to_device_dtype, _get_device, _get_floating_dtype
     # - Get inputs -
     if hasattr(mod, _MAKE_TRACING_INPUTS):
         # This returns a trace_module style dict of method names to test inputs
@@ -163,8 +166,10 @@ def get_tracing_inputs(
     # - Put them on the right device -
     if device is None:
         device = _get_device(mod)
+    if dtype is None:
+        dtype = _get_floating_dtype(mod)
     # Move them
-    trace_inputs = _to_device(trace_inputs, device)
+    trace_inputs = _to_device_dtype(trace_inputs, device, dtype)
     return trace_inputs
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Fix `_get_tracing_inputs` to guess the dtype of a module, as well as its device, so that modules with dtypes different than the current default dtype can still be compiled. (E.g. models loaded from another process with a different default dtype.)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).