### PR TITLE
Use `.is_floating_point()`

### DIFF
--- a/e3nn/util/_argtools.py
+++ b/e3nn/util/_argtools.py
@@ -97,9 +97,6 @@ def _get_device(mod: torch.nn.Module) -> torch.device:
     return a_buf.device if a_buf is not None else 'cpu'
 
 
-_FLOATING_DTYPES = [torch.float32, torch.float64]
-
-
 def _get_floating_dtype(mod: torch.nn.Module) -> torch.dtype:
     """Guess floating dtype for module.
 
@@ -108,13 +105,13 @@ def _get_floating_dtype(mod: torch.nn.Module) -> torch.dtype:
     # Try to a get a parameter
     a_buf = None
     for buf in mod.parameters():
-        if buf.dtype in _FLOATING_DTYPES:
+        if buf.is_floating_point():
             a_buf = buf
             break
     if a_buf is None:
         # If there isn't one, try to get a buffer
         for buf in mod.buffers():
-            if buf.dtype in _FLOATING_DTYPES:
+            if buf.is_floating_point():
                 a_buf = buf
                 break
     return a_buf.dtype if a_buf is not None else torch.get_default_dtype()
@@ -128,7 +125,7 @@ def _to_device_dtype(args, device=None, dtype=None):
         kwargs['dtype'] = dtype
 
     if isinstance(args, torch.Tensor):
-        if args.dtype in _FLOATING_DTYPES:
+        if args.is_floating_point():
             # Only convert dtypes of floating tensors
             return args.to(device=device, dtype=dtype)
         else:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Use [`.is_floating_point()`](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.is_floating_point) instead of the `_FLOATING_TYPES` hack; this should in theory fix edge cases we haven't seen yet for strange floating point types like `float16`, `tensorfloat32` (NVIDIA Ampere), etc. It's also just cleaner + more correct.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).