### PR TITLE
path_normalization for TensorProduct

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `irrep_normalization` and `path_normalization` for `TensorProduct`
 
 ## [0.4.1] - 2021-10-29
 ### Added

--- a/docs/api/o3/o3_sh.rst
+++ b/docs/api/o3/o3_sh.rst
@@ -182,7 +182,7 @@ To obtain a nicer figure (that looks like the spherical harmonics shown on Wikip
 
 .. jupyter-execute::
 
-    tp = o3.ElementwiseTensorProduct("1o", "1o", ['2e'], normalization='norm')
+    tp = o3.ElementwiseTensorProduct("1o", "1o", ['2e'], irrep_normalization='norm')
     y2 = tp(r, r)
     plot(y2)
 
@@ -190,7 +190,7 @@ Similarly, the next spherical harmonic function :math:`Y^3` is the :math:`L=3` p
 
 .. jupyter-execute::
 
-    tp = o3.ElementwiseTensorProduct("2e", "1o", ['3o'], normalization='norm')
+    tp = o3.ElementwiseTensorProduct("2e", "1o", ['3o'], irrep_normalization='norm')
     y3 = tp(y2, r)
     plot(y3)
 

--- a/e3nn/o3/_norm.py
+++ b/e3nn/o3/_norm.py
@@ -46,7 +46,7 @@ class Norm(torch.nn.Module):
             irreps_in,
             irreps_out,
             instr,
-            normalization='component'
+            irrep_normalization='component'
         )
 
         self.irreps_in = irreps_in

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -46,12 +46,16 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
     out_var : list of float, Tensor, or None
         Variance for each irrep in ``irreps_out``. If ``None``, all default to ``1.0``.
 
-    normalization : {'component', 'norm'}
+    irrep_normalization : {'component', 'norm'}
         The assumed normalization of the input and output representations. If it is set to "norm":
 
         .. math::
 
             \| x \| = \| y \| = 1 \Longrightarrow \| x \otimes y \| = 1
+
+    path_normalization : {'element', 'path'}
+        If set to ``element``, each output is normalized by the total number of elements (independently of their paths).
+        If it is set to ``path``, each path is normalized by the total number of elements in the path, then each output is normalized by the number of paths.
 
     internal_weights : bool
         whether the `e3nn.o3.TensorProduct` contains its learnable weights as a parameter

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -1,3 +1,4 @@
+import warnings
 from math import sqrt
 from typing import Iterator, List, Optional, Union
 
@@ -190,11 +191,19 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         path_normalization: str = 'element',
         internal_weights: Optional[bool] = None,
         shared_weights: Optional[bool] = None,
+        normalization=None,  # for backward compatibility
         _specialized_code: Optional[bool] = None,
         _optimize_einsums: Optional[bool] = None
     ):
         # === Setup ===
         super().__init__()
+
+        if normalization is not None:
+            warnings.warn(
+                "`normalization` is deprecated. Use `irrep_normalization` instead.",
+                DeprecationWarning
+            )
+            irrep_normalization = normalization
 
         assert irrep_normalization in ['component', 'norm']
         assert path_normalization in ['element', 'path']

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -1,16 +1,16 @@
-from typing import Optional, List, Union, Iterator
-
-import torch
-import torch.fx
+from math import sqrt
+from typing import Iterator, List, Optional, Union
 
 import e3nn
+import torch
+import torch.fx
 from e3nn import o3
-from e3nn.util.jit import compile_mode
-from e3nn.util.codegen import CodeGenMixin
 from e3nn.util import prod
+from e3nn.util.codegen import CodeGenMixin
+from e3nn.util.jit import compile_mode
 
-from ._instruction import Instruction
 from ._codegen import codegen_tensor_product
+from ._instruction import Instruction
 
 
 @compile_mode('script')
@@ -182,7 +182,8 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         in1_var: Optional[Union[List[float], torch.Tensor]] = None,
         in2_var: Optional[Union[List[float], torch.Tensor]] = None,
         out_var: Optional[Union[List[float], torch.Tensor]] = None,
-        normalization: str = 'component',
+        irrep_normalization: str = 'component',
+        path_normalization: str = 'element',
         internal_weights: Optional[bool] = None,
         shared_weights: Optional[bool] = None,
         _specialized_code: Optional[bool] = None,
