### PR TITLE
Instructions for `o3.Linear`; zero multiplicities fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ Most recent change on the bottom.
 
 ### Fixed
 - `TensorProduct` can now gracefully handle multiplicities of zero
+- `weight_views`/`weight_view_for_instruction` methods now support `shared_weights=False`
 
 ## [0.2.9] - 2021-05-04
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,9 @@ Most recent change on the bottom.
 - Instruction support for `o3.Linear`
 - `o3.Linear.weight_views` and `o3.Linear.weight_view_for_instruction`
 
+### Changed
+- `o3.Linear` no longer automatically simplifies its `irreps_in` or `irreps_out`. If you want this behaviour, simplify your irreps explicitly!
+
 ## [0.2.9] - 2021-05-04
 ### Added
 - Normalization testing with `assert_normalized`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,9 @@ Most recent change on the bottom.
 ### Changed
 - `o3.Linear` no longer automatically simplifies its `irreps_in` or `irreps_out`. If you want this behaviour, simplify your irreps explicitly!
 
+### Fixed
+- `TensorProduct` can now gracefully handle multiplicities of zero
+
 ## [0.2.9] - 2021-05-04
 ### Added
 - Normalization testing with `assert_normalized`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Most recent change on the bottom.
 
 ## [Unreleased]
+### Added
+- Instruction support for `o3.Linear`
+- `o3.Linear.weight_views` and `o3.Linear.weight_view_for_instruction`
 
 ## [0.2.9] - 2021-05-04
 ### Added

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -533,7 +533,7 @@ class Irreps(tuple):
         --------
 
         >>> Irreps("4x0e + 0x1o + 2x3e").remove_zero_multiplicities()
-        4x0e + 2x3e
+        4x0e+2x3e
 
         """
         out = [(mul, ir) for mul, ir in self if mul > 0]

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -522,6 +522,23 @@ class Irreps(tuple):
                 out.append((mul, ir))
         return Irreps(out)
 
+    def remove_zero_multiplicities(self):
+        """Remove any irreps with multiplicities of zero.
+
+        Returns
+        -------
+        `Irreps`
+
+        Examples
+        --------
+
+        >>> Irreps("4x0e + 0x1o + 2x3e").remove_zero_multiplicities()
+        4x0e + 2x3e
+
+        """
+        out = [(mul, ir) for mul, ir in self if mul > 0]
+        return Irreps(out)
+
     def sort(self):
         r"""Sort the representations.
 

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -178,7 +178,10 @@ class Linear(CodeGenMixin, torch.nn.Module):
         if self.irreps_out.dim > 0:
             output_mask = torch.cat([
                 torch.ones(mul_ir.dim)
-                if any(ins.i_out == i_out for ins in self.instructions)
+                if any(
+                    (ins.i_out == i_out) and (0 not in ins.path_shape)
+                    for ins in self.instructions
+                )
                 else torch.zeros(mul_ir.dim)
                 for i_out, mul_ir in enumerate(self.irreps_out)
             ])

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -80,6 +80,8 @@ class Linear(CodeGenMixin, torch.nn.Module):
     >>> with torch.no_grad():
     ...     lin1.weight.fill_(1.0)
     ...     lin2.weight.fill_(1.0)
+    Parameter containing:
+    ...
     >>> x = torch.arange(10.0)
     >>> (lin1(x) - lin2(x)).abs().item() > 0.1
     True

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -208,7 +208,9 @@ class Linear(CodeGenMixin, torch.nn.Module):
         `torch.Tensor`
             A view on ``weight`` or this object's internal weights for the weights corresponding to the ``instruction`` th instruction.
         """
-        weight = self.weight if weight is None else weight
+        if weight is None:
+            assert self.internal_weights, "Weights must be provided when internal_weights = False"
+            weight = self.weight
         offset = sum(prod(ins.path_shape) for ins in self.instructions[:instruction])
         ins = self.instructions[instruction]
         return weight[offset:offset + prod(ins.path_shape)].view(ins.path_shape)
@@ -233,7 +235,9 @@ class Linear(CodeGenMixin, torch.nn.Module):
         If ``yield_instruction`` is ``True``, yields ``(instruction_index, instruction, weight_view)``.
         Otherwise, yields ``weight_view``.
         """
