### PR TITLE
add codegen registration

### DIFF
--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from math import sqrt
-from typing import List, Tuple
+from typing import List
 
 import torch
 from e3nn import o3
@@ -28,7 +28,7 @@ def codegen_tensor_product_left_right(
     shared_weights: bool = False,
     specialized_code: bool = True,
     optimize_einsums: bool = True,
-) -> Tuple[fx.GraphModule, fx.GraphModule]:
+) -> fx.GraphModule:
     graph = fx.Graph()
 
     # = Function definitions =
@@ -374,7 +374,7 @@ def codegen_tensor_product_right(
     shared_weights: bool = False,
     specialized_code: bool = True,
     optimize_einsums: bool = True,
-) -> Tuple[fx.GraphModule, fx.GraphModule]:
+) -> fx.GraphModule:
     graph = fx.Graph()
 
     # = Function definitions =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Provide a private API to register alternative tensor product codegen providers. If a provider doesn't support given parameters, it just returns `None` and the code tries the next with the default full-featured one as final fallback.

**TODO**: a more generic way of dealing with optimization parameters than the explicit `optimize_einsums` and `specialized_code` parameters

## Motivation and Context
Let us work on optimization without having to maintain branches that get out of sync with `main`.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [X] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
