### PR TITLE
[WIP] Explicit symbolic backwards pass for `TensorProduct`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ Most recent change on the bottom.
 ### Added
 - `preprocess` function in `e3nn.nn.models.v2103.gate_points_networks.SimpleNetwork`
 - Specialized code for `mode="uuw"`
+- New optimization options:
+  - `instruction_profiling`: whether to insert profiler blocks for individual `TensorProduct` instructions
 
 ## [0.3.0] - 2021-05-10
 ### Added

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -6,7 +6,8 @@ from typing import Dict
 _OPT_DEFAULTS: Dict[str, bool] = dict(
     specialized_code=True,
     optimize_einsums=True,
-    explicit_backward=False
+    explicit_backward=False,
+    instruction_profiling=False
 )
 
 
@@ -14,6 +15,7 @@ def set_optimization_defaults(
     specialized_code: bool = True,
     optimize_einsums: bool = True,
     explicit_backward: bool = False,
+    instruction_profiling: bool = False,
 ) -> None:
     r"""Globally set the default optimization settings.
 
@@ -27,6 +29,7 @@ def set_optimization_defaults(
     _OPT_DEFAULTS['specialized_code'] = specialized_code
     _OPT_DEFAULTS['optimize_einsums'] = optimize_einsums
     _OPT_DEFAULTS['explicit_backward'] = explicit_backward
+    _OPT_DEFAULTS['instruction_profiling'] = instruction_profiling
 
 
 def get_optimization_defaults() -> Dict[str, bool]:

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -5,13 +5,15 @@ from typing import Dict
 
 _OPT_DEFAULTS: Dict[str, bool] = dict(
     specialized_code=True,
-    optimize_einsums=True
+    optimize_einsums=True,
+    explicit_backward=False
 )
 
 
 def set_optimization_defaults(
     specialized_code: bool = True,
-    optimize_einsums: bool = True
+    optimize_einsums: bool = True,
+    explicit_backward: bool = False,
 ) -> None:
     r"""Globally set the default optimization settings.
 
