### PR TITLE
Faster CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wheel
-        pip install torch==${TORCH} -f https://download.pytorch.org/whl/cpu/torch_stable.html
+        pip install torch==${TORCH} torchvision -f https://download.pytorch.org/whl/cpu/torch_stable.html
         pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
         pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
         pip install torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wheel
-        pip install torch==${TORCH} torchvision torchaudio -f https://download.pytorch.org/whl/cpu/torch_stable.html
+        pip install torch==${TORCH} -f https://download.pytorch.org/whl/cpu/torch_stable.html
         pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
         pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html
         pip install torch-cluster -f https://pytorch-geometric.com/whl/torch-${TORCH}+${CUDA}.html


### PR DESCRIPTION
Don't install unneeded torchvision and torchaudio

No reason to waste CI time installing dependencies that are never used by e3nn.