### PR TITLE
add linkcode to docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         pip install coveralls
     - name: Test with pytest
       run: |
-        coverage run --source=e3nn -m pytest --doctest-modules .
+        coverage run --source=e3nn -m pytest --doctest-modules --ignore=docs/ .
     - name: Upload to coveralls
       if: github.event_name == 'push'
       run: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ def linkcode_resolve(domain, info):
         rel_path, line_start, line_end = find_source()
         # __file__ is imported from e3nn
         filename = f"e3nn/{rel_path}#L{line_start}-L{line_end}"
-    except:
+    except Exception:
         # no need to be relative to core here as module includes full path.
         filename = info["module"].replace(".", "/") + ".py"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,7 @@ html_theme = 'sphinx_rtd_theme'
 
 myst_update_mathjax = False
 
+
 # Resolve function for the linkcode extension.
 # Thanks to https://github.com/Lasagne/Lasagne/blob/master/docs/conf.py
 def linkcode_resolve(domain, info):
@@ -109,4 +110,4 @@ def linkcode_resolve(domain, info):
         filename = info["module"].replace(".", "/") + ".py"
 
     tag = __version__
-    return	 f"https://github.com/e3nn/e3nn/blob/{tag}/{filename}"
+    return f"https://github.com/e3nn/e3nn/blob/{tag}/{filename}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ author = 'e3nn Developers'
 # The full version, including alpha/beta/rc tags
 release = '0.3.0'
 
+from e3nn import __version__, __file__
 
 # -- General configuration ---------------------------------------------------
 
@@ -35,6 +36,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.linkcode",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "jupyter_sphinx",
@@ -77,3 +79,34 @@ html_theme = 'sphinx_rtd_theme'
 # html_static_path = ['_static']
 
 myst_update_mathjax = False
+
+# Resolve function for the linkcode extension.
+# Thanks to https://github.com/Lasagne/Lasagne/blob/master/docs/conf.py
+def linkcode_resolve(domain, info):
+    def find_source():
+        # try to find the file and line number, based on code from numpy:
+        # https://github.com/numpy/numpy/blob/master/doc/source/conf.py#L286
+        obj = sys.modules[info["module"]]
+        for part in info["fullname"].split("."):
+            obj = getattr(obj, part)
+        import inspect
+        import os
+
+        fn = inspect.getsourcefile(obj)
+        fn = os.path.relpath(fn, start=os.path.dirname(__file__))
+        source, lineno = inspect.getsourcelines(obj)
+        return fn, lineno, lineno + len(source) - 1
+
+    if domain != "py" or not info["module"]:
+        return None
+
+    try:
+        rel_path, line_start, line_end = find_source()
+        # __file__ is imported from e3nn
+        filename = f"e3nn/{rel_path}#L{line_start}-L{line_end}"
+    except:
+        # no need to be relative to core here as module includes full path.
+        filename = info["module"].replace(".", "/") + ".py"
+
+    tag = __version__
+    return	 f"https://github.com/e3nn/e3nn/blob/{tag}/{filename}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 import os
 import sys
+from e3nn import __version__, __file__
 sys.path.insert(0, os.path.abspath('../'))
 
 
@@ -22,8 +23,6 @@ author = 'e3nn Developers'
 
 # The full version, including alpha/beta/rc tags
 release = '0.3.0'
-
-from e3nn import __version__, __file__
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Added code in `conf.py` to autogenerate links to code definitions.

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
I wanted to be able to link directly from the API docs to github code.

## How Has This Been Tested?
I have successfully run `make html` with these changes and the docs look as desired.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).