### PR TITLE
Do the transform for the equivariance test in float64

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,15 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Remove `CartesianTensor._rtp`. Instead recompute the `ReducedTensorProduct` everytime. The user can save the `ReducedTensorProduct` to avoid creating it each time.
+
 ### Added
 - Created module for reflected imports allowing for nice syntax for creating `irreps`, e.g. `from e3nn.o3.irreps import l3o # same as Irreps("o3")`
 - Add `uvu<v` mode for `TensorProduct`. Compute only the upper triangular part of the `uv` terms.
 - `TensorSquare`. computes `x \otimes x` and decompose it.
 - `*equivariance_error` now tell you which arguments had which error
+
 ### Changed
 - Give up the support of python 3.6, set `python_requires='>=3.7'` in setup
 - Optimize a little bit `ReducedTensorProduct`: solve linear system only once per irrep instead of 2L+1 times.
 - Do not scale line width by `path_weight` in `TensorProduct.visualize`
+- `*equivariance_error` now transforms its inputs in float64 by default, regardless of the dtype used for the calculation itself
 
 ## [0.4.3] - 2021-11-18
 ### Fixed

--- a/e3nn/util/_argtools.py
+++ b/e3nn/util/_argtools.py
@@ -11,15 +11,26 @@ from e3nn.o3 import Irreps
 def _transform(dat, irreps_dat, rot_mat, translation=0.):
     """Transform ``dat`` by ``rot_mat`` and ``translation`` according to ``irreps_dat``."""
     out = []
+    transform_dtype = rot_mat.dtype
+    translation = torch.as_tensor(translation, dtype=transform_dtype)
     for irreps, a in zip(irreps_dat, dat):
+        in_dtype = a.dtype
         if irreps is None:
             out.append(a)
         elif irreps == 'cartesian_points':
             translation = torch.as_tensor(translation, device=a.device)
-            out.append((a @ rot_mat.T.to(a.device)) + translation)
+            out.append(
+                (
+                    (a.to(transform_dtype) @ rot_mat.T.to(a.device)) + translation
+                ).to(in_dtype)
+            )
         else:
             # For o3.Irreps
-            out.append(a @ irreps.D_from_matrix(rot_mat).T.to(a.device))
+            out.append(
+                (
+                    a.to(transform_dtype) @ irreps.D_from_matrix(rot_mat).T.to(a.device)
+                ).to(in_dtype)
+            )
     return out
 
 

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -149,7 +149,7 @@ def format_equivariance_error(errors: dict) -> str:
     -------
         A string.
     """
-    return "; ".join(
+    return "\n".join(
         "(parity_k={:d}, did_translate={}) -> max error={:.3e} in argument {}".format(
             int(k[0]),
             bool(k[1]),
@@ -207,7 +207,7 @@ def assert_equivariant(
     )
 
     logger.info(
-        "Tested equivariance of `%s` -- max componentwise errors: %s",
+        "Tested equivariance of `%s` -- max componentwise errors:\n%s",
         _logging_name(func),
         format_equivariance_error(errors),
     )
@@ -233,7 +233,8 @@ def equivariance_error(
     irreps_out=None,
     ntrials=1,
     do_parity=True,
-    do_translation=True
+    do_translation=True,
+    transform_dtype=torch.float64
 ):
     r"""Get the maximum equivariance error for ``func`` over ``ntrials``
 
@@ -289,7 +290,7 @@ def equivariance_error(
         for this_test in tests:
             parity_k, this_do_translate = this_test
             # Build a rotation matrix for point data
-            rot_mat = o3.rand_matrix()
+            rot_mat = o3.rand_matrix(dtype=transform_dtype)
             # add parity
             rot_mat *= (-1)**parity_k
             # build translation


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Transform tensors for the equivariance test in `float64`.

## Motivation and Context
Removes (to a greater extent) the test itself as a possible source of equivariance error. For testing a float32 network, this means that the transformations for the _test_ are effectively exact and all equivariance error will come from the function itself.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- X ] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
