### PR TITLE
FX-only codegen

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         flake8 . --count --show-source --statistics
     - name: Install dependencies
       env:
-        TORCH: "1.8.1"
+        TORCH: "1.8.0"
         TORCHG: "1.8.0"
         CUDA: "cpu"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Most recent change on the bottom.
 
 ## [Unreleased]
+### Changed
+- Generated code (modules like `TensorProduct`, `Linear`, `Extract`) now pickled using TorchScript IR, rather than Python source code.
+- e3nn now only requires PyTorch >= 1.8.0 rather than 1.8.1
 
 ## [0.2.8] - 2021-04-21
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,11 +4,11 @@
 
 ### PyTorch
 
-e3nn requires PyTorch >=1.8.1 For installation instructions, please see the [PyTorch homepage](https://pytorch.org/).
+e3nn requires PyTorch >=1.8.0 For installation instructions, please see the [PyTorch homepage](https://pytorch.org/).
 
 ### optional: torch_geometric
 
-First you have to install [pytorch_geometric](https://github.com/rusty1s/pytorch_geometric). For `torch` 1.8.1 and no CUDA support:
+First you have to install [pytorch_geometric](https://github.com/rusty1s/pytorch_geometric). For `torch` 1.8.* and no CUDA support:
 
 ```bash
 TORCH=1.8.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ plotly
 jupyter-sphinx
 
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.8.1+cpu
+torch==1.8.0+cpu
 
 --find-links https://pytorch-geometric.com/whl/torch-1.8.0+cpu.html
 torch-scatter

--- a/e3nn/o3/_angular_spherical_harmonics.py
+++ b/e3nn/o3/_angular_spherical_harmonics.py
@@ -117,7 +117,6 @@ def legendre(l, z, y=None):
 _legendre_code = """
 import torch
 
-@torch.jit.script
 def main(z: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     out = z.new_zeros(z.shape + (lsize,))
 
@@ -145,7 +144,7 @@ def _legendre_genjit(ls):
     code = _legendre_code
     code = code.replace("lsize", str(sum(2 * l + 1 for l in ls)))
     code = code.replace("# fill out", fill)
-    return eval_code(code).main
+    return torch.jit.script(eval_code(code)["main"])
 
 
 def _poly_legendre(l, m):

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -7,11 +7,12 @@ from torch import fx
 import e3nn
 from e3nn import o3
 from e3nn.util.jit import compile_mode
+from e3nn.util.codegen import CodeGenMixin
 from ._tensor_product._codegen import _sum_tensors
 
 
 @compile_mode('script')
-class Linear(torch.nn.Module):
+class Linear(CodeGenMixin, torch.nn.Module):
     r"""Linear operation equivariant to :math:`O(3)`
 
     Parameters
@@ -83,10 +84,9 @@ class Linear(torch.nn.Module):
             shared_weights=shared_weights,
             optimize_einsums=self._optimize_einsums
         )
-        self._compiled_main = torch.jit.script(fx.GraphModule(
-            root=self,
-            graph=graph
-        ))
+        self._codegen_register({
+            "_compiled_main": graph
+        })
 
         # == Generate weights ==
         if internal_weights and self.weight_numel > 0:

--- a/e3nn/o3/_reduce.py
+++ b/e3nn/o3/_reduce.py
@@ -251,7 +251,7 @@ class ReducedTensorProducts(fx.GraphModule):
             if isinstance(path, _INPUT):
                 out = inputs[path.tensor]
                 if (path.start, path.stop) != (0, self.irreps_in[path.tensor].dim):
-                    out = out[..., path.start:path.stop]
+                    out = out.narrow(-1, path.start, path.stop - path.start)
             if isinstance(path, _TP):
                 x1 = evaluate(path.args[0]).node
                 x2 = evaluate(path.args[1]).node

--- a/e3nn/o3/_reduce.py
+++ b/e3nn/o3/_reduce.py
@@ -274,7 +274,9 @@ class ReducedTensorProducts(fx.GraphModule):
         self.recompile()
 
     def __repr__(self):
-        return f"""{self.__class__.__name__}(
-    in: {' times '.join(map(repr, self.irreps_in))}
-    out: {self.irreps_out}
-)"""
+        return (
+            f"ReducedTensorProducts(\n"
+            f"    in: {' times '.join(map(repr, self.irreps_in))}\n"
+            f"    out: {self.irreps_out}\n"
+            ")"
+        )

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -6,6 +6,7 @@ import torch.fx
 import e3nn
 from e3nn import o3
 from e3nn.util.jit import compile_mode
+from e3nn.util.codegen import CodeGenMixin
 from e3nn.util import prod
 
 from ._instruction import Instruction
@@ -13,7 +14,7 @@ from ._codegen import codegen_tensor_product
 
 
 @compile_mode('script')
-class TensorProduct(torch.nn.Module):
+class TensorProduct(CodeGenMixin, torch.nn.Module):
     r"""Tensor product with parametrized paths.
 
     Parameters
@@ -268,15 +269,10 @@ class TensorProduct(torch.nn.Module):
             self._specialized_code,
             self._optimize_einsums
         )
-        # We always compile the internal code:
-        self._compiled_main_out = torch.jit.script(torch.fx.GraphModule(
-            root=self,
-            graph=graph_out
-        ))
-        self._compiled_main_right = torch.jit.script(torch.fx.GraphModule(
-            root=self,
-            graph=graph_right
-        ))
+        self._codegen_register({
+            "_compiled_main_out": graph_out,
+            "_compiled_main_right": graph_right
+        })
 
         self._wigners = wigners
 

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -5,26 +5,27 @@ import torch
 from torch import fx
 
 
-def _dummy_getstate():
-    return None
-
-
 class CodeGenMixin:
     """Mixin for classes that dynamically generate TorchScript code using FX.
 
-    This class manages evaluating and compiling generated code for subclasses while remaining pickle/deepcopy compatible. If subclasses need to override ``__getstate__``/``__setstate__``, they should be sure to call CodeGenMixin's first and use its output.
+    This class manages evaluating and compiling generated code for subclasses
+    while remaining pickle/deepcopy compatible. If subclasses need to override
+    ``__getstate__``/``__setstate__``, they should be sure to call CodeGenMixin's
+    implimentation first and use its output.
     """
     def _codegen_register(
         self,
         funcs: Dict[str, fx.Graph],
         compile: bool = True
     ) -> None:
-        """Register dynamically generated methods.
+        """Register ``fx.Graph``s as TorchScript submodules.
+
+        ``fx.GraphModule``s will be built with the current module as their ``root``.
 
         Parameters
         ----------
             funcs : Dict[str, fx.Graph]
-                Dictionary mapping method names to their code.
+                Dictionary mapping submodule names to graphs.
         """
         if not hasattr(self, "__codegen__"):
             # list of submodule names that are managed by this object
@@ -39,37 +40,51 @@ class CodeGenMixin:
                 class_name=fname
             ))
             assert isinstance(scriptmod, torch.jit.ScriptModule)
-            # To prevent pickle from erroring, even though we don't actually try
-            # to serialize the scriptmodule.
-            scriptmod.__getstate__ = _dummy_getstate
             # Add the ScriptModule as a submodule so it can be called
             setattr(self, fname, scriptmod)
 
     # In order to support copy.deepcopy and pickling, we need to not save the compiled TorchScript functions:
     # See pickle docs: https://docs.python.org/3/library/pickle.html#pickling-class-instances
-    # torch.nn.Module does not currently impliment __get/setstate__ but may in the future, which is why we have these hasattr checks for other superclasses.
     def __getstate__(self):
         # - Get a state to work with -
         # We need to check if other parent classes of self define __getstate__
+        # torch.nn.Module does not currently impliment __get/setstate__ but
+        # may in the future, which is why we have these hasattr checks for
+        # other superclasses.
         if hasattr(super(CodeGenMixin, self), "__getstate__"):
-            out = super(CodeGenMixin, self).__getstate__().copy()
+            out = super(CodeGenMixin, self).__getstate__()
         else:
-            out = self.__dict__.copy()
-        # - Remove compiled methods -
+            out = self.__dict__
+
+        out = out.copy()
+        # We need a copy of the _modules OrderedDict
+        # Otherwise, modifying the returned state will modify the current module itself
+        out["_modules"] = out["_modules"].copy()
+
+        # - Add saved versions of the ScriptModules to the state -
+        codegen_state = {}
         if hasattr(self, "__codegen__"):
-            # We cant save compiled functions
             for fname in self.__codegen__:
+                # Get the module
                 smod = getattr(self, fname)
+                assert isinstance(smod, torch.jit.ScriptModule)
                 # Save the compiled code as TorchScript IR
                 buffer = io.BytesIO()
                 torch.jit.save(smod, buffer)
                 # Serialize that IR (just some `bytes`) instead of
                 # the ScriptModule
-                out[fname] = buffer.getvalue()
+                codegen_state[fname] = buffer.getvalue()
+                # Remove the compiled submodule from being a submodule
+                # of the saved module
+                del out["_modules"][fname]
+
+            out["__codegen__"] = codegen_state
         return out
 
     def __setstate__(self, d):
         d = d.copy()
+        # We don't want to add this to the object when we call super's __setstate__
+        codegen_state = d.pop("__codegen__", None)
 
         # We need to initialize self first so that we can add submodules
         # We need to check if other parent classes of self define __getstate__
@@ -78,17 +93,15 @@ class CodeGenMixin:
         else:
             self.__dict__.update(d)
 
-        if "__codegen__" in d:
-            codegen_state = d.pop("__codegen__")
-            for fname in codegen_state:
+        if codegen_state is not None:
+            for fname, buffer in codegen_state.items():
+                assert isinstance(fname, str)
                 # Make sure bytes, not ScriptModules, got made
-                assert isinstance(getattr(self, fname), bytes)
-                # Load the TorchScript IR buffer
-                buffer = d[fname]
                 assert isinstance(buffer, bytes)
+                # Load the TorchScript IR buffer
                 buffer = io.BytesIO(buffer)
                 smod = torch.jit.load(buffer)
                 assert isinstance(smod, torch.jit.ScriptModule)
                 # Add the ScriptModule as a submodule
                 setattr(self, fname, smod)
-            self.__codegen__ = codegen_state
+            self.__codegen__ = list(codegen_state.keys())

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'sympy',
         'scipy',   # only for SphericalTensor.find_peaks
-        'torch>=1.8.1',  # >= 1.8 is required for FX
+        'torch>=1.8.0',  # >= 1.8 is required for FX
     ],
     include_package_data=True,
     classifiers=[

--- a/tests/nn/extract_test.py
+++ b/tests/nn/extract_test.py
@@ -1,7 +1,9 @@
+import pytest
+
 import torch
 
 from e3nn.nn import Extract, ExtractIr
-from e3nn.util.test import assert_auto_jitable
+from e3nn.util.test import assert_auto_jitable, assert_equivariant
 
 
 def test_extract():
@@ -9,6 +11,21 @@ def test_extract():
     out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     assert out == (torch.Tensor([1.]), torch.Tensor([2.]))
     assert_auto_jitable(c)
+    assert_equivariant(c, irreps_out=list(c.irreps_outs))
+
+
+@pytest.mark.parametrize("squeeze", [True, False])
+def test_extract_single(squeeze):
+    c = Extract('1e + 0e + 0e', ['0e'], [(1,)], squeeze_out=squeeze)
+    out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
+    if squeeze:
+        assert isinstance(out, torch.Tensor)
+    else:
+        assert len(out) == 1
+        out = out[0]
+    assert out == torch.Tensor([1.])
+    assert_auto_jitable(c)
+    assert_equivariant(c, irreps_out=list(c.irreps_outs))
 
 
 def test_extract_ir():
@@ -16,3 +33,4 @@ def test_extract_ir():
     out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     assert torch.all(out == torch.Tensor([1., 2.]))
     assert_auto_jitable(c)
+    assert_equivariant(c)

--- a/tests/nn/extract_test.py
+++ b/tests/nn/extract_test.py
@@ -1,5 +1,7 @@
 import pytest
 
+import copy
+
 import torch
 
 from e3nn.nn import Extract, ExtractIr
@@ -34,3 +36,10 @@ def test_extract_ir():
     assert torch.all(out == torch.Tensor([1., 2.]))
     assert_auto_jitable(c)
     assert_equivariant(c)
+
+
+def test_copy():
+    c = Extract('1e + 0e + 0e', ['0e', '0e'], [(1,), (2,)])
+    _ = copy.deepcopy(c)
+    c = ExtractIr('1e + 0e + 0e', '0e')
+    _ = copy.deepcopy(c)

--- a/tests/nn/models/gate_points_2101_test.py
+++ b/tests/nn/models/gate_points_2101_test.py
@@ -121,8 +121,14 @@ def test_copy(network):
 
 def test_save(network):
     f, random_graph = network
+    # Get a saved, loaded network
     with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
         torch.save(f, tmp.name)
         f2 = torch.load(tmp.name)
     x = random_graph()
     assert torch.all(f(x) == f2(x))
+    # Get a double-saved network
+    with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
+        torch.save(f2, tmp.name)
+        f3 = torch.load(tmp.name)
+    assert torch.all(f(x) == f3(x))

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -421,17 +421,25 @@ def test_deepcopy(l1, p1, l2, p2, lo, po, mode, weight):
 @pytest.mark.parametrize('l1, p1, l2, p2, lo, po, mode, weight', random_params(n=1))
 def test_save(l1, p1, l2, p2, lo, po, mode, weight):
     tp = make_tp(l1, p1, l2, p2, lo, po, mode, weight)
+    # Saved TP
     with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
         torch.save(tp, tmp.name)
         tp2 = torch.load(tmp.name)
+    # JITed, saved TP
     with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
         tp_jit = assert_auto_jitable(tp)
         tp_jit.save(tmp.name)
         tp3 = torch.jit.load(tmp.name)
+    # Double-saved TP
+    with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
+        torch.save(tp2, tmp.name)
+        tp4 = torch.load(tmp.name)
     x1 = torch.randn(2, tp.irreps_in1.dim)
     x2 = torch.randn(2, tp.irreps_in2.dim)
     res1 = tp(x1, x2)
     res2 = tp2(x1, x2)
     res3 = tp3(x1, x2)
+    res4 = tp4(x1, x2)
     assert torch.allclose(res1, res2)
     assert torch.allclose(res1, res3)
+    assert torch.allclose(res1, res4)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Initial work on FX-only codegen:

- [X] Pure FX TensorProduct
- [X] Pure FX Linear
- [X] Pure FX Extract / ExtractIr
- [X] Simplified `ExtractIr` without submodules
- [X] `ReducedTensorProduct` without `Ellipsis` using [`torch.narrow`](https://pytorch.org/docs/stable/generated/torch.narrow.html) — this removes the need for PyTorch 1.8.1, allowing 1.8.0 support to be maintained

Issues remaining:

- [x] Use of `eval_code` in `angular_spherical_harmonics` has to be somehow changed if we want to remove `eval_code` entirely
- [x] Copying + saving of models: pickling a `ScriptModule` isn't possible, so `TensorProduct` and `Linear` may still need to use a modified version of `CodeGenMixin` to manage pickle state with `fx.Graph`s instead of strings. Not clear yet what has to be done here.

## How Has This Been Tested?
e3nn test suite

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).