-        weight = self.weight if weight is None else weight
+        if weight is None:
+            assert self.internal_weights, "Weights must be provided when internal_weights = False"
+            weight = self.weight
         offset = 0
         for ins_i, ins in enumerate(self.instructions):
             flatsize = prod(ins.path_shape)

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -132,6 +132,7 @@ class Linear(CodeGenMixin, torch.nn.Module):
                 for i_out, (_, ir_out) in enumerate(self.irreps_out)
                 if ir_in == ir_out
             ]
+            # note that "empty" instructions to/from empty irreps are dealt with in the codegen
 
         instruction_objs = []
         for i_in, i_out in instructions:
@@ -286,6 +287,9 @@ def _codegen_linear(
     outsize = size + (irreps_out.dim,)
 
     # = Short-circut for nothing to do =
+    # We produce no code for empty instructions
+    instructions = [ins for ins in instructions if 0 not in ins.path_shape]
+
     if len(instructions) == 0:
         out = x.new_zeros(outsize)
 
@@ -358,6 +362,7 @@ def _codegen_linear(
             like=x
         )
         for i_out, mul_ir_out in enumerate(irreps_out)
+        if mul_ir_out.mul > 0
     ]
     if len(out) > 1:
         out = torch.cat(out, dim=1)

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -55,7 +55,10 @@ def codegen_tensor_product(
         size_right = torch.broadcast_tensors(empty_right.expand(x2s_right.shape[:-1]), empty_right.expand(ws_right.shape[:-1]))[0].shape
 
     # = Short-circut for zero dimensional =
-    if irreps_in1.dim == 0 or irreps_in2.dim == 0 or irreps_out.dim == 0:
+    # We produce no code for empty instructions
+    instructions = [ins for ins in instructions if 0 not in ins.path_shape]
+
+    if len(instructions) == 0:
         out_out = x1s_out.new_zeros(size_out + (irreps_out.dim,))
         out_right = x2s_right.new_zeros(size_right + (irreps_in1.dim, irreps_out.dim,))
 
@@ -372,6 +375,7 @@ def codegen_tensor_product(
             like=x1s_out
         )
         for i_out, mul_ir_out in enumerate(irreps_out)
+        if mul_ir_out.mul > 0
     ]
     if len(out_out) > 1:
         out_out = torch.cat(out_out, dim=1)
@@ -387,8 +391,10 @@ def codegen_tensor_product(
                 like=x2s_right
             )
             for i_out, mul_ir_out in enumerate(irreps_out)
+            if mul_ir_out.mul > 0
         ], dim=2)
         for i_in1, mul_ir_in1 in enumerate(irreps_in1)
+        if mul_ir_in1.mul > 0
     ]
     if len(out_right) > 1:
         out_right = torch.cat(out_right, dim=1)

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -307,7 +307,10 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         if self.irreps_out.dim > 0:
             output_mask = torch.cat([
                 torch.ones(mul * ir.dim)
-                if any(i.i_out == i_out and i.path_weight > 0 for i in self.instructions)
+                if any(
+                    (ins.i_out == i_out) and (ins.path_weight != 0) and (0 not in ins.path_shape)
+                    for ins in self.instructions
+                )
                 else torch.zeros(mul * ir.dim)
                 for i_out, (mul, ir) in enumerate(self.irreps_out)
             ])

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -182,3 +182,22 @@ def test_weight_view():
         m.weight_view_for_instruction(1).fill_(0.0)
     out = m(inp)
     assert torch.allclose(out[:, :6], torch.zeros(1))
+
+
+def test_weight_view_unshared():
+    m = o3.Linear(
+        "4x0e + 3x1o + 2x0e",
+        "2x1o + 8x0e",
+        instructions=[(0, 1), (1, 0)],
+        shared_weights=False
+    )
+    batchdim = 7
+    inp = m.irreps_in.randn(batchdim, -1)
+    weights = torch.randn(batchdim, m.weight_numel)
+    assert m.weight_view_for_instruction(0, weights).shape == (batchdim, 4, 8)
+    assert m.weight_view_for_instruction(1, weights).shape == (batchdim, 3, 2)
+    # Make weights going to output 0 all zeros
+    with torch.no_grad():
+        m.weight_view_for_instruction(1, weights).fill_(0.0)
+    out = m(inp, weights)
+    assert torch.allclose(out[:, :6], torch.zeros(1))

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -20,8 +20,8 @@ class SlowLinear(torch.nn.Module):
     ):
         super().__init__()
 
