### PR TITLE
Update calculation of edge_vec with periodic boundary conditions.

### DIFF
--- a/docs/guide/periodic_boundary_conditions.rst
+++ b/docs/guide/periodic_boundary_conditions.rst
@@ -133,7 +133,7 @@ object representing a single example, we use the following expression:
 
     edge_src, edge_dst = data['edge_index'][0], data['edge_index'][1]
     edge_vec = (data['pos'][edge_dst] - data['pos'][edge_src]
-                + torch.einsum('ni,nij->j', data['edge_shift'], data['lattice']))
+                + torch.einsum('ni,nij->nj', data['edge_shift'], data['lattice']))
 
 The first line in the definition of ``edge_vec`` is simply how one normally computes
 relative distance vectors given two points. The second line adds the contribution
@@ -189,7 +189,7 @@ application.
             edge_batch = batch[edge_src]
             edge_vec = (data['pos'][edge_dst]
                         - data['pos'][edge_src]
-                        + torch.einsum('ni,nij->j', data['edge_shift'], data['lattice'][edge_batch]))
+                        + torch.einsum('ni,nij->nj', data['edge_shift'], data['lattice'][edge_batch]))
 
             return batch, data['x'], edge_src, edge_dst, edge_vec
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Updated `torch.einsum('ni,nij->j'` to `torch.einsum('ni,nij->nj'` in the calculation of `edge_vec` with periodic boundary conditions described in the documentation.

## Motivation and Context
Preserves the batch dimension when applying a lattice vector shift to the edge vector rather than contracting along the batch dimension.

## How Has This Been Tested?
There were no changes made to the code, just updates to the example described in the documentation.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
