### PR TITLE
Added parity of 1 to the spherical harmonics representation method.

### DIFF
--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -367,13 +367,16 @@ class Irreps(tuple):
         return super().__new__(cls, out)
 
     @staticmethod
-    def spherical_harmonics(lmax):
+    def spherical_harmonics(lmax,p=-1):
         r"""representation of the spherical harmonics
 
         Parameters
         ----------
         lmax : int
             maximum :math:`l`
+
+        p : {1, -1}
+            the parity of the representation
 
         Returns
         -------
@@ -385,8 +388,10 @@ class Irreps(tuple):
 
         >>> Irreps.spherical_harmonics(3)
         1x0e+1x1o+1x2e+1x3o
+        >>> Irreps.spherical_harmonics(4,1)
+        1x0e+1x1e+1x2e+1x3e+1x4e 
         """
-        return Irreps([(1, (l, (-1)**l)) for l in range(lmax + 1)])
+        return Irreps([(1, (l, (p)**l)) for l in range(lmax + 1)])
 
     def slices(self):
         r"""List of slices corresponding to indices for each irrep.

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -367,7 +367,7 @@ class Irreps(tuple):
         return super().__new__(cls, out)
 
     @staticmethod
-    def spherical_harmonics(lmax,p=-1):
+    def spherical_harmonics(lmax, p=-1):
         r"""representation of the spherical harmonics
 
         Parameters
@@ -388,10 +388,11 @@ class Irreps(tuple):
 
         >>> Irreps.spherical_harmonics(3)
         1x0e+1x1o+1x2e+1x3o
+
         >>> Irreps.spherical_harmonics(4,1)
         1x0e+1x1e+1x2e+1x3e+1x4e 
         """
-        return Irreps([(1, (l, (p)**l)) for l in range(lmax + 1)])
+        return Irreps([(1, (l, p**l)) for l in range(lmax + 1)])
 
     def slices(self):
         r"""List of slices corresponding to indices for each irrep.

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -389,8 +389,8 @@ class Irreps(tuple):
         >>> Irreps.spherical_harmonics(3)
         1x0e+1x1o+1x2e+1x3o
 
-        >>> Irreps.spherical_harmonics(4,1)
-        1x0e+1x1e+1x2e+1x3e+1x4e 
+        >>> Irreps.spherical_harmonics(4, p=1)
+        1x0e+1x1e+1x2e+1x3e+1x4e
         """
         return Irreps([(1, (l, p**l)) for l in range(lmax + 1)])
 


### PR DESCRIPTION
## Motivation and Context
spherical harmonics method in irreps was missing even parity.
Added p=-1 as a default argument.

## How Has This Been Tested?
Added example:
>>> Irreps.spherical_harmonics(4,1)
       1x0e+1x1e+1x2e+1x3e+1x4e 



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] All new and existing tests passed.
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).