@@ -191,33 +192,14 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         # === Setup ===
         super().__init__()
 
-        # Determine irreps
+        assert irrep_normalization in ['component', 'norm']
+        assert path_normalization in ['element', 'path']
+
         self.irreps_in1 = o3.Irreps(irreps_in1)
         self.irreps_in2 = o3.Irreps(irreps_in2)
         self.irreps_out = o3.Irreps(irreps_out)
+        del irreps_in1, irreps_in2, irreps_out
 
-        self._in1_dim = self.irreps_in1.dim
-        self._in2_dim = self.irreps_in2.dim
-
-        if in1_var is None:
-            self.in1_var = [1.0 for _ in range(len(self.irreps_in1))]
-        else:
-            self.in1_var = [float(var) for var in in1_var]
-            assert len(self.in1_var) == len(self.irreps_in1), "Len of ir1_var must be equal to len(irreps_in1)"
-
-        if in2_var is None:
-            self.in2_var = [1.0 for _ in range(len(self.irreps_in2))]
-        else:
-            self.in2_var = [float(var) for var in in2_var]
-            assert len(self.in2_var) == len(self.irreps_in2), "Len of ir2_var must be equal to len(irreps_in2)"
-
-        if out_var is None:
-            self.out_var = [1.0 for _ in range(len(self.irreps_out))]
-        else:
-            self.out_var = [float(var) for var in out_var]
-            assert len(self.out_var) == len(self.irreps_out), "Len of out_var must be equal to len(irreps_out)"
-
-        # Preprocess instructions into objects
         instructions = [x if len(x) == 6 else x + (1.0,) for x in instructions]
         instructions = [
             Instruction(
@@ -233,10 +215,76 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
             )
             for i_in1, i_in2, i_out, connection_mode, has_weight, path_weight in instructions
         ]
-        self.instructions = instructions
 
-        assert normalization in ['component', 'norm'], normalization
-        self.normalization = normalization
+        if in1_var is None:
+            in1_var = [1.0 for _ in range(len(self.irreps_in1))]
+        else:
+            in1_var = [float(var) for var in in1_var]
+            assert len(in1_var) == len(self.irreps_in1), "Len of ir1_var must be equal to len(irreps_in1)"
+
+        if in2_var is None:
+            in2_var = [1.0 for _ in range(len(self.irreps_in2))]
+        else:
+            in2_var = [float(var) for var in in2_var]
+            assert len(in2_var) == len(self.irreps_in2), "Len of ir2_var must be equal to len(irreps_in2)"
+
+        if out_var is None:
+            out_var = [1.0 for _ in range(len(self.irreps_out))]
+        else:
+            out_var = [float(var) for var in out_var]
+            assert len(out_var) == len(self.irreps_out), "Len of out_var must be equal to len(irreps_out)"
+
+        def num_elements(ins):
+            return {
+                'uvw': (self.irreps_in1[ins.i_in1].mul * self.irreps_in2[ins.i_in2].mul),
+                'uvu': self.irreps_in2[ins.i_in2].mul,
+                'uvv': self.irreps_in1[ins.i_in1].mul,
+                'uuw': self.irreps_in1[ins.i_in1].mul,
+                'uuu': 1,
+                'uvuv': 1,
+            }[ins.connection_mode]
+
+        normalization_coefficients = []
+        for ins in instructions:
+            mul_ir_in1 = self.irreps_in1[ins.i_in1]
+            mul_ir_in2 = self.irreps_in2[ins.i_in2]
+            mul_ir_out = self.irreps_out[ins.i_out]
+            assert mul_ir_in1.ir.p * mul_ir_in2.ir.p == mul_ir_out.ir.p
+            assert abs(mul_ir_in1.ir.l - mul_ir_in2.ir.l) <= mul_ir_out.ir.l <= mul_ir_in1.ir.l + mul_ir_in2.ir.l
+            assert ins.connection_mode in ['uvw', 'uvu', 'uvv', 'uuw', 'uuu', 'uvuv']
+
+            alpha = 1
+
+            if irrep_normalization == 'component':
+                alpha *= mul_ir_out.ir.dim
+            if irrep_normalization == 'norm':
+                alpha *= mul_ir_in1.ir.dim * mul_ir_in2.ir.dim
+
+            if path_normalization == 'element':
+                x = sum(
+                    in1_var[i.i_in1] * in2_var[i.i_in2] * num_elements(i)
+                    for i in instructions
+                    if i.i_out == ins.i_out
+                )
+            if path_normalization == 'path':
+                x = in1_var[ins.i_in1] * in2_var[ins.i_in2] * num_elements(ins)
+                x *= len([i for i in instructions if i.i_out == ins.i_out])
+
+            if x > 0.0:
+                alpha /= x
+
+            alpha *= out_var[ins.i_out]
+            alpha *= ins.path_weight
+
+            normalization_coefficients += [sqrt(alpha)]
+
+        self.instructions = [
+            Instruction(ins.i_in1, ins.i_in2, ins.i_out, ins.connection_mode, ins.has_weight, alpha, ins.path_shape)
+            for ins, alpha in zip(instructions, normalization_coefficients)
+        ]
+
+        self._in1_dim = self.irreps_in1.dim
+        self._in2_dim = self.irreps_in2.dim
 
         if shared_weights is False and internal_weights is None:
             internal_weights = False
