### PR TITLE
Added pre-commit hook and some missing types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,48 @@
+exclude: &exclude_files >
+    (?x)^(
+        docs/.*|
+        tests/.*|
+        .github/.*|
+        LICENSE|
+    )$
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: mixed-line-ending
+    -   id: trailing-whitespace
+
+-   repo: https://github.com/PyCQA/pylint
+    rev: pylint-2.5.2
+    hooks:
+    -   id: pylint
+        language: system
+        args: [
+            '--disable=protected-access',
+            '--disable=no-else-return',
+            '--disable=raise-missing-from',
+            '--disable=invalid-name',
+            '--disable=duplicate-code',
+            '--disable=import-outside-toplevel',
+            '--disable=missing-docstring',
+            '--disable=bad-continuation',
+            '--disable=locally-disabled',
+            '--disable=too-few-public-methods',
+            '--disable=too-many-arguments',
+            '--disable=too-many-instance-attributes',
+            '--disable=too-many-local-variables',
+            '--disable=too-many-locals',
+            '--disable=too-many-branches',
+            '--disable=too-many-statements',
+            '--disable=too-many-return-statements',
+            '--disable=redefined-builtin',
+            '--disable=redefined-outer-name',
+            '--disable=line-too-long',
+            '--disable=fixme',
+        ]
+        exclude: *exclude_files
+
 -   repo: https://github.com/pycqa/flake8
     rev: '3.9.2'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,4 @@
