### PR TITLE
Small bugfixes for profiling

### DIFF
--- a/examples/tensor_product_benchmark.py
+++ b/examples/tensor_product_benchmark.py
@@ -95,10 +95,11 @@ def main():
 
     print("starting...")
 
+    # tanh() forces it to realize the grad as a full size matrix rather than expanded (stride 0) ones
     t = Timer(
         stmt=(
             "tp.zero_grad()\n"
-            "out = tp(*next(inputs))\n" + ("out.sum().backward()\n" if args.backward else '')
+            "out = tp(*next(inputs))\n" + ("out.tanh().sum().backward()\n" if args.backward else '')
         ),
         globals={'tp': tp, 'inputs': inputs}
     )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description

1. Workaroud for profiler hanging on certain CUDA drivers, see https://github.com/pytorch/kineto/issues/126
2. Use `tanh()` to force pytorch to realize the backwards gradient of the sum by making it value dependent (this prevents false performance numbers if performance would be significantly different for a zero-stride expanded gradient tensor)

## How Has This Been Tested?
Ran it.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
