### PR TITLE
Small tetris example improvements; related fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Most recent change on the bottom.
 ### Added
 - Normalization testing with `assert_normalized`
 - Optional logging for equivariance and normalization tests
+- Public `e3nn.util.test.format_equivariance_error` method for printing equivariance test results
 
 ### Changed
 - Generated code (modules like `TensorProduct`, `Linear`, `Extract`) now pickled using TorchScript IR, rather than Python source code.

--- a/e3nn/o3/_spherical_harmonics.py
+++ b/e3nn/o3/_spherical_harmonics.py
@@ -146,9 +146,11 @@ def spherical_harmonics(
         tensor :math:`x` of shape ``(..., 3)``.
 
     normalize : bool
-        normalize ``x`` on the sphere
+        whether to normalize the ``x`` to unit vectors that lie on the sphere before projecting onto the spherical harmonics
 
     normalization : {'integral', 'component', 'norm'}
+        normalization of the output tensors --- note that this option is independent of ``normalize``, which controls the processing of the *input*, rather than the output.
+        Valid options:
         * *component*: :math:`\|Y^l(x)\|^2 = 2l+1, x \in S^2`
         * *norm*: :math:`\|Y^l(x)\| = 1, x \in S^2`, ``component / sqrt(2l+1)``
         * *integral*: :math:`\int_{S^2} Y^l_m(x)^2 dx = 1`, ``component / sqrt(4pi)``

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -136,7 +136,18 @@ def random_irreps(
         return out
 
 
-def _format_equivar_error(errors: dict) -> str:
+def format_equivariance_error(errors: dict) -> str:
+    """Format the dictionary returned by ``equivariance_error`` into a readable string.
+
+    Parameters
+    ----------
+        errors : dict
+            A dictionary of errors returned by ``equivariance_error``.
+
+    Returns
+    -------
+        A string.
+    """
     return "; ".join(
         "(parity_k={:d}, did_translate={}) -> error={:.3e}".format(
             int(k[0]),
@@ -196,7 +207,7 @@ def assert_equivariant(
     logger.info(
         "Tested equivariance of %s -- max componentwise errors: %s",
         _logging_name(func),
-        _format_equivar_error(errors),
+        format_equivariance_error(errors),
     )
 
     # Check it
@@ -207,7 +218,7 @@ def assert_equivariant(
 
     if len(problems) != 0:
         errstr = "Largest componentwise equivariance error was too large for: "
-        errstr += _format_equivar_error(problems)
+        errstr += format_equivariance_error(problems)
         assert len(problems) == 0, errstr
 
     return errors

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -205,7 +205,7 @@ def assert_equivariant(
     )
 
     logger.info(
-        "Tested equivariance of %s -- max componentwise errors: %s",
+        "Tested equivariance of `%s` -- max componentwise errors: %s",
         _logging_name(func),
         format_equivariance_error(errors),
     )

--- a/examples/tetris_gate.py
+++ b/examples/tetris_gate.py
@@ -168,8 +168,10 @@ def main():
     # `assert_equivariant` also tests parity and translation, and
     # can handle non-(psuedo)scalar outputs.
     # To "interpret" between it and torch_geometric, we use a small wrapper:
+
     def wrapper(pos, batch):
         return f(Data(pos=pos, batch=batch))
+
     # `assert_equivariant` uses logging to print a summary of the equivariance error,
     # so we enable logging
     logging.basicConfig(level=logging.INFO)

--- a/examples/tetris_polynomial.py
+++ b/examples/tetris_polynomial.py
@@ -139,8 +139,10 @@ def main():
     # `assert_equivariant` also tests parity and translation, and
     # can handle non-(psuedo)scalar outputs.
     # To "interpret" between it and torch_geometric, we use a small wrapper:
+
     def wrapper(pos, batch):
         return f(Data(pos=pos, batch=batch))
+
     # `assert_equivariant` uses logging to print a summary of the equivariance error,
     # so we enable logging
     logging.basicConfig(level=logging.INFO)

--- a/examples/tetris_polynomial.py
+++ b/examples/tetris_polynomial.py
@@ -10,6 +10,8 @@ This example is minimal:
 
 >>> test()
 """
+import logging
+
 import torch
 from torch_cluster import radius_graph
 from torch_geometric.data import Data, DataLoader
@@ -127,20 +129,31 @@ def main():
     # == Check equivariance ==
     # Because the model outputs (psuedo)scalars, we can easily directly
     # check its equivariance to the same data with new rotations:
+    print("Testing equivariance directly...")
     rotated_data, _ = tetris()
     error = f(rotated_data) - f(data)
     print(f"Equivariance error = {error.abs().max().item():.1e}")
 
+    print("Testing equivariance using `assert_equivariance`...")
     # We can also use the library's `assert_equivariant` helper
     # `assert_equivariant` also tests parity and translation, and
     # can handle non-(psuedo)scalar outputs.
     # To "interpret" between it and torch_geometric, we use a small wrapper:
-    def wrapper(pos):
-        return f(Data(pos=pos, batch=torch.zeros(len(pos), dtype=torch.long)))
+    def wrapper(pos, batch):
+        return f(Data(pos=pos, batch=batch))
+    # `assert_equivariant` uses logging to print a summary of the equivariance error,
+    # so we enable logging
+    logging.basicConfig(level=logging.INFO)
     assert_equivariant(
         wrapper,
-        args_in=[data.pos],
-        irreps_in=["cartesian_points"],
+        # We provide the original data that `assert_equivariant` will transform...
+        args_in=[data.pos, data.batch],
+        # ...in accordance with these irreps...
+        irreps_in=[
+            "cartesian_points",  # pos has vector 1o irreps, but is also translation equivariant
+            None,  # `None` indicates invariant, possibly non-floating-point data
+        ],
+        # ...and confirm that the outputs transform correspondingly for these irreps:
         irreps_out=[f.irreps_out],
     )
 

--- a/tests/o3/cartesian_spherical_harmonics_test.py
+++ b/tests/o3/cartesian_spherical_harmonics_test.py
@@ -152,15 +152,8 @@ def test_recurrence_relation(float_tolerance, l):
     assert (a - b).abs().max() < 100*float_tolerance
 
 
-@pytest.mark.parametrize(
-    "normalization,normalize",
-    [
-        ("integral", True),
-        ("component", True),
-        ("norm", True),
-        ("component", False)  # doesn't matter which we use for False
-    ]
-)
+@pytest.mark.parametrize("normalization", ["integral", "component", "norm"])
+@pytest.mark.parametrize("normalize", [True, False])
 def test_module(normalization, normalize):
     l = o3.Irreps("0e + 1o + 3o")
     sp = o3.SphericalHarmonics(l, normalize, normalization)

--- a/tests/o3/cartesian_spherical_harmonics_test.py
+++ b/tests/o3/cartesian_spherical_harmonics_test.py
@@ -152,10 +152,17 @@ def test_recurrence_relation(float_tolerance, l):
     assert (a - b).abs().max() < 100*float_tolerance
 
 
-def test_module():
+@pytest.mark.parametrize(
+    "normalization,normalize",
+    [
+        ("integral", True),
+        ("component", True),
+        ("norm", True),
+        ("component", False)  # doesn't matter which we use for False
+    ]
+)
+def test_module(normalization, normalize):
     l = o3.Irreps("0e + 1o + 3o")
-    normalize = True
-    normalization = 'integral'
     sp = o3.SphericalHarmonics(l, normalize, normalization)
     sp_jit = assert_auto_jitable(sp)
     xyz = torch.randn(11, 3)

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -60,7 +60,7 @@ def test_linear():
     assert_auto_jitable(m)
     assert_normalized(
         m,
-        n_weight=75,
+        n_weight=100,
         n_input=10_000,
         atol=0.5
     )

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -102,7 +102,7 @@ def test_normalized(l1, p1, l2, p2, lo, po, mode, weight):
     # especially for uvuv
     assert_normalized(
         m,
-        n_weight=75,
+        n_weight=100,
         n_input=10_000,
         atol=0.5
     )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

- Fixed accuracy metric for tetris examples (accuracy should be how many shapes are correctly classified, not how many rounded one-hot labels are right)
- Print more info in tetris examples
- Make `format_equivariance_error` public
- Add some more comprehensive tests to `o3.SphericalHarmonics`
- Add `assert_equivariant` to tetris examples as a demonstration of the full-featured way to test equivariance

## How Has This Been Tested?
e3nn tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [x] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).