@@ -259,13 +307,9 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         # Generate the actual tensor product code
         graphmod_out, graphmod_right = codegen_tensor_product(
             self.irreps_in1,
-            self.in1_var,
             self.irreps_in2,
-            self.in2_var,
             self.irreps_out,
-            self.out_var,
             self.instructions,
-            self.normalization,
             self.shared_weights,
             self._specialized_code,
             self._optimize_einsums
@@ -515,8 +559,8 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
 
         import matplotlib
         import matplotlib.pyplot as plt
-        from matplotlib.path import Path
         from matplotlib import patches
+        from matplotlib.path import Path
 
         if ax is None:
             ax = plt.gca()

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -246,12 +246,12 @@ def test_f():
         "0e + 1e + 2e",
         "0e + 2x1e + 2e",
         f_in=44,
-        f_out=5,
+        f_out=25,
         _optimize_einsums=False
     )
     assert_equivariant(m, args_in=[torch.randn(10, 44, 9)])
     m = assert_auto_jitable(m)
     y = m(torch.randn(10, 44, 9))
     assert m.weight_numel == 4
-    assert m.weight.numel() == 44 * 5 * 4
+    assert m.weight.numel() == 44 * 25 * 4
     assert 0.7 < y.pow(2).mean() < 1.4

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -96,15 +96,16 @@ def test_bilinear_right_variance_equivariance(float_tolerance, l1, p1, l2, p2, l
 
 
 # This is a fairly expensive test, so we don't run too many configs
+@pytest.mark.parametrize('path_normalization', ['element', 'path'])
 @pytest.mark.parametrize('l1, p1, l2, p2, lo, po, mode, weight', random_params(n=8))
-def test_normalized(l1, p1, l2, p2, lo, po, mode, weight):
+def test_normalized(l1, p1, l2, p2, lo, po, mode, weight, path_normalization):
     if torch.get_default_dtype() != torch.float32:
         pytest.skip(
             "No reason to run expensive normalization tests again at float64 expense."
         )
     # Explicit fixed path weights screw with the output normalization,
     # so don't use them
-    m = make_tp(l1, p1, l2, p2, lo, po, mode, weight, mul=5, path_weights=False)
+    m = make_tp(l1, p1, l2, p2, lo, po, mode, weight, mul=5, path_weights=False, path_normalization=path_normalization)
     # normalization
     # n_weight, n_input has to be decently high to ensure statistical convergence
     # especially for uvuv
@@ -183,12 +184,12 @@ def test_specialized_code(normalization, mode, weighted, float_tolerance):
     ]
     tp1 = TensorProduct(
         irreps_in1, irreps_in2, irreps_out,
-        ins, normalization=normalization,
+        ins, irrep_normalization=normalization,
         _specialized_code=False
     )
     tp2 = TensorProduct(
         irreps_in1, irreps_in2, irreps_out,
-        ins, normalization=normalization,
+        ins, irrep_normalization=normalization,
         _specialized_code=True
     )
     with torch.no_grad():


### PR DESCRIPTION
## Description
- add `path_normalization` that can take values `element` or `path`
- rename `normalization` into `irrep_normalization`

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
