### PR TITLE
Compile minimum stuff

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `irrep_normalization` and `path_normalization` for `TensorProduct`
+- `compile_right` flag to `TensorProduct`
+- Add new global flag `jit_script_fx=False` that by default turns of the `torch.jit.script` of fx code
 
 ## [0.4.1] - 2021-10-29
 ### Added

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `irrep_normalization` and `path_normalization` for `TensorProduct`
 - `compile_right` flag to `TensorProduct`
-- Add new global flag `jit_script_fx=False` that by default turns of the `torch.jit.script` of fx code
+- Add new global flag `jit_script_fx` to optionally turn off `torch.jit.script` of fx code
 
 ## [0.4.1] - 2021-10-29
 ### Added

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -10,23 +10,18 @@ _OPT_DEFAULTS: Dict[str, bool] = dict(
 )
 
 
-def set_optimization_defaults(
-    specialized_code: bool = True,
-    optimize_einsums: bool = False,
-    jit_script_fx: bool = False,
-) -> None:
+def set_optimization_defaults(**kwargs) -> None:
     r"""Globally set the default optimization settings.
 
     Parameters
     ----------
-    specialized_code : bool, default True
-        Whether to use specialized code for (combinations of) irreps for which it exists.
-    optimize_einsums : bool, default True
-        Whether to use ``opt_einsum_fx``.
+    **kwargs
+        Keyword arguments to set the default optimization settings.
     """
-    _OPT_DEFAULTS['specialized_code'] = specialized_code
-    _OPT_DEFAULTS['optimize_einsums'] = optimize_einsums
-    _OPT_DEFAULTS['jit_script_fx'] = jit_script_fx
+    for k, v in kwargs.items():
+        if k not in _OPT_DEFAULTS:
+            raise ValueError(f"Unknown optimization option: {k}")
+        _OPT_DEFAULTS[k] = v
 
 
 def get_optimization_defaults() -> Dict[str, bool]:

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -5,13 +5,15 @@ from typing import Dict
 
 _OPT_DEFAULTS: Dict[str, bool] = dict(
     specialized_code=True,
-    optimize_einsums=True
+    optimize_einsums=False,
+    jit_script_fx=False,
 )
 
 
 def set_optimization_defaults(
     specialized_code: bool = True,
-    optimize_einsums: bool = True
+    optimize_einsums: bool = False,
+    jit_script_fx: bool = False,
 ) -> None:
     r"""Globally set the default optimization settings.
 
@@ -24,6 +26,7 @@ def set_optimization_defaults(
     """
     _OPT_DEFAULTS['specialized_code'] = specialized_code
     _OPT_DEFAULTS['optimize_einsums'] = optimize_einsums
+    _OPT_DEFAULTS['jit_script_fx'] = jit_script_fx
 
 
 def get_optimization_defaults() -> Dict[str, bool]:

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -6,7 +6,7 @@ from typing import Dict
 _OPT_DEFAULTS: Dict[str, bool] = dict(
     specialized_code=True,
     optimize_einsums=False,
-    jit_script_fx=False,
+    jit_script_fx=True,
 )
 
 

--- a/e3nn/nn/models/v2103/voxel_convolution.py
+++ b/e3nn/nn/models/v2103/voxel_convolution.py
@@ -60,7 +60,12 @@ class Convolution(torch.nn.Module):
         sh = o3.spherical_harmonics(self.irreps_sh, lattice, True, 'component')  # [x, y, z, irreps_sh.dim]
         self.register_buffer('sh', sh)
 
-        self.tp = FullyConnectedTensorProduct(self.irreps_in, self.irreps_sh, self.irreps_out, shared_weights=False)
+        self.tp = FullyConnectedTensorProduct(
+            self.irreps_in, self.irreps_sh, self.irreps_out,
+            shared_weights=False,
+            compile_left_right=False,
+            compile_right=False,
+        )
 
         self.weight = torch.nn.Parameter(torch.randn(self.num_rbfs, self.tp.weight_numel))
 

--- a/e3nn/nn/models/v2103/voxel_convolution.py
+++ b/e3nn/nn/models/v2103/voxel_convolution.py
@@ -64,7 +64,7 @@ class Convolution(torch.nn.Module):
             self.irreps_in, self.irreps_sh, self.irreps_out,
             shared_weights=False,
             compile_left_right=False,
-            compile_right=False,
+            compile_right=True,
         )
 
         self.weight = torch.nn.Parameter(torch.randn(self.num_rbfs, self.tp.weight_numel))

--- a/e3nn/nn/models/v2104/voxel_convolution.py
+++ b/e3nn/nn/models/v2104/voxel_convolution.py
@@ -87,7 +87,7 @@ class Convolution(torch.nn.Module):
             self.irreps_in, self.irreps_sh, self.irreps_out,
             shared_weights=False,
             compile_left_right=False,
-            compile_right=False,
+            compile_right=True,
         )
 
         self.weight = torch.nn.Parameter(torch.randn(self.num_radial_basis, self.tp.weight_numel))

--- a/e3nn/nn/models/v2104/voxel_convolution.py
+++ b/e3nn/nn/models/v2104/voxel_convolution.py
@@ -83,7 +83,12 @@ class Convolution(torch.nn.Module):
         )  # [x, y, z, irreps_sh.dim]
         self.register_buffer('sh', sh)
 
-        self.tp = FullyConnectedTensorProduct(self.irreps_in, self.irreps_sh, self.irreps_out, shared_weights=False)
+        self.tp = FullyConnectedTensorProduct(
+            self.irreps_in, self.irreps_sh, self.irreps_out,
+            shared_weights=False,
+            compile_left_right=False,
+            compile_right=False,
+        )
 
         self.weight = torch.nn.Parameter(torch.randn(self.num_radial_basis, self.tp.weight_numel))
 

--- a/e3nn/o3/_linear.py
+++ b/e3nn/o3/_linear.py
@@ -1,6 +1,6 @@
 from typing import List, NamedTuple, Optional, Tuple, Union
 
-from opt_einsum_fx import jitable, optimize_einsums_full
+from opt_einsum_fx import optimize_einsums_full
 import torch
 from torch import fx
 
@@ -489,6 +489,6 @@ def _codegen_linear(
                 bias_numel,
             ),
         )
-        graphmod_out = jitable(optimize_einsums_full(graphmod_out, example_inputs))
+        graphmod_out = optimize_einsums_full(graphmod_out, example_inputs)
 
     return graphmod_out, weight_numel, bias_numel

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -20,7 +20,7 @@ def _sum_tensors(xs: List[torch.Tensor], shape: torch.Size, like: torch.Tensor):
     return like.new_zeros(shape)
 
 