@@ -24,6 +26,7 @@ def set_optimization_defaults(
     """
     _OPT_DEFAULTS['specialized_code'] = specialized_code
     _OPT_DEFAULTS['optimize_einsums'] = optimize_einsums
+    _OPT_DEFAULTS['explicit_backward'] = explicit_backward
 
 
 def get_optimization_defaults() -> Dict[str, bool]:

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -603,12 +603,14 @@ def codegen_tensor_product(
     # ==== end build backward ====
 
     # == Eliminate dead code ==
+    from opt_einsum_fx import fuse_reshapes
     from opt_einsum_fx.fx_utils import eliminate_dead_code
     for gm in (graphmod_out, graphmod_right) + (
         (graphmod_backward,) if explicit_backward
         else tuple()
     ):
         eliminate_dead_code(gm.graph)
+        fuse_reshapes(gm.graph, in_place=True)
         gm.recompile()
 
     # == Optimize ==

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -663,7 +663,12 @@ def codegen_tensor_product(
                 ),
             )
 
-            graphmod_out = jitable(optimize_einsums_full(graphmod_out, example_inputs,))
+            graphmod_out = jitable(optimize_einsums_full(
+                graphmod_out,
+                example_inputs,
+                # if explict backward, we want to do as much as possible in-place
+                in_place_muls=explicit_backward
+            ))
             deduplicate(graphmod_out.graph)
             graphmod_out.recompile()
 

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -2,7 +2,6 @@ from math import sqrt
 from typing import List, Tuple, Union
 import copy
 import itertools
-import operator
 
 import torch
 from torch import fx
@@ -44,7 +43,7 @@ def _combine(tensors: List[fx.Proxy], to: List[int], lengths: List[int], batch_s
         graph: fx.Graph = node0.graph
         with graph.inserting_after(node0):
             bufshape = (batch_shape + (sum(lengths),))
-            bufkwargs={"device": tensors[0].device.node, "dtype": tensors[0].dtype.node}
+            bufkwargs = {"device": tensors[0].device.node, "dtype": tensors[0].dtype.node}
         with graph.inserting_after(bufshape.node):
             buffer = fx.Proxy(graph.call_function(
                 torch.zeros,
@@ -504,6 +503,7 @@ def codegen_tensor_product(
         # - Find certain nodes in the grad graph -
         # There doesn't seem to be a better way to identify nodes across a graph copy
         # since fx.Graph removes all custom Node attributes during copy
+
         def find_in_graph_copy(graph: fx.Graph, nodes: List[Union[fx.Node, fx.Proxy]]) -> List[fx.Node]:
             """ !! NOT a general function --- only works if the graphs are copies."""
             nodes = [n.node if isinstance(n, fx.Proxy) else n for n in nodes]

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -5,7 +5,7 @@ import torch.fx
 
 import e3nn
 from e3nn import o3
-from e3nn.util.jit import compile_mode
+from e3nn.util.jit import compile_mode, set_compile_mode
 from e3nn.util.codegen import CodeGenMixin
 from e3nn.util import prod
 
@@ -309,6 +309,13 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
             "_compiled_main_out": graphmod_out,
             "_compiled_main_right": graphmod_right
         })
+
+        if self.compile_options["explicit_backward"]:
+            # TorchScript doesn't support torch.autograd.Function
+            set_compile_mode(self, "unsupported")
+        else:
+            # ... but everything else is supported.
+            set_compile_mode(self, "script")
 
     def __repr__(self):
         npath = sum(prod(i.path_shape) for i in self.instructions)

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -270,28 +270,10 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
             self._specialized_code,
             self._optimize_einsums
         )
-        graphmod_out = torch.jit.script(graphmod_out)
-        graphmod_backwards = torch.jit.script(graphmod_backwards)
-
-        class _MyForward(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, x1, x2, w):
-                ctx.save_for_backward(x1, x2, w)
-                return graphmod_out(x1, x2, w)
-
-            @staticmethod
-            def backward(ctx, grad):
-                x1, x2, w = ctx.saved_tensors
-                ret =  graphmod_backwards(x1, x2, w, grad)
-                return ret
-
-        self._compiled_main_out = _MyForward.apply
-        self._compiled_main_right = torch.jit.script(graphmod_right)
-
-        # self._codegen_register({
-        #     "_compiled_main_out": graphmod_out,
-        #     "_compiled_main_right": graphmod_right
-        # })
+        self._codegen_register({
+            "_compiled_main_out": (graphmod_out, graphmod_backwards),
+            "_compiled_main_right": graphmod_right
+        })
 
         # === Determine weights ===
         self.weight_numel = sum(prod(ins.path_shape) for ins in self.instructions if ins.has_weight)

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -281,13 +281,15 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         self,
         specialized_code: Optional[bool] = None,
         optimize_einsums: Optional[bool] = None,
-        explicit_backward: Optional[bool] = None
+        explicit_backward: Optional[bool] = None,
+        instruction_profiling: Optional[bool] = None
     ):
         opt_defaults = e3nn.get_optimization_defaults()
         self.compile_options = {}
         self.compile_options['specialized_code'] = specialized_code if specialized_code is not None else opt_defaults['specialized_code']
         self.compile_options['optimize_einsums'] = optimize_einsums if optimize_einsums is not None else opt_defaults['optimize_einsums']
         self.compile_options['explicit_backward'] = explicit_backward if explicit_backward is not None else opt_defaults['explicit_backward']
+        self.compile_options['instruction_profiling'] = instruction_profiling if instruction_profiling is not None else opt_defaults['instruction_profiling']
         del opt_defaults
 
         # Generate the actual tensor product code
@@ -303,7 +305,8 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
             shared_weights=self.shared_weights,
             specialized_code=self.compile_options["specialized_code"],
             optimize_einsums=self.compile_options["optimize_einsums"],
-            explicit_backward=self.compile_options["explicit_backward"]
+            explicit_backward=self.compile_options["explicit_backward"],
+            instruction_profiling=self.compile_options["instruction_profiling"]
         )
         self._codegen_register({
             "_compiled_main_out": graphmod_out,

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -1,8 +1,46 @@
-from typing import Dict
+from typing import Dict, Union, Tuple, Callable
 import io
 
 import torch
 from torch import fx
+
+
+def _make_autograd_func(forward: torch.jit.ScriptModule, backward: torch.jit.ScriptModule) -> Callable:
+    # Make a singleton autograd function
+    # TODO: cache these based on IRs?
+    class _MyFunc(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, *args):
+            ctx.save_for_backward(*args)
+            return _MyFunc._forward(*args)
+
+        @staticmethod
+        def backward(ctx, *grads):
+            args = ctx.saved_tensors + tuple(grads)
+            return _MyFunc._backward(*args)
+    _MyFunc._forward = forward
+    _MyFunc._backward = backward
+    return _MyFunc.apply
+
+
+def _scriptmodule_to_bytes(smod: torch.jit.ScriptModule) -> bytes:
+    assert isinstance(smod, torch.jit.ScriptModule)
+    # Save the compiled code as TorchScript IR
+    buffer = io.BytesIO()
+    torch.jit.save(smod, buffer)
+    # Serialize that IR (just some `bytes`) instead of
+    # the ScriptModule
+    return buffer.getvalue()
+
+
+def _scriptmodule_from_bytes(buffer: bytes) -> torch.jit.ScriptModule:
+    # Make sure bytes, not ScriptModules, got made
+    assert isinstance(buffer, bytes)
+    # Load the TorchScript IR buffer
+    buffer = io.BytesIO(buffer)
+    smod = torch.jit.load(buffer)
+    assert isinstance(smod, torch.jit.ScriptModule)
+    return smod
 
 
 class CodeGenMixin:
@@ -15,26 +53,44 @@ class CodeGenMixin:
     """
     def _codegen_register(
         self,
-        funcs: Dict[str, fx.GraphModule],
+        funcs: Dict[str, Union[fx.GraphModule, Tuple[fx.GraphModule, fx.GraphModule]]],
     ) -> None:
         """Register ``fx.GraphModule``s as TorchScript submodules.
 
         Parameters
         ----------
-            funcs : Dict[str, fx.GraphModule]
+            funcs : Dict[str, Union[fx.GraphModule, Tuple[fx.GraphModule, fx.GraphModule]]]
                 Dictionary mapping submodule names to graph modules.
+                If a value is a two-tuple of graph modules, the first is the forward pass and the second is the backward pass.
         """
         if not hasattr(self, "__codegen__"):
             # list of submodule names that are managed by this object
-            self.__codegen__ = []
-        self.__codegen__.extend(funcs.keys())
+            self.__codegen__ = {}
 
         for fname, graphmod in funcs.items():
-            assert isinstance(graphmod, fx.GraphModule)
-            scriptmod = torch.jit.script(graphmod)
-            assert isinstance(scriptmod, torch.jit.ScriptModule)
-            # Add the ScriptModule as a submodule so it can be called
-            setattr(self, fname, scriptmod)
+            if isinstance(graphmod, fx.GraphModule):
+                forward = graphmod
+                backward = None
+            elif isinstance(graphmod, tuple):
+                assert len(graphmod) == 2
+                forward, backward = graphmod
+                assert isinstance(forward, fx.GraphModule)
+                assert isinstance(backward, fx.GraphModule)
+            else:
+                raise TypeError(f"Invalid code to register `{graphmod}`")
+
+            forward = torch.jit.script(forward)
+            assert isinstance(forward, torch.jit.ScriptModule)
+
+            if backward is None:
+                self.__codegen__[fname] = forward
+                # Add the ScriptModule as a submodule so it can be called
+                setattr(self, fname, forward)
+            else:
+                backward = torch.jit.script(backward)
+                assert isinstance(backward, torch.jit.ScriptModule)
+                self.__codegen__[fname] = (forward, backward)
+                setattr(self, fname, _make_autograd_func(forward, backward))
 
     # In order to support copy.deepcopy and pickling, we need to not save the compiled TorchScript functions:
     # See pickle docs: https://docs.python.org/3/library/pickle.html#pickling-class-instances
@@ -57,19 +113,18 @@ class CodeGenMixin:
         # - Add saved versions of the ScriptModules to the state -
         codegen_state = {}
         if hasattr(self, "__codegen__"):
-            for fname in self.__codegen__:
-                # Get the module
-                smod = getattr(self, fname)
-                assert isinstance(smod, torch.jit.ScriptModule)
-                # Save the compiled code as TorchScript IR
-                buffer = io.BytesIO()
-                torch.jit.save(smod, buffer)
-                # Serialize that IR (just some `bytes`) instead of
-                # the ScriptModule
-                codegen_state[fname] = buffer.getvalue()
-                # Remove the compiled submodule from being a submodule
-                # of the saved module
-                del out["_modules"][fname]
+            for fname, smod in self.__codegen__.items():
+                if isinstance(smod, torch.jit.ScriptModule):
+                    codegen_state[fname] = _scriptmodule_to_bytes(smod)
+                    # Remove the compiled submodule from being a submodule
+                    # of the saved module
+                    del out["_modules"][fname]
+                else:
+                    codegen_state[fname] = tuple(_scriptmodule_to_bytes(mod) for mod in smod)
+                    # no need to remove submodule since it was in an autograd function
+                    # but since its an attribute, and not a submodule, we need to 
+                    # remove it from the __dict__ instead:
+                    del out[fname]
 
             out["__codegen__"] = codegen_state
         return out
@@ -87,14 +142,20 @@ class CodeGenMixin:
             self.__dict__.update(d)
 
         if codegen_state is not None:
+            new_codegen_state = {}
             for fname, buffer in codegen_state.items():
                 assert isinstance(fname, str)
-                # Make sure bytes, not ScriptModules, got made
-                assert isinstance(buffer, bytes)
-                # Load the TorchScript IR buffer
-                buffer = io.BytesIO(buffer)
-                smod = torch.jit.load(buffer)
-                assert isinstance(smod, torch.jit.ScriptModule)
-                # Add the ScriptModule as a submodule
-                setattr(self, fname, smod)
-            self.__codegen__ = list(codegen_state.keys())
+                if isinstance(buffer, bytes):
+                    # its just a forward
+                    # Add the ScriptModule as a submodule
+                    smod = _scriptmodule_from_bytes(buffer)
+                    setattr(self, fname, smod)
+                    new_codegen_state[fname] = smod
+                elif isinstance(buffer, tuple):
+                    assert len(buffer) == 2
+                    forward, backward = (_scriptmodule_from_bytes(b) for b in buffer)
+                    new_codegen_state[fname] = (forward, backward)
+                    setattr(self, fname, _make_autograd_func(forward, backward))
+                else:
+                    raise TypeError
+            self.__codegen__ = new_codegen_state

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -50,6 +50,17 @@ def get_compile_mode(mod: torch.nn.Module) -> str:
     return mode
 
 
+def set_compile_mode(mod: torch.nn.Module, mode: Optional[str]) -> None:
+    """Set the compilation mode of a module.
+
+    Parameters
+    ----------
+        mod : torch.nn.Module
+    """
+    assert mode in _VALID_MODES, "Invalid compile mode `%r`" % mode
+    setattr(mod, _E3NN_COMPILE_MODE, mode)
+
+
 def compile(
     mod: torch.nn.Module,
     n_trace_checks: int = 1,

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -328,9 +328,10 @@ def equivariance_error(
 # Make something else for general script/traceability
 def assert_auto_jitable(
     func,
-    error_on_warnings=True,
-    n_trace_checks=2,
-    strict_shapes=True,
+    error_on_warnings: bool = True,
+    n_trace_checks: int = 2,
+    strict_shapes: bool = True,
+    allow_unsupported: bool = False
 ):
     r"""Assert that submodule ``func`` is automatically JITable.
 
@@ -344,6 +345,8 @@ def assert_auto_jitable(
             If ``args_in`` is ``None`` and arguments are being automatically generated, this many random arguments will be generated as test inputs for ``torch.jit.trace``.
         strict_shapes : bool
             Test that the traced function errors on inputs with feature dimensions that don't match the input irreps.
+        allow_unsupported : bool
+            If True (False by default), does nothing on ``@compile_mode("unsupported")`` modules.
     Returns
     -------
         The traced TorchScript function.
@@ -351,8 +354,13 @@ def assert_auto_jitable(
     # Prevent pytest from showing this function in the traceback
     __tracebackhide__ = True
 
-    if get_compile_mode(func) is None:
+    mode = get_compile_mode(func)
+
+    if mode is None:
         raise ValueError("assert_auto_jitable is only for modules marked with @compile_mode")
+
+    if allow_unsupported and mode == "unsupported":
+        return
 
     # Test tracing
     with warnings.catch_warnings():

--- a/examples/tensor_product_profile.py
+++ b/examples/tensor_product_profile.py
@@ -50,12 +50,15 @@ def main():
     irreps_in1 = Irreps(args.irreps_in1)
     irreps_in2 = Irreps(args.irreps_in2)
     irreps_out = Irreps(args.irreps_out)
+    compile_opts = dict(
+        specialized_code=args.specialized_code,
+        optimize_einsums=args.opt_ein
+    )
     tp = FullyConnectedTensorProduct(
         irreps_in1,
         irreps_in2,
         irreps_out,
-        _specialized_code=args.specialized_code,
-        _optimize_einsums=args.opt_ein
+        compile_options=compile_opts
     )
     tp = tp.to(device=device)
 

--- a/tests/defaults_test.py
+++ b/tests/defaults_test.py
@@ -4,21 +4,21 @@ import e3nn
 def test_opt_defaults():
     a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
     b = e3nn.o3.Linear("4x1o", "4x1o")
-    assert a._specialized_code
-    assert a._optimize_einsums
-    assert b._optimize_einsums
+    assert a.compile_options["specialized_code"]
+    assert a.compile_options["optimize_einsums"]
+    assert b.compile_options["optimize_einsums"]
     old_defaults = e3nn.get_optimization_defaults()
     try:
         e3nn.set_optimization_defaults(optimize_einsums=False)
         a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
         b = e3nn.o3.Linear("4x1o", "4x1o")
-        assert a._specialized_code
-        assert not a._optimize_einsums
-        assert not b._optimize_einsums
+        assert a.compile_options["specialized_code"]
+        assert not a.compile_options["optimize_einsums"]
+        assert not b.compile_options["optimize_einsums"]
     finally:
         e3nn.set_optimization_defaults(**old_defaults)
     a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
     b = e3nn.o3.Linear("4x1o", "3x1o")
-    assert a._specialized_code
-    assert a._optimize_einsums
-    assert b._optimize_einsums
+    assert a.compile_options["specialized_code"]
+    assert a.compile_options["optimize_einsums"]
+    assert b.compile_options["optimize_einsums"]

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -13,7 +13,8 @@ def make_tp(
     l1, p1, l2, p2, lo, po, mode, weight,
     mul: int = 25,
     path_weights: bool = True,
-    **kwargs
+    reraise: bool = True,
+    **kwargs,
 ):
     def mul_out(mul):
         if mode == "uvuv":
@@ -34,7 +35,10 @@ def make_tp(
             **kwargs
         )
     except AssertionError:
-        return None
+        if reraise:
+            raise
+        else:
+            return None
 
 
 def random_params(n=25):
@@ -48,7 +52,7 @@ def random_params(n=25):
         po = random.choice([-1, 1])
         mode = random.choice(['uvw', 'uvu', 'uvv', 'uuw', 'uuu', 'uvuv'])
         weight = random.choice([True, False])
-        if make_tp(l1, p1, l2, p2, lo, po, mode, weight) is not None:
+        if make_tp(l1, p1, l2, p2, lo, po, mode, weight, reraise=False) is not None:
             params.add((l1, p1, l2, p2, lo, po, mode, weight))
     return params
 
@@ -539,7 +543,8 @@ def test_explicit_backward(
             specialized_code=special_code,
             optimize_einsums=opt_ein,
             explicit_backward=True
-        )
+        ),
+        reraise=True
     )
 
     # make sure its marked as no JIT support

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -611,3 +611,12 @@ def test_explicit_backward(
     assert torch.allclose(x1_orig.grad, x1_explicit.grad, atol=atol)
     assert torch.allclose(x2_orig.grad, x2_explicit.grad, atol=atol)
     assert torch.allclose(orig_tp.weight.grad, explicit_tp.weight.grad, atol=atol)
+
+    # Now we do the whole check again, but this time comparing to finite difference, instead of autograd:
+    # gradcheck is meant to work only in double
+    if torch.get_default_dtype() == torch.float64:
+        torch.autograd.gradcheck(
+            explicit_tp,
+            (x1_explicit, x2_explicit),
+        )
+        # TODO: gradgradcheck?


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This is an attempt to give `TensorProduct` an explicit, symbolically generated backwards pass for optimization purposes. Depends heavily on work I'm doing on the [`grad` branch](https://github.com/Linux-cpp-lisp/opt_einsum_fx/tree/grad) of `opt_einsum_fx`, which implements *just* enough of a symbolic autodifferention engine for FX to make this possible.

Includes #273.

## Motivation and Context
In theory, with an explicit backwards pass:
- The einsums for the backward (which are different from the forward) can be independently optimized
- Common contractions can be consolidated
- In-place operations can be used for the forward pass, reducing allocations

So far, it's not clear if this actually yields speed-ups. Probably more useful for 2nd order gradient applications.

## How Has This Been Tested?
Some new tests, etc., ongoing

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).