### PR TITLE
Let equivariance error methods tell which argument led to errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created module for reflected imports allowing for nice syntax for creating `irreps`, e.g. `from e3nn.o3.irreps import l3o # same as Irreps("o3")`
 - Add `uvu<v` mode for `TensorProduct`. Compute only the upper triangular part of the `uv` terms.
 - `TensorSquare`. computes `x \otimes x` and decompose it.
+- `*equivariance_error` now tell you which arguments had which error
 ### Changed
 - Give up the support of python 3.6, set `python_requires='>=3.7'` in setup
 - Optimize a little bit `ReducedTensorProduct`: solve linear system only once per irrep instead of 2L+1 times.


### PR DESCRIPTION
## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
