### PR TITLE
Normalization testing; small `Activation` improvement

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Most recent change on the bottom.
 
 ## [Unreleased]
+### Added
+- Normalization testing with `assert_normalized`
 
 ## [0.2.8] - 2021-04-21
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Most recent change on the bottom.
 ## [Unreleased]
 ### Added
 - Normalization testing with `assert_normalized`
+- Optional logging for equivariance and normalization tests
 
 ## [0.2.8] - 2021-04-21
 ### Added

--- a/docs/guide/equivar_testing.rst
+++ b/docs/guide/equivar_testing.rst
@@ -82,3 +82,10 @@ To test equivariance on a specific graph, ``args_in`` can be used:
         args_in=[my_pos, my_x],
         irreps_out=[f.irreps_out],
     )
+
+Logging
+-------
+``assert_equivariant`` also logs the equivariance error to the ``e3nn.util.test`` logger with level ``INFO`` regardless of whether the test fails. When running in pytest, these logs can be seen using the `"Live Logs" feature <https://docs.pytest.org/en/stable/logging.html#live-logs>`_:
+
+.. code::
+    pytest tests/ --log-cli-level info

--- a/docs/guide/normalization.rst
+++ b/docs/guide/normalization.rst
@@ -78,3 +78,14 @@ It imply that the two first moments of :math:`x \cdot w` (and therefore mean and
                                   &= \sum_{i} \sum_{j} \langle x_i x_j \rangle \langle w_i w_j \rangle
 
                                   &= \sigma^2 \sum_{i} \langle x_i^2 \rangle
+
+Testing
+-------
+
+You can use ``e3nn.util.test.assert_normalized`` to check whether a function or module is normalized at initialization:
+
+.. code::
+
+    from e3nn.util.test import assert_normalized
+    from e3nn import o3
+    assert_normalized(o3.Linear("10x0e", "10x0e"))

--- a/e3nn/nn/_activation.py
+++ b/e3nn/nn/_activation.py
@@ -96,7 +96,9 @@ class Activation(torch.nn.Module):
                     output.append(features.narrow(dim, index, mul * ir.dim))
                 index += mul * ir.dim
 
-            if output:
+            if len(output) > 1:
                 return torch.cat(output, dim=dim)
+            elif len(output) == 1:
+                return output[0]
             else:
                 return torch.zeros_like(features)

--- a/e3nn/util/_argtools.py
+++ b/e3nn/util/_argtools.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import random
 import warnings
 
@@ -76,11 +78,12 @@ def _get_args_in(func, args_in=None, irreps_in=None, irreps_out=None):
     return args_in, irreps_in, irreps_out
 
 
-def _rand_args(irreps_in):
+def _rand_args(irreps_in, batch_size: Optional[int] = None):
     if not all((isinstance(i, Irreps) or i == 'cartesian_points') for i in irreps_in):
         raise ValueError("Random arguments cannot be generated when argument types besides Irreps and `'cartesian_points'` are specified; provide explicit ``args_in``")
-    # Generate random args with random size batch dim between 1 and 4:
-    batch_size = random.randint(1, 4)
+    if batch_size is None:
+        # Generate random args with random size batch dim between 1 and 4:
+        batch_size = random.randint(1, 4)
     args_in = [
         torch.randn(batch_size, 3) if (irreps == 'cartesian_points') else irreps.randn(batch_size, -1)
         for irreps in irreps_in

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -386,17 +386,14 @@ def assert_normalized(
             tolerance for checking moments. Higher values for this prevent explosive computational costs for this test.
     """
     # Prevent pytest from showing this function in the traceback
-    #__tracebackhide__ = True
+    __tracebackhide__ = True
 
     if normalization not in ("component", "norm"):
         raise ValueError(f"invalid normalization `{normalization}`")
 
     irreps_in, irreps_out = _get_io_irreps(func, irreps_in=irreps_in, irreps_out=irreps_out)
 
-    if (
-        all(i.num_irreps == 0 for i in irreps_in) or \
-        all(i.num_irreps == 0 for i in irreps_out)
-    ):
+    if all(i.num_irreps == 0 for i in irreps_in) or all(i.num_irreps == 0 for i in irreps_out):
         # Short-circut
         return
 

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -453,7 +453,6 @@ def assert_normalized(
             targets = [1.0 / math.sqrt(ir.dim) for _, ir in irreps]
 
         for i, (target, ir_slice) in enumerate(zip(targets, irreps.slices())):
-            print(expected_square)
             assert torch.allclose(
                 expected_square[ir_slice],
                 torch.as_tensor(target),

--- a/tests/nn/activation_test.py
+++ b/tests/nn/activation_test.py
@@ -1,0 +1,30 @@
+import pytest
+
+import torch
+
+from e3nn import o3
+from e3nn.nn import Activation
+from e3nn.util.test import assert_equivariant, assert_auto_jitable
+
+
+@pytest.mark.parametrize(
+    "irreps_in,acts",
+    [
+        ("256x0o", [torch.abs]),
+        ("37x0e", [torch.tanh]),
+        ("4x0e + 3x0o", [torch.nn.functional.silu, torch.abs])
+    ]
+)
+def test_activation(irreps_in, acts):
+    irreps_in = o3.Irreps(irreps_in)
+    a = Activation(irreps_in, acts)
+    assert_auto_jitable(a)
+    assert_equivariant(a)
+
+    inp = irreps_in.randn(13, -1)
+    out = a(inp)
+    for ir_slice, act in zip(irreps_in.slices(), acts):
+        this_out = out[:, ir_slice]
+        true_up_to_factor = act(inp[:, ir_slice])
+        factors = this_out / true_up_to_factor
+        assert torch.allclose(factors, factors[0])

--- a/tests/nn/activation_test.py
+++ b/tests/nn/activation_test.py
@@ -4,7 +4,7 @@ import torch
 
 from e3nn import o3
 from e3nn.nn import Activation
-from e3nn.util.test import assert_equivariant, assert_auto_jitable
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, assert_normalized
 
 
 @pytest.mark.parametrize(
@@ -28,3 +28,5 @@ def test_activation(irreps_in, acts):
         true_up_to_factor = act(inp[:, ir_slice])
         factors = this_out / true_up_to_factor
         assert torch.allclose(factors, factors[0])
+
+    assert_normalized(a)

--- a/tests/nn/gate_test.py
+++ b/tests/nn/gate_test.py
@@ -3,7 +3,7 @@ import torch
 from e3nn.o3 import Irreps
 from e3nn.nn import Gate
 from e3nn.nn._gate import _Sortcut
-from e3nn.util.test import assert_equivariant, assert_auto_jitable
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, assert_normalized
 
 
 def test_gate():
@@ -15,3 +15,4 @@ def test_gate():
     g = Gate(irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated)
     assert_equivariant(g)
     assert_auto_jitable(g)
+    assert_normalized(g)

--- a/tests/nn/gate_test.py
+++ b/tests/nn/gate_test.py
@@ -1,14 +1,9 @@
 import torch
 
 from e3nn.o3 import Irreps
-from e3nn.nn import Gate, Activation
+from e3nn.nn import Gate
 from e3nn.nn._gate import _Sortcut
 from e3nn.util.test import assert_equivariant, assert_auto_jitable
-
-
-def test_activation():
-    a = Activation("256x0o", [torch.abs])
-    assert_auto_jitable(a)
 
 
 def test_gate():

--- a/tests/nn/normact_test.py
+++ b/tests/nn/normact_test.py
@@ -20,6 +20,7 @@ def test_norm_activation(float_tolerance, do_bias, nonlin):
     norm_act = NormActivation(
         irreps_in=irreps_in,
         scalar_nonlinearity=nonlin,
+        normalize=True,
         bias=do_bias
     )
 

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -61,8 +61,8 @@ def test_linear():
     assert_normalized(
         m,
         n_weight=125,
-        n_input=5000,
-        atol=0.2  # Linear admits stricter
+        n_input=10_000,
+        atol=0.3
     )
 
 

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -62,7 +62,7 @@ def test_linear():
         m,
         n_weight=125,
         n_input=10_000,
-        atol=0.3
+        atol=0.4
     )
 
 

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -5,7 +5,7 @@ from typing import Optional
 import torch
 
 from e3nn import o3
-from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps, assert_normalized
 
 
 class SlowLinear(torch.nn.Module):
@@ -58,6 +58,12 @@ def test_linear():
 
     assert_equivariant(m)
     assert_auto_jitable(m)
+    assert_normalized(
+        m,
+        n_weight=125,
+        n_input=5000,
+        atol=0.2  # Linear admits stricter
+    )
 
 
 def test_single_out():

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -60,7 +60,7 @@ def test_linear():
     assert_auto_jitable(m)
     assert_normalized(
         m,
-        n_weight=50,
+        n_weight=75,
         n_input=10_000,
         atol=0.5
     )

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -60,9 +60,9 @@ def test_linear():
     assert_auto_jitable(m)
     assert_normalized(
         m,
-        n_weight=125,
+        n_weight=50,
         n_input=10_000,
-        atol=0.4
+        atol=0.5
     )
 
 

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -4,10 +4,15 @@ import copy
 import pytest
 import torch
 from e3nn.o3 import TensorProduct, FullyConnectedTensorProduct, Irreps
-from e3nn.util.test import assert_equivariant, assert_auto_jitable
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, assert_normalized
 
 
-def make_tp(l1, p1, l2, p2, lo, po, mode, weight, **kwargs):
+def make_tp(
+    l1, p1, l2, p2, lo, po, mode, weight,
+    mul: int = 25,
+    path_weights: bool = True,
+    **kwargs
+):
     def mul_out(mul):
         if mode == "uvuv":
             return mul**2
@@ -15,14 +20,14 @@ def make_tp(l1, p1, l2, p2, lo, po, mode, weight, **kwargs):
 
     try:
         return TensorProduct(
-            [(25, (l1, p1)), (19, (l1, p1))],
-            [(25, (l2, p2)), (19, (l2, p2))],
-            [(mul_out(25), (lo, po)), (mul_out(19), (lo, po))],
+            [(mul, (l1, p1)), (19, (l1, p1))],
+            [(mul, (l2, p2)), (19, (l2, p2))],
+            [(mul_out(mul), (lo, po)), (mul_out(19), (lo, po))],
             [
                 (0, 0, 0, mode, weight),
                 (1, 1, 1, mode, weight),
-                (0, 0, 1, 'uvw', True, 0.5),
-                (0, 1, 1, 'uvw', True, 0.2),
+                (0, 0, 1, 'uvw', True, 0.5 if path_weights else 1.0),
+                (0, 1, 1, 'uvw', True, 0.2 if path_weights else 1.0),
             ],
             **kwargs
         )
@@ -79,6 +84,27 @@ def test(float_tolerance, l1, p1, l2, p2, lo, po, mode, weight):
 
     # equivariance
     assert_equivariant(m, irreps_in=[m.irreps_in1, m.irreps_in2], irreps_out=m.irreps_out)
+
+
+# This is a fairly expensive test, so we don't run too many configs
+@pytest.mark.parametrize('l1, p1, l2, p2, lo, po, mode, weight', random_params(n=8))
+def test_normalized(l1, p1, l2, p2, lo, po, mode, weight):
+    if torch.get_default_dtype() != torch.float32:
+        pytest.skip(
+            "No reason to run expensive normalization tests again at float64 expense."
+        )
+    # Explicit fixed path weights screw with the output normalization,
+    # so don't use them
+    m = make_tp(l1, p1, l2, p2, lo, po, mode, weight, mul=5, path_weights=False)
+    # normalization
+    # n_weight, n_input has to be decently high to ensure statistical convergence
+    # especially for uvuv
+    assert_normalized(
+        m,
+        n_weight=100,
+        n_input=10_000,
+        atol=0.4
+    )
 
 
 @pytest.mark.parametrize('normalization', ['component', 'norm'])

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -101,9 +101,9 @@ def test_normalized(l1, p1, l2, p2, lo, po, mode, weight):
     # especially for uvuv
     assert_normalized(
         m,
-        n_weight=100,
+        n_weight=75,
         n_input=10_000,
-        atol=0.4
+        atol=0.5
     )
 
 

--- a/tests/util/test_test.py
+++ b/tests/util/test_test.py
@@ -47,6 +47,6 @@ def test_bad_normalize():
 def test_normalized_ident():
     def ident(x1):
         return x1
-    ident.irreps_in = random_irreps(clean=True,  allow_empty=False)
+    ident.irreps_in = random_irreps(clean=True, allow_empty=False)
     ident.irreps_out = ident.irreps_in
     assert_normalized(ident)

--- a/tests/util/test_test.py
+++ b/tests/util/test_test.py
@@ -2,25 +2,51 @@ import pytest
 
 import torch
 
-from e3nn.util.test import assert_equivariant, assert_auto_jitable
+from e3nn import o3
+from e3nn.util.jit import compile_mode
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, assert_normalized, random_irreps
 
 
-@pytest.mark.xfail
 def test_assert_equivariant():
     def not_equivariant(x1, x2):
         return x1*x2
-    not_equivariant.irreps_in1 = "2x0e + 1x1e + 3x2o + 1x4e"
-    not_equivariant.irreps_in2 = "2x0o + 3x0o + 3x2e + 1x4o"
-    assert_equivariant(not_equivariant)
+    not_equivariant.irreps_in1 = o3.Irreps("2x0e + 1x1e + 3x2o + 1x4e")
+    not_equivariant.irreps_in2 = o3.Irreps("2x0o + 3x0o + 3x2e + 1x4o")
+    not_equivariant.irreps_out = o3.Irreps("1x1e + 2x0o + 3x2e + 1x4o")
+    assert not_equivariant.irreps_in1.dim == not_equivariant.irreps_in2.dim
+    assert not_equivariant.irreps_in1.dim == not_equivariant.irreps_out.dim
+    with pytest.raises(AssertionError):
+        assert_equivariant(not_equivariant)
 
 
-@pytest.mark.xfail
 def test_jit_trace():
-    def not_tracable(param):
-        if param.shape[0] == 7:
-            return torch.ones(8)
-        else:
-            return torch.randn(8, 3)
-    not_tracable.irreps_in = "2x0e"
-    not_tracable.irreps_out = "1x1o"
-    assert_auto_jitable(not_tracable)
+    @compile_mode('trace')
+    class NotTracable(torch.nn.Module):
+        def forward(self, param):
+            if param.shape[0] == 7:
+                return torch.ones(8)
+            else:
+                return torch.randn(8, 3)
+    not_tracable = NotTracable()
+    not_tracable.irreps_in = o3.Irreps("2x0e")
+    not_tracable.irreps_out = o3.Irreps("1x1o")
+    # TorchScript returns some weird exceptions...
+    with pytest.raises(Exception):
+        assert_auto_jitable(not_tracable)
+
+
+def test_bad_normalize():
+    def not_normal(x1):
+        return 870.0 * x1.square().relu()
+    not_normal.irreps_in = random_irreps(clean=True, allow_empty=False)
+    not_normal.irreps_out = not_normal.irreps_in
+    with pytest.raises(AssertionError):
+        assert_normalized(not_normal)
+
+
+def test_normalized_ident():
+    def ident(x1):
+        return x1
+    ident.irreps_in = random_irreps(clean=True,  allow_empty=False)
+    ident.irreps_out = ident.irreps_in
+    assert_normalized(ident)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Done:

- Avoid `torch.cat` when unneeded in `Activation`
- More tests for `Activation`
- Added `assert_normalized` and use for various modules
- Weight support in `assert_normalized`
- `assert_normalized` for `Linear`, `TensorProduct` tests

## How Has This Been Tested?
e3nn tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).