+-   repo: https://github.com/pycqa/flake8
+    rev: '3.9.2'
+    hooks:
+    -   id: flake8

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,6 @@
+[TYPECHECK]
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=numpy.*,torch.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,23 @@
 # Contribute
 
 For the docstrings we use the [numpy style](https://numpydoc.readthedocs.io/en/latest/format.html).
+
+You can install some of the commonly used development tools by using e3nn's 'dev' extra:
+
+```
+pip install -e '.[dev]'
+```
+
+To have atomic code style checks performed at each commit, you can install the pre-commit hook using:
+
+```
+pre-commit install
+```
+
+These checks are automatically run on any commit made to the github repository but the pre-commit hook allows you to see if there are any problems locally.
+
+Additionally, you may want to run the tests locally before pushing to remote.  This can be done with (from the root e3nn directory):
+
+```
+pytest tests
+```

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ReducedTensorProducts`: `normalization` and `filter_ir_mid` where not properly propagated through the recusive calls, this bug has no effects if the default values where used
 - Use `torch.linalg.eigh` instead of the deprecated `torch.symeig`
 
+### Added
+- (dev only) Pre-commit hooks that run pylint and flake8.  These catch some common mistakes/style issues.
+
 ## [0.3.3] - 2021-06-21
 ### Changed
 - `FullyConnectedNet` is now a `torch.nn.Sequential`

--- a/e3nn/io/_cartesian_tensor.py
+++ b/e3nn/io/_cartesian_tensor.py
@@ -24,7 +24,15 @@ class CartesianTensor(o3.Irreps):
     >>> x.from_vectors(torch.ones(3), torch.ones(3), torch.ones(3))
     tensor([0.])
     """
-    def __new__(cls, formula):
+    # pylint: disable=abstract-method
+
+    # These are set in __new__
+    _rtp: o3.ReducedTensorProducts
+    num_index: int
+
+    def __new__(
+            # pylint: disable=signature-differs
+            cls, formula):
         f = formula.split('=')[0].replace('-', '')
         rtp = o3.ReducedTensorProducts(formula, **{i: "1o" for i in f})
         ret = super().__new__(cls, rtp.irreps_out)
@@ -62,7 +70,7 @@ class CartesianTensor(o3.Irreps):
         `torch.Tensor`
             irreps tensor of shape ``(..., self.dim)``
         """
-        return self._rtp(*xs)
+        return self._rtp(*xs)  # pylint: disable=not-callable
 
     def change_of_basis(self):
         r"""change of basis from cartesian tensor to irreps

--- a/e3nn/io/_spherical_tensor.py
+++ b/e3nn/io/_spherical_tensor.py
@@ -60,7 +60,11 @@ class SphericalTensor(o3.Irreps):
     >>> SphericalTensor(3, 1, -1)
     1x0e+1x1o+1x2e+1x3o
     """
-    def __new__(cls, lmax, p_val, p_arg):
+    # pylint: disable=abstract-method
+
+    def __new__(
+            # pylint: disable=signature-differs
+            cls, lmax, p_val, p_arg):
         return super().__new__(cls, [(1, (l, p_val * p_arg**l)) for l in range(lmax + 1)])
 
     def with_peaks_at(self, vectors, values=None):
@@ -108,7 +112,7 @@ class SphericalTensor(o3.Irreps):
         if vectors.numel() == 0:
             return torch.zeros(vectors.shape[:-2] + (self.dim,))
 
-        assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"
+        assert self[0][1].p == 1, "since the value is set by the radii who is even, p_val has to be 1"  # pylint: disable=no-member
 
         assert vectors.dim() == 2 and vectors.shape[1] == 3
 

--- a/e3nn/io/_spherical_tensor.py
+++ b/e3nn/io/_spherical_tensor.py
@@ -129,7 +129,7 @@ class SphericalTensor(o3.Irreps):
 
         return solution @ coeff
 
-    def sum_of_diracs(self, positions, values):
+    def sum_of_diracs(self, positions: torch.Tensor, values: torch.Tensor) -> torch.Tensor:
         r"""Sum (almost-) dirac deltas
 
         .. math::
@@ -183,7 +183,7 @@ class SphericalTensor(o3.Irreps):
 
         return 4 * pi / (self.lmax + 1)**2 * (y * v).sum(-2)
 
-    def from_samples_on_s2(self, positions, values, res=100):
+    def from_samples_on_s2(self, positions: torch.Tensor, values: torch.Tensor, res=100) -> torch.Tensor:
         r"""Convert a set of position on the sphere and values into a spherical tensor
 
         Parameters

--- a/e3nn/math/_normalize_activation.py
+++ b/e3nn/math/_normalize_activation.py
@@ -21,7 +21,9 @@ class normalize2mom(torch.nn.Module):
     _is_id: bool
     cst: float
 
-    def __init__(self, f, dtype=None, device=None):
+    def __init__(
+            # pylint: disable=unused-argument
+            self, f, dtype=None, device=None):
         super().__init__()
 
         # Try to infer a device:
@@ -47,8 +49,11 @@ class normalize2mom(torch.nn.Module):
         else:
             return self.f(x).mul(self.cst)
 
-    def _make_tracing_inputs(self, n: int):
+    @staticmethod
+    def _make_tracing_inputs(
+            # pylint: disable=unused-argument
+            n: int):
         # No reason to trace this with more than one tiny input,
         # since f is assumed by `moment` to be an elementwise scalar
         # function
-        return [{'forward': (torch.zeros(size=(1,),),)}]
+        return [{'forward': (torch.zeros(size=(1,), ),)}]

--- a/e3nn/math/_soft_one_hot_linspace.py
+++ b/e3nn/math/_soft_one_hot_linspace.py
@@ -4,7 +4,7 @@ import torch
 from e3nn.math import soft_unit_step
 
 
-def soft_one_hot_linspace(x, start, end, number, basis=None, cutoff=None):
+def soft_one_hot_linspace(x: torch.Tensor, start, end, number, basis=None, cutoff=None):
     r"""Projection on a basis of functions
 
     Returns a set of :math:`\{y_i(x)\}_{i=1}^N`,
@@ -93,6 +93,8 @@ def soft_one_hot_linspace(x, start, end, number, basis=None, cutoff=None):
         plt.ylim(0, 2)
         plt.tight_layout()
     """
+    # pylint: disable=misplaced-comparison-constant
+
     if cutoff not in [True, False]:
         raise ValueError("cutoff must be specified")
 

--- a/e3nn/math/_soft_unit_step.py
+++ b/e3nn/math/_soft_unit_step.py
@@ -2,6 +2,8 @@ import torch
 
 
 class _SoftUnitStep(torch.autograd.Function):
+    # pylint: disable=arguments-differ
+
     @staticmethod
     def forward(ctx, x):
         ctx.save_for_backward(x)

--- a/e3nn/math/perm.py
+++ b/e3nn/math/perm.py
@@ -1,9 +1,9 @@
+from typing import Tuple, Set, Optional
+
 import random
 import math
 import torch
 from e3nn.math import complete_basis
-
-from typing import Tuple, Set, Optional
 
 TY_PERM = Tuple[int]
 

--- a/e3nn/nn/_batchnorm.py
+++ b/e3nn/nn/_batchnorm.py
@@ -1,6 +1,7 @@
 import torch
-from e3nn import o3
 from torch import nn
+
+from e3nn import o3
 from e3nn.util.jit import compile_mode
 
 

--- a/e3nn/nn/_batchnorm.py
+++ b/e3nn/nn/_batchnorm.py
@@ -15,7 +15,7 @@ class BatchNorm(nn.Module):
 
     Parameters
     ----------
-    irreps : `Irreps`
+    irreps : `o3.Irreps`
         representation
 
     eps : float

--- a/e3nn/nn/_dropout.py
+++ b/e3nn/nn/_dropout.py
@@ -21,7 +21,7 @@ class Dropout(torch.nn.Module):
 
     Parameters
     ----------
-    irreps : `Irreps`
+    irreps : `o3.Irreps`
         representation
 
     p : float

--- a/e3nn/nn/_extract.py
+++ b/e3nn/nn/_extract.py
@@ -9,6 +9,8 @@ from e3nn import o3
 
 @compile_mode('script')
 class Extract(fx.GraphModule):
+    # pylint: disable=abstract-method
+
     def __init__(self, irreps_in, irreps_outs, instructions, squeeze_out: bool = False):
         r"""Extract sub sets of irreps
 
@@ -78,6 +80,8 @@ class Extract(fx.GraphModule):
 
 @compile_mode('script')
 class ExtractIr(Extract):
+    # pylint: disable=abstract-method
+
     def __init__(self, irreps_in, ir):
         r"""Extract ``ir`` from irreps
 

--- a/e3nn/nn/_fc.py
+++ b/e3nn/nn/_fc.py
@@ -1,8 +1,9 @@
+from typing import List
+
 import torch
 
 from e3nn.math import normalize2mom
 from e3nn.util.jit import compile_mode
-from typing import List
 
 
 @compile_mode('script')

--- a/e3nn/nn/_identity.py
+++ b/e3nn/nn/_identity.py
@@ -31,7 +31,9 @@ class Identity(torch.nn.Module):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.irreps_in} -> {self.irreps_out})"
 
-    def forward(self, features):
+    def forward(
+            # pylint: disable=no-self-use
+            self, features):
         """evaluate
         """
         return features

--- a/e3nn/nn/_s2act.py
+++ b/e3nn/nn/_s2act.py
@@ -15,7 +15,7 @@ class S2Activation(torch.nn.Module):
 
     Parameters
     ----------
-    irreps : `Irreps`
+    irreps : `o3.Irreps`
         input representation of the form ``[(1, (l, p_val * (p_arg)^l)) for l in [0, ..., lmax]]``
 
     act : function
@@ -37,7 +37,7 @@ class S2Activation(torch.nn.Module):
     >>> from e3nn import io
     >>> m = S2Activation(io.SphericalTensor(5, p_val=+1, p_arg=-1), torch.tanh, 100)
     '''
-    def __init__(self, irreps, act, res, normalization='component', lmax_out=None, random_rot=False):
+    def __init__(self, irreps: o3.Irreps, act, res, normalization='component', lmax_out=None, random_rot=False):
         super().__init__()
 
         irreps = o3.Irreps(irreps).simplify()

--- a/e3nn/nn/_s2act.py
+++ b/e3nn/nn/_s2act.py
@@ -44,7 +44,7 @@ class S2Activation(torch.nn.Module):
         _, (_, p_val) = irreps[0]
         _, (lmax, _) = irreps[-1]
         assert all(mul == 1 for mul, _ in irreps)
-        assert irreps.ls == [l for l in range(lmax + 1)]
+        assert irreps.ls == list(range(lmax + 1))
         if all(p == p_val for _, (l, p) in irreps):
             p_arg = 1
         elif all(p == p_val * (-1) ** l for _, (l, p) in irreps):
@@ -57,7 +57,7 @@ class S2Activation(torch.nn.Module):
         if lmax_out is None:
             lmax_out = lmax
 
-        if p_val == +1 or p_val == 0:
+        if p_val in (0, +1):
             self.irreps_out = o3.Irreps([(1, (l, p_val * p_arg ** l)) for l in range(lmax_out + 1)])
         if p_val == -1:
             x = torch.linspace(0, 10, 256)

--- a/e3nn/nn/models/v2103/gate_points_networks.py
+++ b/e3nn/nn/models/v2103/gate_points_networks.py
@@ -5,12 +5,12 @@
 from typing import Dict, Union
 
 import torch
-from e3nn import o3
-from e3nn.math import soft_one_hot_linspace
 from torch_cluster import radius_graph
 from torch_geometric.data import Data
 from torch_scatter import scatter
 
+from e3nn import o3
+from e3nn.math import soft_one_hot_linspace
 from .gate_points_message_passing import MessagePassing
 
 

--- a/e3nn/nn/models/v2103/points_convolution.py
+++ b/e3nn/nn/models/v2103/points_convolution.py
@@ -1,9 +1,10 @@
 import torch
+from torch_scatter import scatter
+
 from e3nn import o3
 from e3nn.nn import FullyConnectedNet
 from e3nn.o3 import FullyConnectedTensorProduct, TensorProduct
 from e3nn.util.jit import compile_mode
-from torch_scatter import scatter
 
 
 @compile_mode('script')

--- a/e3nn/o3/_angular_spherical_harmonics.py
+++ b/e3nn/o3/_angular_spherical_harmonics.py
@@ -105,6 +105,8 @@ def spherical_harmonics_alpha(l: int, alpha: torch.Tensor) -> torch.Tensor:
 
 @compile_mode('script')
 class Legendre(fx.GraphModule):
+    # pylint: disable=abstract-method
+
     def __init__(self, ls):
         super().__init__(self, fx.Graph())
 

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -48,7 +48,7 @@ class Irrep(tuple):
     >>> Irrep("1o") + Irrep("2o")
     1x1o+1x2o
     """
-    def __new__(cls, l: Union['Irrep', str, tuple], p=None):
+    def __new__(cls, l: Union[int, 'Irrep', str, tuple], p=None):
         if p is None:
             if isinstance(l, Irrep):
                 return l

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -551,7 +551,7 @@ class Irreps(tuple):
 
         Returns
         -------
-        irreps : `Irreps`
+        irreps : `e3nn.o3.Irreps`
         p : tuple of int
         inv : tuple of int
 

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -1,6 +1,6 @@
 import itertools
 import collections
-from typing import List
+from typing import List, Union
 
 import torch
 
@@ -48,7 +48,7 @@ class Irrep(tuple):
     >>> Irrep("1o") + Irrep("2o")
     1x1o+1x2o
     """
-    def __new__(cls, l, p=None):
+    def __new__(cls, l: Union['Irrep', str, tuple], p=None):
         if p is None:
             if isinstance(l, Irrep):
                 return l

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -1,14 +1,15 @@
 import math
 from typing import List, NamedTuple, Optional, Tuple, Union
 
-import e3nn
+from opt_einsum_fx import jitable, optimize_einsums_full
 import torch
+from torch import fx
+
+import e3nn
 from e3nn import o3
 from e3nn.util import prod
 from e3nn.util.codegen import CodeGenMixin
 from e3nn.util.jit import compile_mode
-from opt_einsum_fx import jitable, optimize_einsums_full
-from torch import fx
 
 from ._tensor_product._codegen import _sum_tensors
 
@@ -303,7 +304,6 @@ class Linear(CodeGenMixin, torch.nn.Module):
                 yield ins_i, ins, this_weight
             else:
                 yield this_weight
-        return
 
 
 def _codegen_linear(

--- a/e3nn/o3/_reduce.py
+++ b/e3nn/o3/_reduce.py
@@ -125,6 +125,8 @@ class ReducedTensorProducts(fx.GraphModule):
     >>> b = tp(x, y)
     >>> assert torch.allclose(a, b, atol=1e-3, rtol=1e-3)
     """
+    # pylint: disable=abstract-method
+
     def __init__(self, formula, filter_ir_out=None, filter_ir_mid=None, eps=1e-9, **irreps):
         super().__init__(self, fx.Graph())
 

--- a/e3nn/o3/_spherical_harmonics.py
+++ b/e3nn/o3/_spherical_harmonics.py
@@ -50,7 +50,7 @@ class SphericalHarmonics(torch.nn.Module):
         if irreps_in not in (o3.Irreps("1x1o"), o3.Irreps("1x1e")):
             raise ValueError(f"irreps_in for SphericalHarmonics must be either a vector (`1x1o`) or a pseudovector (`1x1e`), not `{irreps_in}`")
         self.irreps_in = irreps_in
-        input_p = irreps_in[0].ir.p
+        input_p = irreps_in[0].ir.p  # pylint: disable=no-member
 
         if isinstance(irreps_out, o3.Irreps):
             ls = []

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -468,7 +468,6 @@ def codegen_tensor_product(
                 flat_weight_index,
             ),
         )
-
         graphmod_out = jitable(optimize_einsums_full(graphmod_out, example_inputs))
         graphmod_right = jitable(optimize_einsums_full(graphmod_right, example_inputs[1:]))
 

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -1,11 +1,12 @@
 from math import sqrt
 from typing import List, Tuple
 
+from opt_einsum_fx import jitable, optimize_einsums_full
 import torch
+from torch import fx
+
 from e3nn import o3
 from e3nn.util import prod
-from opt_einsum_fx import jitable, optimize_einsums_full
-from torch import fx
 
 from ._instruction import Instruction
 

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Iterator
 
 import torch
 import torch.fx
@@ -833,9 +833,9 @@ class FullTensorProduct(TensorProduct):
     """
     def __init__(
         self,
-        irreps_in1,
-        irreps_in2,
-        filter_ir_out=None,
+        irreps_in1: o3.Irreps,
+        irreps_in2: o3.Irreps,
+        filter_ir_out: Iterator[o3.Irrep] = None,
         **kwargs
     ):
 

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -477,7 +477,6 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
                     yield ins_i, ins, this_weight
                 else:
                     yield this_weight
-        return
 
     def visualize(
         self,

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -13,6 +13,8 @@ class CodeGenMixin:
     ``__getstate__``/``__setstate__``, they should be sure to call CodeGenMixin's
     implimentation first and use its output.
     """
+    # pylint: disable=super-with-arguments
+
     def _codegen_register(
         self,
         funcs: Dict[str, fx.GraphModule],

--- a/e3nn/util/default_type.py
+++ b/e3nn/util/default_type.py
@@ -1,7 +1,8 @@
+from typing import Optional, Tuple
+
 import torch
 import torch.jit
 
-from typing import Optional, Tuple
 
 # Please see PR #203 for these commented out code: https://github.com/e3nn/e3nn/pull/203
 

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -53,8 +53,8 @@ def get_compile_mode(mod: torch.nn.Module) -> str:
 def compile(
     mod: torch.nn.Module,
     n_trace_checks: int = 1,
-    script_options: dict = {},
-    trace_options: dict = {},
+    script_options: dict = None,
+    trace_options: dict = None,
     in_place: bool = True,
 ):
     """Recursively compile a module and all submodules according to their decorators.
@@ -76,6 +76,9 @@ def compile(
     -------
     Returns the compiled module.
     """
+    script_options = script_options or {}
+    trace_options = trace_options or {}
+
     mode = get_compile_mode(mod)
     if mode == 'unsupported':
         raise NotImplementedError(f"{type(mod).__name__} does not support TorchScript compilation")
@@ -176,7 +179,7 @@ def get_tracing_inputs(
 def trace_module(
     mod: torch.nn.Module,
     inputs: dict = None,
-    check_inputs: list = [],
+    check_inputs: list = None,
     in_place: bool = True
 ):
     """Trace a module.
@@ -192,6 +195,8 @@ def trace_module(
     -------
     Traced module.
     """
+    check_inputs = check_inputs or []
+
     # Set the compile mode for mod, temporarily
     old_mode = getattr(mod, _E3NN_COMPILE_MODE, None)
     if old_mode is not None and old_mode != 'trace':
@@ -222,7 +227,7 @@ def trace_module(
 def trace(
     mod: torch.nn.Module,
     example_inputs: tuple = None,
-    check_inputs: list = [],
+    check_inputs: list = None,
     in_place: bool = True
 ):
     """Trace a module.

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -243,6 +243,8 @@ def trace(
     -------
     Traced module.
     """
+    check_inputs = check_inputs or []
+
     return trace_module(
         mod=mod,
         inputs=({'forward': example_inputs} if example_inputs is not None else None),

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -13,6 +13,7 @@ from e3nn import o3
 from e3nn.util.jit import compile, get_tracing_inputs, get_compile_mode, _MAKE_TRACING_INPUTS
 from ._argtools import _get_args_in, _get_io_irreps, _transform, _rand_args
 
+# pylint: disable=unused-variable
 
 # Make a logger for reporting error statistics
 logger = logging.getLogger(__name__)
@@ -265,7 +266,7 @@ def equivariance_error(
     else:
         parity_ks = torch.Tensor([0])
 
-    if ('cartesian_points' not in irreps_in):
+    if 'cartesian_points' not in irreps_in:
         # There's nothing to translate
         do_translation = False
     if do_translation:
@@ -296,12 +297,12 @@ def equivariance_error(
             x2 = func(*args_in)
 
             # Deal with output shapes
-            assert type(x1) == type(x2), f"Inconsistant return types {type(x1)} and {type(x2)}"
+            assert type(x1) == type(x2), f"Inconsistant return types {type(x1)} and {type(x2)}"  # pylint: disable=unidiomatic-typecheck
             if isinstance(x1, torch.Tensor):
                 # Make sequences
                 x1 = [x1]
                 x2 = [x2]
-            elif isinstance(x1, list) or isinstance(x1, tuple):
+            elif isinstance(x1, (list, tuple)):
                 # They're already tuples
                 x1 = list(x1)
                 x2 = list(x2)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-from setuptools import find_packages, setup
-
 import os
 import re
+
+from setuptools import find_packages, setup
 
 
 # Recommendations from https://packaging.python.org/

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,12 @@ setup(
         'torch>=1.8.0',  # >= 1.8 is required for FX
         'opt_einsum_fx',  # optimization of TensorProduct FX code
     ],
+    extras_require={
+        'dev': [
+            'pytest',
+            'pre-commit',
+        ],
+    },
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
Quality of life improvements.

## Description

* Added pre-commit hook that allows users to do `pre-commit install` and
flake8 will be run each time a commit is made
* Added 'dev' extra to e3nn.  This allows ones to do `pip install -e
.[dev]` and automatically get pytest and pre-commit (for now).  The idea
is that you automatically install libraries that everyone doing
development should have.
* Added full instructions for the pre-commit hook and running of test to
CONTRIBUTING.md
* Added a few missing type hints that I came across

## Motivation and Context
This makes automated checking during development easier and more transparent.

## How Has This Been Tested?
All tests pass.

## Screenshots
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation improvement (updates to user guides, docstrings, or developer docs)

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] All new and existing tests passed.
- [x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).