-def codegen_tensor_product(
+def codegen_tensor_product_left_right(
     irreps_in1: o3.Irreps,
     irreps_in2: o3.Irreps,
     irreps_out: o3.Irreps,
@@ -30,27 +30,19 @@ def codegen_tensor_product(
     optimize_einsums: bool = True,
 ) -> Tuple[fx.GraphModule, fx.GraphModule]:
     graph_out = fx.Graph()
-    graph_right = fx.Graph()
 
     # = Function definitions =
     tracer_out = fx.proxy.GraphAppendingTracer(graph_out)
-    tracer_right = fx.proxy.GraphAppendingTracer(graph_right)
 
     x1s_out = fx.Proxy(graph_out.placeholder('x1', torch.Tensor), tracer=tracer_out)
     x2s_out = fx.Proxy(graph_out.placeholder('x2', torch.Tensor), tracer=tracer_out)
     ws_out = fx.Proxy(graph_out.placeholder('w', torch.Tensor), tracer=tracer_out)
 
-    x2s_right = fx.Proxy(graph_right.placeholder('x2', torch.Tensor), tracer=tracer_right)
-    ws_right = fx.Proxy(graph_right.placeholder('w', torch.Tensor), tracer=tracer_right)
-
     empty_out = fx.Proxy(graph_out.call_function(torch.empty, ((),), dict(device='cpu')), tracer=tracer_out)
-    empty_right = fx.Proxy(graph_right.call_function(torch.empty, ((),), dict(device='cpu')), tracer=tracer_right)
     if shared_weights:
         size_out = torch.broadcast_tensors(empty_out.expand(x1s_out.shape[:-1]), empty_out.expand(x2s_out.shape[:-1]))[0].shape
-        size_right = x2s_right.shape[:-1]
     else:
         size_out = torch.broadcast_tensors(empty_out.expand(x1s_out.shape[:-1]), empty_out.expand(x2s_out.shape[:-1]), empty_out.expand(ws_out.shape[:-1]))[0].shape
-        size_right = torch.broadcast_tensors(empty_right.expand(x2s_right.shape[:-1]), empty_right.expand(ws_right.shape[:-1]))[0].shape
 
     # = Short-circut for zero dimensional =
     # We produce no code for empty instructions
@@ -58,44 +50,33 @@ def codegen_tensor_product(
 
     if len(instructions) == 0:
         out_out = x1s_out.new_zeros(size_out + (irreps_out.dim,))
-        out_right = x2s_right.new_zeros(size_right + (irreps_in1.dim, irreps_out.dim,))
 
         graph_out.output(out_out.node, torch.Tensor)
-        graph_right.output(out_right.node, torch.Tensor)
         # Short circut
-        return (
-            fx.GraphModule({}, graph_out, "tp_forward"),
-            fx.GraphModule({}, graph_right, "tp_right")
-        )
+        return fx.GraphModule({}, graph_out, "tp_forward")
 
     # = Broadcast inputs =
     if shared_weights:
         x1s_out, x2s_out = x1s_out.broadcast_to(size_out + (-1,)), x2s_out.broadcast_to(size_out + (-1,))
     else:
         x1s_out, x2s_out, ws_out = x1s_out.broadcast_to(size_out + (-1,)), x2s_out.broadcast_to(size_out + (-1,)), ws_out.broadcast_to(size_out + (-1,))
-        x2s_right, ws_right = x2s_right.broadcast_to(size_right + (-1,)), ws_right.broadcast_to(size_right + (-1,))
 
     outsize_out = size_out + (irreps_out.dim,)
-    outsize_right = size_right + (irreps_in1.dim, irreps_out.dim,)
 
     x1s_out = x1s_out.reshape(-1, irreps_in1.dim)
     x2s_out = x2s_out.reshape(-1, irreps_in2.dim)
-    x2s_right = x2s_right.reshape(-1, irreps_in2.dim)
 
     batch_out = x1s_out.shape[0]
-    batch_right = x2s_right.shape[0]
 
     # = Determine number of weights and reshape weights ==
     weight_numel = sum(prod(ins.path_shape) for ins in instructions if ins.has_weight)
     if weight_numel > 0:
         ws_out = ws_out.reshape(-1, weight_numel)
-        ws_right = ws_right.reshape(-1, weight_numel)
     del weight_numel
 
     # = book-keeping for wigners =
     w3j = []
     w3j_dict_out = dict()
-    w3j_dict_right = dict()
 
     # = extract individual input irreps =
     # If only one input irrep, can avoid creating a view
@@ -108,22 +89,15 @@ def codegen_tensor_product(
         ]
 
     x2_list_out = []
-    x2_list_right = []
     # If only one input irrep, can avoid creating a view
     if len(irreps_in2) == 1:
         x2_list_out.append(
             x2s_out.reshape(batch_out, irreps_in2[0].mul, irreps_in2[0].ir.dim)
         )
-        x2_list_right.append(
-            x2s_right.reshape(batch_right, irreps_in2[0].mul, irreps_in2[0].ir.dim)
-        )
     else:
         for i, mul_ir in zip(irreps_in2.slices(), irreps_in2):
             x2_list_out.append(
                 x2s_out[:, i].reshape(batch_out, mul_ir.mul, mul_ir.ir.dim)
-            )
-            x2_list_right.append(
-                x2s_right[:, i].reshape(batch_right, mul_ir.mul, mul_ir.ir.dim)
             )
 
     # The einsum string index to prepend to the weights if the weights are not shared and have a batch dimension
@@ -136,7 +110,6 @@ def codegen_tensor_product(
     flat_weight_index = 0
 
     out_list_out = []
-    out_list_right = []
 
     for ins in instructions:
         mul_ir_in1 = irreps_in1[ins.i_in1]
@@ -156,18 +129,12 @@ def codegen_tensor_product(
 
         x1_out = x1_list_out[ins.i_in1]
         x2_out = x2_list_out[ins.i_in2]
-        x2_right = x2_list_right[ins.i_in2]
-
-        e1_right = fx.Proxy(graph_right.call_function(torch.eye, (mul_ir_in1.mul,), dict(dtype=x2s_right.dtype.node, device=x2s_right.device.node)), tracer=tracer_right)
-        e2_right = fx.Proxy(graph_right.call_function(torch.eye, (mul_ir_in2.mul,), dict(dtype=x2s_right.dtype.node, device=x2s_right.device.node)), tracer=tracer_right)
-        i1_right = fx.Proxy(graph_right.call_function(torch.eye, (mul_ir_in1.ir.dim,), dict(dtype=x2s_right.dtype.node, device=x2s_right.device.node)), tracer=tracer_right)
 
         assert ins.connection_mode in ['uvw', 'uvu', 'uvv', 'uuw', 'uuu', 'uvuv']
 
         if ins.has_weight:
             # Extract the weight from the flattened weight tensor
             w_out = ws_out[:, flat_weight_index:flat_weight_index + prod(ins.path_shape)].reshape((() if shared_weights else (-1,)) + tuple(ins.path_shape))
-            w_right = ws_right[:, flat_weight_index:flat_weight_index + prod(ins.path_shape)].reshape((() if shared_weights else (-1,)) + tuple(ins.path_shape))
             flat_weight_index += prod(ins.path_shape)
 
         # Construct the general xx in case this instruction isn't specialized
@@ -185,68 +152,50 @@ def codegen_tensor_product(
         key = (mul_ir_in1.ir.l, mul_ir_in2.ir.l, mul_ir_out.ir.l)
         if key not in w3j:
             w3j_dict_out[key] = fx.Proxy(graph_out.get_attr(f"_w3j_{key[0]}_{key[1]}_{key[2]}"), tracer=tracer_out)
-            w3j_dict_right[key] = fx.Proxy(graph_right.get_attr(f"_w3j_{key[0]}_{key[1]}_{key[2]}"), tracer=tracer_right)
             w3j.append(key)
         w3j_out = w3j_dict_out[key]
-        w3j_right = w3j_dict_right[key]
 
         if ins.connection_mode == 'uvw':
             assert ins.has_weight
             if specialized_code and key == (0, 0, 0):
                 ein_out = torch.einsum(f"{z}uvw,zu,zv->zw", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out.reshape(batch_out, mul_ir_in2.dim))
-                ein_right = torch.einsum(f"{z}uvw,zv->zuw", w_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
             elif specialized_code and mul_ir_in1.ir.l == 0:
                 ein_out = torch.einsum(f"{z}uvw,zu,zvj->zwj", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out) / sqrt(mul_ir_out.ir.dim)
-                ein_right = torch.einsum(f"{z}uvw,zvi->zuwi", w_right, x2_right) / sqrt(mul_ir_out.ir.dim)
             elif specialized_code and mul_ir_in2.ir.l == 0:
                 ein_out = torch.einsum(f"{z}uvw,zui,zv->zwi", w_out, x1_out, x2_out.reshape(batch_out, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
-                ein_right = torch.einsum(f"{z}uvw,ij,zv->zuiwj", w_right, i1_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
             elif specialized_code and mul_ir_out.ir.l == 0:
                 ein_out = torch.einsum(f"{z}uvw,zui,zvi->zw", w_out, x1_out, x2_out) / sqrt(mul_ir_in1.ir.dim)
-                ein_right = torch.einsum(f"{z}uvw,zvi->zuiw", w_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
             else:
                 ein_out = torch.einsum(f"{z}uvw,ijk,zuvij->zwk", w_out, w3j_out, xx)
-                ein_right = torch.einsum(f"{z}uvw,ijk,zvj->zuiwk", w_right, w3j_right, x2_right)
         if ins.connection_mode == 'uvu':
             assert mul_ir_in1.mul == mul_ir_out.mul
             if ins.has_weight:
                 if specialized_code and key == (0, 0, 0):
                     ein_out = torch.einsum(f"{z}uv,zu,zv->zu", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out.reshape(batch_out, mul_ir_in2.dim))
-                    ein_right = torch.einsum(f"{z}uv,uw,zv->zuw", w_right, e1_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
                 elif specialized_code and mul_ir_in1.ir.l == 0:
                     ein_out = torch.einsum(f"{z}uv,zu,zvj->zuj", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out) / sqrt(mul_ir_out.ir.dim)
-                    ein_right = torch.einsum(f"{z}uv,uw,zvi->zuwi", w_right, e1_right, x2_right) / sqrt(mul_ir_out.ir.dim)
                 elif specialized_code and mul_ir_in2.ir.l == 0:
                     ein_out = torch.einsum(f"{z}uv,zui,zv->zui", w_out, x1_out, x2_out.reshape(batch_out, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
-                    ein_right = torch.einsum(f"{z}uv,ij,uw,zv->zuiwj", w_right, i1_right, e1_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
                 elif specialized_code and mul_ir_out.ir.l == 0:
                     ein_out = torch.einsum(f"{z}uv,zui,zvi->zu", w_out, x1_out, x2_out) / sqrt(mul_ir_in1.ir.dim)
-                    ein_right = torch.einsum(f"{z}uv,uw,zvi->zuiw", w_right, e1_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
                 else:
                     ein_out = torch.einsum(f"{z}uv,ijk,zuvij->zuk", w_out, w3j_out, xx)
-                    ein_right = torch.einsum(f"{z}uv,ijk,uw,zvj->zuiwk", w_right, w3j_right, e1_right, x2_right)
             else:
                 # not so useful operation because v is summed
                 ein_out = torch.einsum("ijk,zuvij->zuk", w3j_out, xx)
-                ein_right = torch.einsum("ijk,uw,zvj->zuiwk", w3j_right, e1_right, x2_right)
         if ins.connection_mode == 'uvv':
             assert mul_ir_in2.mul == mul_ir_out.mul
             if ins.has_weight:
                 if specialized_code and key == (0, 0, 0):
                     ein_out = torch.einsum(f"{z}uv,zu,zv->zv", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out.reshape(batch_out, mul_ir_in2.dim))
-                    ein_right = torch.einsum(f"{z}uv,vw,zv->zuw", w_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
                 elif specialized_code and mul_ir_in1.ir.l == 0:
                     ein_out = torch.einsum(f"{z}uv,zu,zvj->zvj", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out) / sqrt(mul_ir_out.ir.dim)
-                    ein_right = torch.einsum(f"{z}uv,vw,zvi->zuwi", w_right, e2_right, x2_right) / sqrt(mul_ir_out.ir.dim)
                 elif specialized_code and mul_ir_in2.ir.l == 0:
                     ein_out = torch.einsum(f"{z}uv,zui,zv->zvi", w_out, x1_out, x2_out.reshape(batch_out, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
-                    ein_right = torch.einsum(f"{z}uv,ij,vw,zv->zuiwj", w_right, i1_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
                 elif specialized_code and mul_ir_out.ir.l == 0:
                     ein_out = torch.einsum(f"{z}uv,zui,zvi->zv", w_out, x1_out, x2_out) / sqrt(mul_ir_in1.ir.dim)
-                    ein_right = torch.einsum(f"{z}uv,vw,zvi->zuiw", w_right, e2_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
                 else:
                     ein_out = torch.einsum(f"{z}uv,ijk,zuvij->zvk", w_out, w3j_out, xx)
-                    ein_right = torch.einsum(f"{z}uv,ijk,zvj->zuivk", w_right, w3j_right, x2_right)
             else:
                 # not so useful operation because u is summed
                 # only specialize out for this path
@@ -260,8 +209,6 @@ def codegen_tensor_product(
                     ein_out = torch.einsum("zui,zvi->zv", x1_out, x2_out) / sqrt(mul_ir_in1.ir.dim)
                 else:
                     ein_out = torch.einsum("ijk,zuvij->zvk", w3j_out, xx)
-                s2ones = fx.Proxy(graph_right.call_function(torch.ones, (mul_ir_in1.mul,), dict(device=x2_right.device.node, dtype=x2_right.dtype.node)), tracer=tracer_right)
-                ein_right = torch.einsum("u,ijk,zvj->zuivk", s2ones, w3j_right, x2_right)
         if ins.connection_mode == 'uuw':
             assert mul_ir_in1.mul == mul_ir_in2.mul
             if ins.has_weight:
@@ -275,89 +222,67 @@ def codegen_tensor_product(
                     ein_out = torch.einsum(f"{z}uw,zui,zui->zw", w_out, x1_out, x2_out) / sqrt(mul_ir_in1.ir.dim)
                 else:
                     ein_out = torch.einsum(f"{z}uw,ijk,zuij->zwk", w_out, w3j_out, xx)
-                # TODO: specialize right()
-                ein_right = torch.einsum(f"{z}uw,ijk,zuj->zuiwk", w_right, w3j_right, x2_right)
             else:
                 # equivalent to tp(x, y, 'uuu').sum('u')
                 assert mul_ir_out.mul == 1
                 ein_out = torch.einsum("ijk,zuij->zk", w3j_out, xx)
-                ein_right = torch.einsum("ijk,zuj->zuik", w3j_right, x2_right)
         if ins.connection_mode == 'uuu':
             assert mul_ir_in1.mul == mul_ir_in2.mul == mul_ir_out.mul
             if ins.has_weight:
                 if specialized_code and key == (0, 0, 0):
                     ein_out = torch.einsum(f"{z}u,zu,zu->zu", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out.reshape(batch_out, mul_ir_in2.dim))
-                    ein_right = torch.einsum(f"{z}u,uw,zu->zuw", w_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
                 elif specialized_code and key == (1, 1, 1):
                     ein_out = torch.einsum(
                         f"{z}u,zui->zui",
                         w_out,
                         torch.cross(x1_out, x2_out, dim=2)
                     ) / sqrt(2*3)
-                    # For cross product, use the general case right()
-                    ein_right = torch.einsum(f"{z}u,ijk,uw,zuj->zuiwk", w_right, w3j_right, e1_right, x2_right)
                 elif specialized_code and mul_ir_in1.ir.l == 0:
                     ein_out = torch.einsum(f"{z}u,zu,zuj->zuj", w_out, x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out) / sqrt(mul_ir_out.ir.dim)
-                    ein_right = torch.einsum(f"{z}u,uw,zui->zuwi", w_right, e2_right, x2_right) / sqrt(mul_ir_out.ir.dim)
                 elif specialized_code and mul_ir_in2.ir.l == 0:
                     ein_out = torch.einsum(f"{z}u,zui,zu->zui", w_out, x1_out, x2_out.reshape(batch_out, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
-                    ein_right = torch.einsum(f"{z}u,ij,uw,zu->zuiwj", w_right, i1_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
                 elif specialized_code and mul_ir_out.ir.l == 0:
                     ein_out = torch.einsum(f"{z}u,zui,zui->zu", w_out, x1_out, x2_out) / sqrt(mul_ir_in1.ir.dim)
-                    ein_right = torch.einsum(f"{z}u,uw,zui->zuiw", w_right, e2_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
                 else:
                     ein_out = torch.einsum(f"{z}u,ijk,zuij->zuk", w_out, w3j_out, xx)
-                    ein_right = torch.einsum(f"{z}u,ijk,uw,zuj->zuiwk", w_right, w3j_right, e1_right, x2_right)
             else:
                 if specialized_code and key == (0, 0, 0):
                     ein_out = torch.einsum("zu,zu->zu", x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out.reshape(batch_out, mul_ir_in2.dim))
-                    ein_right = torch.einsum("uw,zu->zuw", e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
                 elif specialized_code and key == (1, 1, 1):
                     ein_out = torch.cross(x1_out, x2_out, dim=2) * (1.0 / sqrt(2*3))
-                    # For cross product, use the general case right()
-                    ein_right = torch.einsum("ijk,uw,zuj->zuiwk", w3j_right, e1_right, x2_right)
                 elif specialized_code and mul_ir_in1.ir.l == 0:
                     ein_out = torch.einsum("zu,zuj->zuj", x1_out.reshape(batch_out, mul_ir_in1.dim), x2_out) / sqrt(mul_ir_out.ir.dim)
-                    ein_right = torch.einsum("uw,zui->zuwi", e2_right, x2_right) / sqrt(mul_ir_out.ir.dim)
                 elif specialized_code and mul_ir_in2.ir.l == 0:
                     ein_out = torch.einsum("zui,zu->zui", x1_out, x2_out.reshape(batch_out, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
-                    ein_right = torch.einsum("ij,uw,zu->zuiwj", i1_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
                 elif specialized_code and mul_ir_out.ir.l == 0:
                     ein_out = torch.einsum("zui,zui->zu", x1_out, x2_out) / sqrt(mul_ir_in1.ir.dim)
-                    ein_right = torch.einsum("uw,zui->zuiw", e2_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
                 else:
                     ein_out = torch.einsum("ijk,zuij->zuk", w3j_out, xx)
-                    ein_right = torch.einsum("ijk,uw,zuj->zuiwk", w3j_right, e1_right, x2_right)
         if ins.connection_mode == 'uvuv':
             assert mul_ir_in1.mul * mul_ir_in2.mul == mul_ir_out.mul
             if ins.has_weight:
                 # TODO implement specialized code
                 ein_out = torch.einsum(f"{z}uv,ijk,zuvij->zuvk", w_out, w3j_out, xx)
-                ein_right = torch.einsum(f"{z}uv,ijk,uw,zvj->zuiwvk", w_right, w3j_right, e1_right, x2_right)
             else:
                 # TODO implement specialized code
                 ein_out = torch.einsum("ijk,zuvij->zuvk", w3j_out, xx)
-                ein_right = torch.einsum("ijk,uw,zvj->zuiwvk", w3j_right, e1_right, x2_right)
 
         ein_out = ins.path_weight * ein_out
-        ein_right = ins.path_weight * ein_right
 
         out_list_out += [ein_out.reshape(batch_out, mul_ir_out.dim)]
-        out_list_right += [ein_right.reshape(batch_right, mul_ir_in1.dim, mul_ir_out.dim)]
 
         # Close the profiler block
         # - PROFILER - graph_out.call_function(torch.ops.profiler._record_function_exit, (handle_out,))
         # - PROFILER - graph_right.call_function(torch.ops.profiler._record_function_exit, (handle_right,))
 
         # Remove unused w3js:
-        if len(w3j_out.node.users) == 0 and len(w3j_right.node.users) == 0:
+        if len(w3j_out.node.users) == 0:
             del w3j[-1]
             # The w3j nodes are reshapes, so we have to remove them from the graph
             # Although they are dead code, they try to reshape to dimensions that don't exist
             # (since the corresponding w3js are not in w3j)
             # so they screw up the shape propagation, even though they would be removed later as dead code by TorchScript.
             graph_out.erase_node(w3j_dict_out.pop(key).node)
-            graph_right.erase_node(w3j_dict_right.pop(key).node)
 
     # = Return the result =
     out_out = [
@@ -375,33 +300,12 @@ def codegen_tensor_product(
         # Avoid an unnecessary copy in a size one torch.cat
         out_out = out_out[0]
 
-    out_right = [
-        torch.cat([
-            _sum_tensors(
-                [out for ins, out in zip(instructions, out_list_right) if (ins.i_in1, ins.i_out) == (i_in1, i_out)],
-                shape=(batch_right, mul_ir_in1.dim, mul_ir_out.dim),
-                like=x2s_right
-            )
-            for i_out, mul_ir_out in enumerate(irreps_out)
-            if mul_ir_out.mul > 0
-        ], dim=2)
-        for i_in1, mul_ir_in1 in enumerate(irreps_in1)
-        if mul_ir_in1.mul > 0
-    ]
-    if len(out_right) > 1:
-        out_right = torch.cat(out_right, dim=1)
-    else:
-        out_right = out_right[0]
-
     out_out = out_out.reshape(outsize_out)
-    out_right = out_right.reshape(outsize_right)
 
     graph_out.output(out_out.node, torch.Tensor)
-    graph_right.output(out_right.node, torch.Tensor)
 
     # check graphs
     graph_out.lint()
-    graph_right.lint()
 
     # Make GraphModules
     wigner_mats = {}
@@ -416,7 +320,6 @@ def codegen_tensor_product(
     for wkey, wmat in wigner_mats.items():
         constants_root.register_buffer(wkey, wmat)
     graphmod_out = fx.GraphModule(constants_root, graph_out, class_name="tp_forward")
-    graphmod_right = fx.GraphModule(constants_root, graph_right, class_name="tp_right")
 
     # == Optimize ==
     # TODO: when eliminate_dead_code() is in PyTorch stable, use that
@@ -449,6 +352,304 @@ def codegen_tensor_product(
             ),
         )
         graphmod_out = jitable(optimize_einsums_full(graphmod_out, example_inputs))
+
+    return graphmod_out
+
+
+def codegen_tensor_product_right(
+    irreps_in1: o3.Irreps,
+    irreps_in2: o3.Irreps,
+    irreps_out: o3.Irreps,
+    instructions: List[Instruction],
+    shared_weights: bool = False,
+    specialized_code: bool = True,
+    optimize_einsums: bool = True,
+) -> Tuple[fx.GraphModule, fx.GraphModule]:
+    graph_right = fx.Graph()
+
+    # = Function definitions =
+    tracer_right = fx.proxy.GraphAppendingTracer(graph_right)
+
+    x2s_right = fx.Proxy(graph_right.placeholder('x2', torch.Tensor), tracer=tracer_right)
+    ws_right = fx.Proxy(graph_right.placeholder('w', torch.Tensor), tracer=tracer_right)
+
+    empty_right = fx.Proxy(graph_right.call_function(torch.empty, ((),), dict(device='cpu')), tracer=tracer_right)
+    if shared_weights:
+        size_right = x2s_right.shape[:-1]
+    else:
+        size_right = torch.broadcast_tensors(empty_right.expand(x2s_right.shape[:-1]), empty_right.expand(ws_right.shape[:-1]))[0].shape
+
+    # = Short-circut for zero dimensional =
+    # We produce no code for empty instructions
+    instructions = [ins for ins in instructions if 0 not in ins.path_shape]
+
+    if len(instructions) == 0:
+        out_right = x2s_right.new_zeros(size_right + (irreps_in1.dim, irreps_out.dim,))
+
+        graph_right.output(out_right.node, torch.Tensor)
+        # Short circut
+        return fx.GraphModule({}, graph_right, "tp_right")
+
+    # = Broadcast inputs =
+    if not shared_weights:
+        x2s_right, ws_right = x2s_right.broadcast_to(size_right + (-1,)), ws_right.broadcast_to(size_right + (-1,))
+
+    outsize_right = size_right + (irreps_in1.dim, irreps_out.dim,)
+
+    x2s_right = x2s_right.reshape(-1, irreps_in2.dim)
+
+    batch_right = x2s_right.shape[0]
+
+    # = Determine number of weights and reshape weights ==
+    weight_numel = sum(prod(ins.path_shape) for ins in instructions if ins.has_weight)
+    if weight_numel > 0:
+        ws_right = ws_right.reshape(-1, weight_numel)
+    del weight_numel
+
+    # = book-keeping for wigners =
+    w3j = []
+    w3j_dict_right = dict()
+
+    # = extract individual input irreps =
+    # If only one input irrep, can avoid creating a view
+    x2_list_right = []
+    # If only one input irrep, can avoid creating a view
+    if len(irreps_in2) == 1:
+        x2_list_right.append(
+            x2s_right.reshape(batch_right, irreps_in2[0].mul, irreps_in2[0].ir.dim)
+        )
+    else:
+        for i, mul_ir in zip(irreps_in2.slices(), irreps_in2):
+            x2_list_right.append(
+                x2s_right[:, i].reshape(batch_right, mul_ir.mul, mul_ir.ir.dim)
+            )
+
+    # The einsum string index to prepend to the weights if the weights are not shared and have a batch dimension
+    z = '' if shared_weights else 'z'
+
+    # Current index in the flat weight tensor
+    flat_weight_index = 0
+
+    out_list_right = []
+
+    for ins in instructions:
+        mul_ir_in1 = irreps_in1[ins.i_in1]
+        mul_ir_in2 = irreps_in2[ins.i_in2]
+        mul_ir_out = irreps_out[ins.i_out]
+
+        assert mul_ir_in1.ir.p * mul_ir_in2.ir.p == mul_ir_out.ir.p
+        assert abs(mul_ir_in1.ir.l - mul_ir_in2.ir.l) <= mul_ir_out.ir.l <= mul_ir_in1.ir.l + mul_ir_in2.ir.l
+
+        if mul_ir_in1.dim == 0 or mul_ir_in2.dim == 0 or mul_ir_out.dim == 0:
+            continue
+
+        # Open the profiler block
+        # - PROFILER - name = f"{mul_ir_in1} x {mul_ir_in2} = {mul_ir_out} {ins.connection_mode} {ins.has_weight}"
+        # - PROFILER - handle_out = graph_out.call_function(torch.ops.profiler._record_function_enter, (name,))
+        # - PROFILER - handle_right = graph_right.call_function(torch.ops.profiler._record_function_enter, (name,))
+
+        x2_right = x2_list_right[ins.i_in2]
+
+        e1_right = fx.Proxy(graph_right.call_function(torch.eye, (mul_ir_in1.mul,), dict(dtype=x2s_right.dtype.node, device=x2s_right.device.node)), tracer=tracer_right)
+        e2_right = fx.Proxy(graph_right.call_function(torch.eye, (mul_ir_in2.mul,), dict(dtype=x2s_right.dtype.node, device=x2s_right.device.node)), tracer=tracer_right)
+        i1_right = fx.Proxy(graph_right.call_function(torch.eye, (mul_ir_in1.ir.dim,), dict(dtype=x2s_right.dtype.node, device=x2s_right.device.node)), tracer=tracer_right)
+
+        assert ins.connection_mode in ['uvw', 'uvu', 'uvv', 'uuw', 'uuu', 'uvuv']
+
+        if ins.has_weight:
+            # Extract the weight from the flattened weight tensor
+            w_right = ws_right[:, flat_weight_index:flat_weight_index + prod(ins.path_shape)].reshape((() if shared_weights else (-1,)) + tuple(ins.path_shape))
+            flat_weight_index += prod(ins.path_shape)
+
+        # Create a proxy & request for the relevant wigner w3j
+        # If not used (because of specialized code), will get removed later.
+        key = (mul_ir_in1.ir.l, mul_ir_in2.ir.l, mul_ir_out.ir.l)
+        if key not in w3j:
+            w3j_dict_right[key] = fx.Proxy(graph_right.get_attr(f"_w3j_{key[0]}_{key[1]}_{key[2]}"), tracer=tracer_right)
+            w3j.append(key)
+        w3j_right = w3j_dict_right[key]
+
+        if ins.connection_mode == 'uvw':
+            assert ins.has_weight
+            if specialized_code and key == (0, 0, 0):
+                ein_right = torch.einsum(f"{z}uvw,zv->zuw", w_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
+            elif specialized_code and mul_ir_in1.ir.l == 0:
+                ein_right = torch.einsum(f"{z}uvw,zvi->zuwi", w_right, x2_right) / sqrt(mul_ir_out.ir.dim)
+            elif specialized_code and mul_ir_in2.ir.l == 0:
+                ein_right = torch.einsum(f"{z}uvw,ij,zv->zuiwj", w_right, i1_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
+            elif specialized_code and mul_ir_out.ir.l == 0:
+                ein_right = torch.einsum(f"{z}uvw,zvi->zuiw", w_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
+            else:
+                ein_right = torch.einsum(f"{z}uvw,ijk,zvj->zuiwk", w_right, w3j_right, x2_right)
+        if ins.connection_mode == 'uvu':
+            assert mul_ir_in1.mul == mul_ir_out.mul
+            if ins.has_weight:
+                if specialized_code and key == (0, 0, 0):
+                    ein_right = torch.einsum(f"{z}uv,uw,zv->zuw", w_right, e1_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
+                elif specialized_code and mul_ir_in1.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}uv,uw,zvi->zuwi", w_right, e1_right, x2_right) / sqrt(mul_ir_out.ir.dim)
+                elif specialized_code and mul_ir_in2.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}uv,ij,uw,zv->zuiwj", w_right, i1_right, e1_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
+                elif specialized_code and mul_ir_out.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}uv,uw,zvi->zuiw", w_right, e1_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
+                else:
+                    ein_right = torch.einsum(f"{z}uv,ijk,uw,zvj->zuiwk", w_right, w3j_right, e1_right, x2_right)
+            else:
+                # not so useful operation because v is summed
+                ein_right = torch.einsum("ijk,uw,zvj->zuiwk", w3j_right, e1_right, x2_right)
+        if ins.connection_mode == 'uvv':
+            assert mul_ir_in2.mul == mul_ir_out.mul
+            if ins.has_weight:
+                if specialized_code and key == (0, 0, 0):
+                    ein_right = torch.einsum(f"{z}uv,vw,zv->zuw", w_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
+                elif specialized_code and mul_ir_in1.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}uv,vw,zvi->zuwi", w_right, e2_right, x2_right) / sqrt(mul_ir_out.ir.dim)
+                elif specialized_code and mul_ir_in2.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}uv,ij,vw,zv->zuiwj", w_right, i1_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
+                elif specialized_code and mul_ir_out.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}uv,vw,zvi->zuiw", w_right, e2_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
+                else:
+                    ein_right = torch.einsum(f"{z}uv,ijk,zvj->zuivk", w_right, w3j_right, x2_right)
+            else:
+                # not so useful operation because u is summed
+                # only specialize out for this path
+                s2ones = fx.Proxy(graph_right.call_function(torch.ones, (mul_ir_in1.mul,), dict(device=x2_right.device.node, dtype=x2_right.dtype.node)), tracer=tracer_right)
+                ein_right = torch.einsum("u,ijk,zvj->zuivk", s2ones, w3j_right, x2_right)
+        if ins.connection_mode == 'uuw':
+            assert mul_ir_in1.mul == mul_ir_in2.mul
+            if ins.has_weight:
+                # TODO: specialize right()
+                ein_right = torch.einsum(f"{z}uw,ijk,zuj->zuiwk", w_right, w3j_right, x2_right)
+            else:
+                # equivalent to tp(x, y, 'uuu').sum('u')
+                assert mul_ir_out.mul == 1
+                ein_right = torch.einsum("ijk,zuj->zuik", w3j_right, x2_right)
+        if ins.connection_mode == 'uuu':
+            assert mul_ir_in1.mul == mul_ir_in2.mul == mul_ir_out.mul
+            if ins.has_weight:
+                if specialized_code and key == (0, 0, 0):
+                    ein_right = torch.einsum(f"{z}u,uw,zu->zuw", w_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
+                elif specialized_code and key == (1, 1, 1):
+                    # For cross product, use the general case right()
+                    ein_right = torch.einsum(f"{z}u,ijk,uw,zuj->zuiwk", w_right, w3j_right, e1_right, x2_right)
+                elif specialized_code and mul_ir_in1.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}u,uw,zui->zuwi", w_right, e2_right, x2_right) / sqrt(mul_ir_out.ir.dim)
+                elif specialized_code and mul_ir_in2.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}u,ij,uw,zu->zuiwj", w_right, i1_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
+                elif specialized_code and mul_ir_out.ir.l == 0:
+                    ein_right = torch.einsum(f"{z}u,uw,zui->zuiw", w_right, e2_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
+                else:
+                    ein_right = torch.einsum(f"{z}u,ijk,uw,zuj->zuiwk", w_right, w3j_right, e1_right, x2_right)
+            else:
+                if specialized_code and key == (0, 0, 0):
+                    ein_right = torch.einsum("uw,zu->zuw", e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim))
+                elif specialized_code and key == (1, 1, 1):
+                    # For cross product, use the general case right()
+                    ein_right = torch.einsum("ijk,uw,zuj->zuiwk", w3j_right, e1_right, x2_right)
+                elif specialized_code and mul_ir_in1.ir.l == 0:
+                    ein_right = torch.einsum("uw,zui->zuwi", e2_right, x2_right) / sqrt(mul_ir_out.ir.dim)
+                elif specialized_code and mul_ir_in2.ir.l == 0:
+                    ein_right = torch.einsum("ij,uw,zu->zuiwj", i1_right, e2_right, x2_right.reshape(batch_right, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
+                elif specialized_code and mul_ir_out.ir.l == 0:
+                    ein_right = torch.einsum("uw,zui->zuiw", e2_right, x2_right) / sqrt(mul_ir_in1.ir.dim)
+                else:
+                    ein_right = torch.einsum("ijk,uw,zuj->zuiwk", w3j_right, e1_right, x2_right)
+        if ins.connection_mode == 'uvuv':
+            assert mul_ir_in1.mul * mul_ir_in2.mul == mul_ir_out.mul
+            if ins.has_weight:
+                # TODO implement specialized code
+                ein_right = torch.einsum(f"{z}uv,ijk,uw,zvj->zuiwvk", w_right, w3j_right, e1_right, x2_right)
+            else:
+                # TODO implement specialized code
+                ein_right = torch.einsum("ijk,uw,zvj->zuiwvk", w3j_right, e1_right, x2_right)
+
+        ein_right = ins.path_weight * ein_right
+
+        out_list_right += [ein_right.reshape(batch_right, mul_ir_in1.dim, mul_ir_out.dim)]
+
+        # Close the profiler block
+        # - PROFILER - graph_out.call_function(torch.ops.profiler._record_function_exit, (handle_out,))
+        # - PROFILER - graph_right.call_function(torch.ops.profiler._record_function_exit, (handle_right,))
+
+        # Remove unused w3js:
+        if len(w3j_right.node.users) == 0:
+            del w3j[-1]
+            # The w3j nodes are reshapes, so we have to remove them from the graph
+            # Although they are dead code, they try to reshape to dimensions that don't exist
+            # (since the corresponding w3js are not in w3j)
+            # so they screw up the shape propagation, even though they would be removed later as dead code by TorchScript.
+            graph_right.erase_node(w3j_dict_right.pop(key).node)
+
+    # = Return the result =
+    out_right = [
+        torch.cat([
+            _sum_tensors(
+                [out for ins, out in zip(instructions, out_list_right) if (ins.i_in1, ins.i_out) == (i_in1, i_out)],
+                shape=(batch_right, mul_ir_in1.dim, mul_ir_out.dim),
+                like=x2s_right
+            )
+            for i_out, mul_ir_out in enumerate(irreps_out)
+            if mul_ir_out.mul > 0
+        ], dim=2)
+        for i_in1, mul_ir_in1 in enumerate(irreps_in1)
+        if mul_ir_in1.mul > 0
+    ]
+    if len(out_right) > 1:
+        out_right = torch.cat(out_right, dim=1)
+    else:
+        out_right = out_right[0]
+
+    out_right = out_right.reshape(outsize_right)
+
+    graph_right.output(out_right.node, torch.Tensor)
+
+    # check graphs
+    graph_right.lint()
+
+    # Make GraphModules
+    wigner_mats = {}
+    for l_1, l_2, l_out in w3j:
+        wigner_mats[f"_w3j_{l_1}_{l_2}_{l_out}"] = o3.wigner_3j(l_1, l_2, l_out)
+
+    # By putting the constants in a Module rather than a dict,
+    # we force FX to copy them as buffers instead of as attributes.
+    #
+    # FX seems to have resolved this issue for dicts in 1.9, but we support all the way back to 1.8.0.
+    constants_root = torch.nn.Module()
+    for wkey, wmat in wigner_mats.items():
+        constants_root.register_buffer(wkey, wmat)
+    graphmod_right = fx.GraphModule(constants_root, graph_right, class_name="tp_right")
+
+    # == Optimize ==
+    # TODO: when eliminate_dead_code() is in PyTorch stable, use that
+    if optimize_einsums:
+        # Note that for our einsums, we can optimize _once_ for _any_ batch dimension
+        # and still get the right path for _all_ batch dimensions.
+        # This is because our einsums are essentially of the form:
+        #    zuvw,ijk,zuvij->zwk    OR     uvw,ijk,zuvij->zwk
+        # In the first case, all but one operands have the batch dimension
+        #    => The first contraction gains the batch dimension
+        #    => All following contractions have batch dimension
+        #    => All possible contraction paths have cost that scales linearly in batch size
+        #    => The optimal path is the same for all batch sizes
+        # For the second case, this logic follows as long as the first contraction is not between the first two operands. Since those two operands do not share any indexes, contracting them first is a rare pathological case. See
+        # https://github.com/dgasmith/opt_einsum/issues/158
+        # for more details.
+        #
+        # TODO: consider the impact maximum intermediate result size on this logic
+        #         \- this is the `memory_limit` option in opt_einsum
+        # TODO: allow user to choose opt_einsum parameters?
+        #
+        # We use float32 and zeros to save memory and time, since opt_einsum_fx looks only at traced shapes, not values or dtypes.
+        batchdim = 4
+        example_inputs = (
+            torch.zeros((batchdim, irreps_in1.dim)),
+            torch.zeros((batchdim, irreps_in2.dim)),
+            torch.zeros(
+                1 if shared_weights else batchdim,
+                flat_weight_index,
+            ),
+        )
         graphmod_right = jitable(optimize_einsums_full(graphmod_right, example_inputs[1:]))
 
-    return graphmod_out, graphmod_right
+    return graphmod_right

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -1,7 +1,7 @@
 from math import sqrt
 from typing import List, Tuple
 
-from opt_einsum_fx import jitable, optimize_einsums_full
+from opt_einsum_fx import optimize_einsums_full
 import torch
 from torch import fx
 
@@ -351,7 +351,7 @@ def codegen_tensor_product_left_right(
                 flat_weight_index,
             ),
         )
-        graphmod_out = jitable(optimize_einsums_full(graphmod_out, example_inputs))
+        graphmod_out = optimize_einsums_full(graphmod_out, example_inputs)
 
     return graphmod_out
 
@@ -650,6 +650,6 @@ def codegen_tensor_product_right(
                 flat_weight_index,
             ),
         )
-        graphmod_right = jitable(optimize_einsums_full(graphmod_right, example_inputs[1:]))
+        graphmod_right = optimize_einsums_full(graphmod_right, example_inputs[1:])
 
     return graphmod_right

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -474,6 +474,9 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         """
         assert y.shape[-1] == self._in2_dim, "Incorrect last dimension for y"
 
+        if not hasattr(self, '_compiled_main_right'):
+            raise ValueError("`right` method is not compiled, set `compile_right` to True when creating the TensorProduct")
+
         # - PROFILER - with torch.autograd.profiler.record_function(self._profiling_str):
         real_weight = self._get_weights(weight)
         return self._compiled_main_right(y, real_weight)

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -357,11 +357,11 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
                 "_compiled_main_left_right": graphmod_left_right,
                 "_compiled_main_right": graphmod_right
             })
-        if graphmod_left_right is not None:
+        elif graphmod_left_right is not None:
             self._codegen_register({
                 "_compiled_main_left_right": graphmod_left_right,
             })
-        if graphmod_right is not None:
+        elif graphmod_right is not None:
             self._codegen_register({
                 "_compiled_main_right": graphmod_right
             })

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -70,6 +70,12 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         where here :math:`i` denotes a *batch-like* index.
         ``shared_weights`` cannot be `False` if ``internal_weights`` is `True`.
 
+    compile_left_right : bool
+        whether to compile the forward function, true by default
+
+    compile_right : bool
+        whether to compile the ``.right`` function, false by default
+
     Examples
     --------
     Create a module that computes elementwise the cross-product of 16 vectors with 16 vectors :math:`z_u = x_u \wedge y_u`

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 import e3nn
 import torch
+from opt_einsum_fx import jitable
 from torch import fx
 
 
@@ -38,7 +39,7 @@ class CodeGenMixin:
             assert isinstance(graphmod, fx.GraphModule)
 
             if opt_defaults['jit_script_fx']:
-                scriptmod = torch.jit.script(graphmod)
+                scriptmod = torch.jit.script(jitable(graphmod))
                 assert isinstance(scriptmod, torch.jit.ScriptModule)
             else:
                 scriptmod = graphmod
@@ -71,7 +72,7 @@ class CodeGenMixin:
                 # Get the module
                 smod = getattr(self, fname)
                 if isinstance(smod, fx.GraphModule):
-                    smod = torch.jit.script(smod)
+                    smod = torch.jit.script(jitable(smod))
                 assert isinstance(smod, torch.jit.ScriptModule)
                 # Save the compiled code as TorchScript IR
                 buffer = io.BytesIO()
@@ -107,7 +108,7 @@ class CodeGenMixin:
                 buffer = io.BytesIO(buffer)
                 smod = torch.jit.load(buffer)
                 if isinstance(smod, fx.GraphModule):
-                    smod = torch.jit.script(smod)
+                    smod = torch.jit.script(jitable(smod))
                 assert isinstance(smod, torch.jit.ScriptModule)
                 # Add the ScriptModule as a submodule
                 setattr(self, fname, smod)

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -70,6 +70,8 @@ class CodeGenMixin:
             for fname in self.__codegen__:
                 # Get the module
                 smod = getattr(self, fname)
+                if isinstance(smod, fx.GraphModule):
+                    smod = torch.jit.script(smod)
                 assert isinstance(smod, torch.jit.ScriptModule)
                 # Save the compiled code as TorchScript IR
                 buffer = io.BytesIO()
@@ -104,6 +106,8 @@ class CodeGenMixin:
                 # Load the TorchScript IR buffer
                 buffer = io.BytesIO(buffer)
                 smod = torch.jit.load(buffer)
+                if isinstance(smod, fx.GraphModule):
+                    smod = torch.jit.script(smod)
                 assert isinstance(smod, torch.jit.ScriptModule)
                 # Add the ScriptModule as a submodule
                 setattr(self, fname, smod)

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -107,8 +107,6 @@ class CodeGenMixin:
                 # Load the TorchScript IR buffer
                 buffer = io.BytesIO(buffer)
                 smod = torch.jit.load(buffer)
-                if isinstance(smod, fx.GraphModule):
-                    smod = torch.jit.script(jitable(smod))
                 assert isinstance(smod, torch.jit.ScriptModule)
                 # Add the ScriptModule as a submodule
                 setattr(self, fname, smod)

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -1,6 +1,7 @@
-from typing import Dict
 import io
+from typing import Dict
 
+import e3nn
 import torch
 from torch import fx
 
@@ -31,10 +32,17 @@ class CodeGenMixin:
             self.__codegen__ = []
         self.__codegen__.extend(funcs.keys())
 
+        opt_defaults = e3nn.get_optimization_defaults()
+
         for fname, graphmod in funcs.items():
             assert isinstance(graphmod, fx.GraphModule)
-            scriptmod = torch.jit.script(graphmod)
-            assert isinstance(scriptmod, torch.jit.ScriptModule)
+
+            if opt_defaults['jit_script_fx']:
+                scriptmod = torch.jit.script(graphmod)
+                assert isinstance(scriptmod, torch.jit.ScriptModule)
+            else:
+                scriptmod = graphmod
+
             # Add the ScriptModule as a submodule so it can be called
             setattr(self, fname, scriptmod)
 

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -47,6 +47,8 @@ def get_compile_mode(mod: torch.nn.Module) -> str:
         mode = getattr(mod, _E3NN_COMPILE_MODE)
     else:
         mode = getattr(type(mod), _E3NN_COMPILE_MODE, None)
+    if mode is None and isinstance(mod, fx.GraphModule):
+        mode = 'script'
     assert mode in _VALID_MODES, "Invalid compile mode `%r`" % mode
     return mode
 

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -1,10 +1,11 @@
-from typing import Optional
-import warnings
-import inspect
 import copy
+import inspect
+import warnings
+from typing import Optional
 
 import torch
-
+from opt_einsum_fx import jitable
+from torch import fx
 
 _E3NN_COMPILE_MODE = "__e3nn_compile_mode__"
 _VALID_MODES = ('trace', 'script', 'unsupported', None)
@@ -103,6 +104,8 @@ def compile(
         )
     # == Compile this module now ==
     if mode == 'script':
+        if isinstance(mod, fx.GraphModule):
+            mod = jitable(mod)
         mod = torch.jit.script(mod, **script_options)
     elif mode == 'trace':
         # These are always modules, so we're always using trace_module
@@ -150,7 +153,9 @@ def get_tracing_inputs(
         Tracing inputs in the format of ``torch.jit.trace_module``: dicts mapping method names like ``'forward'`` to tuples of arguments.
     """
     # Avoid circular imports
-    from ._argtools import _get_io_irreps, _rand_args, _to_device_dtype, _get_device, _get_floating_dtype
+    from ._argtools import (_get_device, _get_floating_dtype, _get_io_irreps,
+                            _rand_args, _to_device_dtype)
+
     # - Get inputs -
     if hasattr(mod, _MAKE_TRACING_INPUTS):
         # This returns a trace_module style dict of method names to test inputs

--- a/tests/defaults_test.py
+++ b/tests/defaults_test.py
@@ -5,20 +5,20 @@ def test_opt_defaults():
     a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
     b = e3nn.o3.Linear("4x1o", "4x1o")
     assert a._specialized_code
-    assert a._optimize_einsums
-    assert b._optimize_einsums
+    assert not a._optimize_einsums
+    assert not b._optimize_einsums
     old_defaults = e3nn.get_optimization_defaults()
     try:
-        e3nn.set_optimization_defaults(optimize_einsums=False)
+        e3nn.set_optimization_defaults(optimize_einsums=True)
         a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
         b = e3nn.o3.Linear("4x1o", "4x1o")
         assert a._specialized_code
-        assert not a._optimize_einsums
-        assert not b._optimize_einsums
+        assert a._optimize_einsums
+        assert b._optimize_einsums
     finally:
         e3nn.set_optimization_defaults(**old_defaults)
     a = e3nn.o3.FullyConnectedTensorProduct("4x1o", "4x1o", "4x1o")
     b = e3nn.o3.Linear("4x1o", "3x1o")
     assert a._specialized_code
-    assert a._optimize_einsums
-    assert b._optimize_einsums
+    assert not a._optimize_einsums
+    assert not b._optimize_einsums

--- a/tests/o3/tensor_product_test.py
+++ b/tests/o3/tensor_product_test.py
@@ -30,6 +30,8 @@ def make_tp(
                 (0, 0, 1, 'uvw', True, 0.5 if path_weights else 1.0),
                 (0, 1, 1, 'uvw', True, 0.2 if path_weights else 1.0),
             ],
+            compile_left_right=True,
+            compile_right=True,
             **kwargs
         )
     except AssertionError:
@@ -126,6 +128,7 @@ def test_empty():
             (0, 0, 0, "uvw", True),
             (1, 1, 0, "uvw", True),
         ],
+        compile_right=True,
     )
     x1, x2 = m.irreps_in1.randn(4, -1), m.irreps_in2.randn(4, -1)
     out = m(x1, x2)
@@ -185,12 +188,14 @@ def test_specialized_code(normalization, mode, weighted, float_tolerance):
     tp1 = TensorProduct(
         irreps_in1, irreps_in2, irreps_out,
         ins, irrep_normalization=normalization,
-        _specialized_code=False
+        compile_right=True,
+        _specialized_code=False,
     )
     tp2 = TensorProduct(
         irreps_in1, irreps_in2, irreps_out,
         ins, irrep_normalization=normalization,
-        _specialized_code=True
+        compile_right=True,
+        _specialized_code=True,
     )
     with torch.no_grad():
         tp2.weight[:] = tp1.weight
@@ -228,7 +233,7 @@ def test_single_out():
 
 
 def test_empty_inputs():
-    tp = FullyConnectedTensorProduct('0e + 1e', '0e + 1e', '0e + 1e')
+    tp = FullyConnectedTensorProduct('0e + 1e', '0e + 1e', '0e + 1e', compile_right=True)
     out = tp(torch.randn(2, 1, 0, 1, 4), torch.randn(1, 2, 0, 3, 4))
     assert out.shape == (2, 2, 0, 3, 4)
 
@@ -369,7 +374,8 @@ def test_input_weights_jit():
         irreps_in2,
         irreps_out,
         internal_weights=False,
-        shared_weights=False
+        shared_weights=False,
+        compile_right=True,
     )
     traced = assert_auto_jitable(m)
     x1 = irreps_in1.randn(2, -1)


### PR DESCRIPTION
- split codegen in two: `left_right` and `right`
- add flags `compile_left_right` and `compile_right` to `TensorProduct`
- set default `optimize_einsums=False`
- add new global flag `jit_script_fx=False` that by default turns of the `torch.jit.script` of `fx` code