### PR TITLE
Add to_cartesian() to CartesianTensor

### DIFF
--- a/e3nn/io/_cartesian_tensor.py
+++ b/e3nn/io/_cartesian_tensor.py
@@ -64,6 +64,21 @@ class CartesianTensor(o3.Irreps):
         Q = self.change_of_basis().flatten(-self.num_index)
         return data.flatten(-self.num_index) @ Q.T
 
+    def from_vectors(self, *xs):
+        r"""convert :math:`x_1 \otimes x_2 \otimes x_3 \otimes \dots`
+
+        Parameters
+        ----------
+        xs : list of `torch.Tensor`
+            list of vectors of shape ``(..., 3)``
+
+        Returns
+        -------
+        `torch.Tensor`
+            irreps tensor of shape ``(..., self.dim)``
+        """
+        return self._rtp(*xs)  # pylint: disable=not-callable
+
     def to_cartesian(self, data):
         r"""convert irreps tensor to cartesian tensor
 
@@ -87,21 +102,6 @@ class CartesianTensor(o3.Irreps):
         cartesian_tensor = cartesian_tensor.view(shape)
 
         return cartesian_tensor
-
-    def from_vectors(self, *xs):
-        r"""convert :math:`x_1 \otimes x_2 \otimes x_3 \otimes \dots`
-
-        Parameters
-        ----------
-        xs : list of `torch.Tensor`
-            list of vectors of shape ``(..., 3)``
-
-        Returns
-        -------
-        `torch.Tensor`
-            irreps tensor of shape ``(..., self.dim)``
-        """
-        return self._rtp(*xs)  # pylint: disable=not-callable
 
     def change_of_basis(self):
         r"""change of basis from cartesian tensor to irreps


### PR DESCRIPTION
Add a convenience function to convert an irreps tensor to a cartesian tensor, as discussed in #308 

## How Has This Been Tested?
docstring test

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [ ] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
