### PR TITLE
wigner_3j always contiguous

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `wigner_3j`  now _always_ returns a contiguous copy regardless of dtype or device
 
 ## [0.4.4] - 2021-12-15
 ### Fixed

--- a/e3nn/o3/_wigner.py
+++ b/e3nn/o3/_wigner.py
@@ -120,22 +120,25 @@ def wigner_3j(l1, l2, l3, flat_src=_W3j_flat, dtype=None, device=None):
 
     try:
         if l1 <= l2 <= l3:
-            out = flat_src[_W3j_indices[(l1, l2, l3)]].reshape(2 * l1 + 1, 2 * l2 + 1, 2 * l3 + 1).clone()
+            out = flat_src[_W3j_indices[(l1, l2, l3)]].reshape(2 * l1 + 1, 2 * l2 + 1, 2 * l3 + 1)
         if l1 <= l3 <= l2:
-            out = flat_src[_W3j_indices[(l1, l3, l2)]].reshape(2 * l1 + 1, 2 * l3 + 1, 2 * l2 + 1).transpose(1, 2).mul((-1) ** (l1 + l2 + l3)).clone()
+            out = flat_src[_W3j_indices[(l1, l3, l2)]].reshape(2 * l1 + 1, 2 * l3 + 1, 2 * l2 + 1).transpose(1, 2).mul((-1) ** (l1 + l2 + l3))
         if l2 <= l1 <= l3:
-            out = flat_src[_W3j_indices[(l2, l1, l3)]].reshape(2 * l2 + 1, 2 * l1 + 1, 2 * l3 + 1).transpose(0, 1).mul((-1) ** (l1 + l2 + l3)).clone()
+            out = flat_src[_W3j_indices[(l2, l1, l3)]].reshape(2 * l2 + 1, 2 * l1 + 1, 2 * l3 + 1).transpose(0, 1).mul((-1) ** (l1 + l2 + l3))
         if l3 <= l2 <= l1:
-            out = flat_src[_W3j_indices[(l3, l2, l1)]].reshape(2 * l3 + 1, 2 * l2 + 1, 2 * l1 + 1).transpose(0, 2).mul((-1) ** (l1 + l2 + l3)).clone()
+            out = flat_src[_W3j_indices[(l3, l2, l1)]].reshape(2 * l3 + 1, 2 * l2 + 1, 2 * l1 + 1).transpose(0, 2).mul((-1) ** (l1 + l2 + l3))
         if l2 <= l3 <= l1:
-            out = flat_src[_W3j_indices[(l2, l3, l1)]].reshape(2 * l2 + 1, 2 * l3 + 1, 2 * l1 + 1).transpose(0, 2).transpose(1, 2).clone()
+            out = flat_src[_W3j_indices[(l2, l3, l1)]].reshape(2 * l2 + 1, 2 * l3 + 1, 2 * l1 + 1).transpose(0, 2).transpose(1, 2)
         if l3 <= l1 <= l2:
-            out = flat_src[_W3j_indices[(l3, l1, l2)]].reshape(2 * l3 + 1, 2 * l1 + 1, 2 * l2 + 1).transpose(0, 2).transpose(0, 1).clone()
+            out = flat_src[_W3j_indices[(l3, l1, l2)]].reshape(2 * l3 + 1, 2 * l1 + 1, 2 * l2 + 1).transpose(0, 2).transpose(0, 1)
     except KeyError:
         raise NotImplementedError(f'Wigner 3j symbols maximum l implemented is {max(_W3j_indices.keys())[0]}, send us an email to ask for more')
 
     dtype, device = explicit_default_types(dtype, device)
-    return out.to(dtype=dtype, device=device)
+    # make sure we always get:
+    # 1. a copy so mutation doesn't ruin the stored tensors
+    # 2. a contiguous tensor, regardless of what transpositions happened above
+    return out.to(dtype=dtype, device=device, copy=True, memory_format=torch.contiguous_format)
 
 
 def _generate_wigner_3j(l1, l2, l3, dtype=None, device=None):  # pragma: no cover


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
Make sure that `wigner_3j`  _always_ returns a contiguous copy regardless of dtype or device

Previously it would fail to on device cpu and dtype default, since then unless you say otherwise `.to()` defaults to preserving memory layout.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [X] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [X] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
