### PR TITLE
Added pytest fixture that sets seeds before tests

### DIFF
--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -1,12 +1,12 @@
-from typing import Iterable, Optional
-
 import random
 import math
-import itertools
-import warnings
-import logging
 import inspect
+import itertools
+import logging
+from typing import Iterable, Optional
+import warnings
 
+import numpy as np
 import torch
 
 from e3nn import o3
@@ -505,3 +505,10 @@ def assert_normalized(
                 max_componentwise
             )
             assert max_componentwise <= atol, f"< x_i^2 > !~= {target:.6f} for output irrep #{i}, {irreps[i]}. Max componentwise error: {max_componentwise:.6f}"
+
+
+def set_random_seeds():
+    """Set the random seeds to try to get some reproducibility"""
+    torch.manual_seed(0)
+    random.seed(0)
+    np.random.seed(0)

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from e3nn.util import test
+
+
+@pytest.fixture(autouse=True)
+def set_random_seed():
+    """Set the random seeds to try to get some reproducibility"""
+    test.set_random_seeds()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,17 @@
+import pytest
+
 # For good practice, we *should* do this:
 # See https://docs.pytest.org/en/stable/fixture.html#using-fixtures-from-other-projects
 # pytest_plugins = ['e3nn.util.test']
 # But doing so exposes float_tolerance to doctests, which don't support parametrized, autouse fixtures.
 # Importing directly somehow only brings in the fixture later, preventing the issue.
-from e3nn.util.test import float_tolerance
+from e3nn.util import test
+
 # Suppress linter errors
-float_tolerance = float_tolerance
+float_tolerance = test.float_tolerance
+
+
+@pytest.fixture(autouse=True)
+def set_random_seed():
+    """Set the random seeds to try to get some reproducibility"""
+    test.set_random_seeds()


### PR DESCRIPTION
This fixture will automatically set the python, numpy and torch seeds
before running each test in the hope of being able to get some
reprodicibility.  There are certain module in torch that may mean the
tests are not 100% identical each time, but for the most part this
should already help with randomly failing tests.

## Description

A fixture that sets seeds for all tests in `tests/` and `examples/`.


## Motivation and Context

Because the tetris test was sometimes randomly failing.

## How Has This Been Tested?

Tested locally

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
