### PR TITLE
SimpleNetwork -- move preprocessing to method for easy overwriting

### DIFF
--- a/e3nn/nn/models/v2103/gate_points_networks.py
+++ b/e3nn/nn/models/v2103/gate_points_networks.py
@@ -69,10 +69,12 @@ class SimpleNetwork(torch.nn.Module):
         # Edge attributes
         edge_vec = data['pos'][edge_src] - data['pos'][edge_dst]
 
-        return batch, edge_index, edge_src, edge_dst, edge_vec
+        return batch, data['x'], edge_src, edge_dst, edge_vec
 
     def forward(self, data: Union[Data, Dict[str, torch.Tensor]]) -> torch.Tensor:
-        batch, edge_index, edge_src, edge_dst, edge_vec = self.preprocess(data)
+        batch, node_inputs, edge_src, edge_dst, edge_vec = self.preprocess(data)
+        del data
+
         edge_attr = o3.spherical_harmonics(range(self.lmax + 1), edge_vec, True, normalization='component')
 
         # Edge length embedding
@@ -87,9 +89,9 @@ class SimpleNetwork(torch.nn.Module):
         ).mul(self.number_of_basis**0.5)
 
         # Node attributes are not used here
-        node_attr = data['pos'].new_ones(data['pos'].shape[0], 1)
+        node_attr = node_inputs.new_ones(node_inputs.shape[0], 1)
 
-        node_outputs = self.mp(data['x'], node_attr, edge_src, edge_dst, edge_attr, edge_length_embedding)
+        node_outputs = self.mp(node_inputs, node_attr, edge_src, edge_dst, edge_attr, edge_length_embedding)
 
         if self.pool_nodes:
             return scatter(node_outputs, batch, dim=0).div(self.num_nodes**0.5)

--- a/e3nn/nn/models/v2103/gate_points_networks.py
+++ b/e3nn/nn/models/v2103/gate_points_networks.py
@@ -54,7 +54,7 @@ class SimpleNetwork(torch.nn.Module):
 
         self.irreps_in = self.mp.irreps_node_input
         self.irreps_out = self.mp.irreps_node_output
-    
+
     def preprocess(self, data: Union[Data, Dict[str, torch.Tensor]]) -> torch.Tensor:
         if 'batch' in data:
             batch = data['batch']

--- a/e3nn/nn/models/v2103/gate_points_networks.py
+++ b/e3nn/nn/models/v2103/gate_points_networks.py
@@ -54,8 +54,8 @@ class SimpleNetwork(torch.nn.Module):
 
         self.irreps_in = self.mp.irreps_node_input
         self.irreps_out = self.mp.irreps_node_output
-
-    def forward(self, data: Union[Data, Dict[str, torch.Tensor]]) -> torch.Tensor:
+    
+    def preprocess(self, data: Union[Data, Dict[str, torch.Tensor]]) -> torch.Tensor:
         if 'batch' in data:
             batch = data['batch']
         else:
@@ -68,6 +68,11 @@ class SimpleNetwork(torch.nn.Module):
 
         # Edge attributes
         edge_vec = data['pos'][edge_src] - data['pos'][edge_dst]
+
+        return batch, edge_index, edge_src, edge_dst, edge_vec
+
+    def forward(self, data: Union[Data, Dict[str, torch.Tensor]]) -> torch.Tensor:
+        batch, edge_index, edge_src, edge_dst, edge_vec = self.preprocess(data)
         edge_attr = o3.spherical_harmonics(range(self.lmax + 1), edge_vec, True, normalization='component')
 
         # Edge length embedding


### PR DESCRIPTION
I have moved the geometric preprocessing step in the forward of SimpleNetwork to a `preprocess` method.

## Motivation and Context
This allows for easy modification of SimpleNetwork for e.g. crystal systems because the method can be easily overwritten.

## How Has This Been Tested?
The behavior of SimpleNetwork is identical, only the organization has changed.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).