### PR TITLE
dtype and autograd fixes for equivariance_error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Remove `CartesianTensor._rtp`. Instead recompute the `ReducedTensorProduct` everytime. The user can save the `ReducedTensorProduct` to avoid creating it each time.
+- `*equivariance_error` no longer keeps around unneeded autograd graphs
 
 ### Added
 - Created module for reflected imports allowing for nice syntax for creating `irreps`, e.g. `from e3nn.o3.irreps import l3o # same as Irreps("o3")`

--- a/e3nn/util/_argtools.py
+++ b/e3nn/util/_argtools.py
@@ -8,28 +8,31 @@ import torch
 from e3nn.o3 import Irreps
 
 
-def _transform(dat, irreps_dat, rot_mat, translation=0.):
+def _transform(dat, irreps_dat, rot_mat, translation=0.0, output_transform_dtype: bool = False):
     """Transform ``dat`` by ``rot_mat`` and ``translation`` according to ``irreps_dat``."""
     out = []
     transform_dtype = rot_mat.dtype
     translation = torch.as_tensor(translation, dtype=transform_dtype)
     for irreps, a in zip(irreps_dat, dat):
-        in_dtype = a.dtype
+        if output_transform_dtype:
+            out_dtype = transform_dtype
+        else:
+            out_dtype = a.dtype
         if irreps is None:
-            out.append(a)
+            out.append(a.clone())
         elif irreps == 'cartesian_points':
             translation = torch.as_tensor(translation, device=a.device)
             out.append(
                 (
                     (a.to(transform_dtype) @ rot_mat.T.to(a.device)) + translation
-                ).to(in_dtype)
+                ).to(out_dtype)
             )
         else:
             # For o3.Irreps
             out.append(
                 (
                     a.to(transform_dtype) @ irreps.D_from_matrix(rot_mat).T.to(a.device)
-                ).to(in_dtype)
+                ).to(out_dtype)
             )
     return out
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
 - do the difference and error comparison in float64 too
 - detach things from the autograd graph to free memory when testing models

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