-        irreps_in = o3.Irreps(irreps_in).simplify()
-        irreps_out = o3.Irreps(irreps_out).simplify()
+        irreps_in = o3.Irreps(irreps_in)
+        irreps_out = o3.Irreps(irreps_out)
 
         instr = [
             (i_in, 0, i_out, "uvw", True, 1.0)
@@ -80,12 +80,12 @@ def test_single_out():
     assert torch.all(out2[:, 5:] == 0)
 
 
-# We want to be sure to test a multiple-same L case and a single irrep case
+# We want to be sure to test a multiple-same L case, a single irrep case, and an empty irrep case
 @pytest.mark.parametrize(
-    "irreps_in", ["5x0e", "1e + 2e + 4x1e + 3x3o"] + random_irreps(n=4)
+    "irreps_in", ["5x0e", "1e + 2e + 4x1e + 3x3o", "2x1o + 0x3e"] + random_irreps(n=4)
 )
 @pytest.mark.parametrize(
-    "irreps_out", ["5x0e", "1e + 2e + 3x3o + 3x1e"] + random_irreps(n=4)
+    "irreps_out", ["5x0e", "1e + 2e + 3x3o + 3x1e", "2x1o + 0x3e"] + random_irreps(n=4)
 )
 def test_linear_like_tp(irreps_in, irreps_out):
     """Test that Linear gives the same results as the corresponding TensorProduct."""
@@ -97,7 +97,7 @@ def test_linear_like_tp(irreps_in, irreps_out):
     assert torch.allclose(
         m(inp),
         m_true(inp),
-        atol={torch.float32: 1e-7, torch.float64: 1e-10}[torch.get_default_dtype()],
+        atol={torch.float32: 1e-6, torch.float64: 1e-10}[torch.get_default_dtype()],
     )
 
 

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -166,3 +166,19 @@ def test_instructions():
     inp[:, :m.irreps_in[:2].dim] = 0.0
     out = m(inp)
     assert torch.allclose(out, torch.zeros(1))
+
+
+def test_weight_view():
+    m = o3.Linear(
+        "4x0e + 3x1o + 2x0e",
+        "2x1o + 8x0e",
+        instructions=[(0, 1), (1, 0)]
+    )
+    inp = m.irreps_in.randn(3, -1)
+    assert m.weight_view_for_instruction(0).shape == (4, 8)
+    assert m.weight_view_for_instruction(1).shape == (3, 2)
+    # Make weights going to output 0 all zeros
+    with torch.no_grad():
+        m.weight_view_for_instruction(1).fill_(0.0)
+    out = m(inp)
+    assert torch.allclose(out[:, :6], torch.zeros(1))

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -108,6 +108,23 @@ def test_normalized(l1, p1, l2, p2, lo, po, mode, weight):
     )
 
 
+def test_empty():
+    m = TensorProduct(
+        "0x0e + 1o + 2e",
+        "0e + 1o + 2e",
+        "0x0e + 1o",
+        [
+            (0, 0, 0, "uvw", True),
+            (1, 1, 0, "uvw", True),
+        ],
+    )
+    x1, x2 = m.irreps_in1.randn(4, -1), m.irreps_in2.randn(4, -1)
+    out = m(x1, x2)
+    assert out.shape == (4, m.irreps_out.dim)
+    assert torch.all(out == 0.0)  # no instruction leads to the 1o output
+    m.right(x2)
+
+
 @pytest.mark.parametrize('normalization', ['component', 'norm'])
 @pytest.mark.parametrize(
     'mode,weighted',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

- Allow instructions to be specified to `o3.Linear` to mix only certain irreps
- Weight view methods for `o3.Linear`
- Fix zero multiplicities for TensorProduct
- Make weight views support `shared_weights=False`

## Motivation and Context
Previously, there was no public way to interpret the `.weight` of an `o3.Linear`, since the order of paths was not exposed.

## How Has This Been Tested?
e3nn tests

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).