### PR TITLE
Remove CartesianTensor._rtp

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove `CartesianTensor._rtp`. Instead recompute the `ReducedTensorProduct` everytime. The user can save the `ReducedTensorProduct` to avoid creating it each time.
 
 ## [0.4.3] - 2021-11-18
 ### Fixed

--- a/tests/o3/reduce_tensor_test.py
+++ b/tests/o3/reduce_tensor_test.py
@@ -1,7 +1,20 @@
-import torch
+import tempfile
 
+import torch
 from e3nn import o3
-from e3nn.util.test import assert_equivariant, assert_auto_jitable
+from e3nn.util.test import assert_auto_jitable, assert_equivariant
+
+
+def test_save_load():
+    tp1 = o3.ReducedTensorProducts('ij=-ji', i='5x0e + 1e')
+    with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
+        torch.save(tp1, tmp.name)
+        tp2 = torch.load(tmp.name)
+
+    xs = (torch.randn(2, 5 + 3), torch.randn(2, 5 + 3))
+    assert torch.allclose(tp1(*xs), tp2(*xs))
+
+    assert torch.allclose(tp1.change_of_basis, tp2.change_of_basis)
 
 
 def test_antisymmetric_matrix(float_tolerance):


### PR DESCRIPTION
```python
irreps = CartesianTensor("ij=-ji")

rtp = irreps.reduced_tensor_products()
# rtp is a nn.Module

irreps.from_cartesian(data, rtp=rtp)  # use rtp

irreps.from_cartesian(data)  # create a new ReducedTensorProducts at each call
```