### PR TITLE
Minor quality of life improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,9 @@ jobs:
       run: |
         coverage run --source=e3nn -m pytest --doctest-modules --ignore=docs/ .
     - name: Upload to coveralls
-      if: github.event_name == 'push'
+      env:
+        COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+      # Only send to coveralls if the token has been set and the user pushed
+      if: env.COVERALLS_TOKEN != null && github.event_name == 'push'
       run: |
         COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_TOKEN }} coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ dist
 *.so
 examples/s2cnn/mnist/MNIST_data/MNIST/raw
 examples/s2cnn/mnist/s2_mnist.gz
+
+.idea

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - L=12 spherical harmonics
 
+### Fixed
+- `TensorProduct.visualize` now works even if the TP is on the GPU.
+- Github actions only trigger a push to coveralls if the corresponding token is set in github secrets.
+
 ## [0.5.0] - 2022-04-13
 ### Added
 - Sparse Voxel Convolution

--- a/e3nn/nn/_activation.py
+++ b/e3nn/nn/_activation.py
@@ -34,7 +34,8 @@ class Activation(torch.nn.Module):
     def __init__(self, irreps_in, acts):
         super().__init__()
         irreps_in = o3.Irreps(irreps_in)
-        assert len(irreps_in) == len(acts), (irreps_in, acts)
+        if len(irreps_in) != len(acts):
+            raise ValueError(f'Irreps in and number of activation functions does not match: {len(acts), (irreps_in, acts)}')
 
         # normalize the second moment
         acts = [normalize2mom(act) if act is not None else None for act in acts]

--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -73,8 +73,10 @@ class Irrep(tuple):
             elif isinstance(l, tuple):
                 l, p = l
 
-        assert isinstance(l, int) and l >= 0, l
-        assert p in [-1, 1], p
+        if not isinstance(l, int) or l < 0:
+            raise ValueError(f"l must be positive integer, got {l}")
+        if p not in (-1, 1):
+            raise ValueError(f"parity must be on of (-1, 1), got {p}")
         return super().__new__(cls, (l, p))
 
     @property
@@ -282,6 +284,9 @@ class _MulIr(tuple):
 
     def __repr__(self):
         return f"{self.mul}x{self.ir}"
+
+    def __getitem__(self, item) -> Union[int, Irrep]:  # pylint: disable=useless-super-delegation
+        return super().__getitem__(item)
 
     def count(self, _value):
         raise NotImplementedError
@@ -524,7 +529,7 @@ class Irreps(tuple):
         """
         return Irreps(super().__rmul__(other))
 
-    def simplify(self):
+    def simplify(self) -> 'Irreps':
         """Simplify the representations.
 
         Returns

--- a/e3nn/o3/_reduce.py
+++ b/e3nn/o3/_reduce.py
@@ -1,12 +1,13 @@
 import collections
 
 import torch
+from torch import fx
+
 from e3nn import o3
 from e3nn.math import germinate_formulas, orthonormalize, reduce_permutation
 from e3nn.util import explicit_default_types
 from e3nn.util.codegen import CodeGenMixin
 from e3nn.util.jit import compile_mode
-from torch import fx
 
 _TP = collections.namedtuple("tp", "op, args")
 _INPUT = collections.namedtuple("input", "tensor, start, stop")
@@ -83,7 +84,7 @@ class ReducedTensorProducts(CodeGenMixin, torch.nn.Module):
     ----------
     formula : str
         String made of letters ``-`` and ``=`` that represent the indices symmetries of the tensor.
-        For instance ``ij=ji`` means that the tensor has to indices and if they are exchanged, its value is the same.
+        For instance ``ij=ji`` means that the tensor has two indices and if they are exchanged, its value is the same.
         ``ij=-ji`` means that the tensor change its sign if the two indices are exchanged.
 
     filter_ir_out : list of `e3nn.o3.Irrep`, optional

--- a/e3nn/o3/_tensor_product/_sub.py
+++ b/e3nn/o3/_tensor_product/_sub.py
@@ -232,6 +232,7 @@ def _square_instructions_full(irreps_in, filter_ir_out=None, irrep_normalization
         list of instructions
 
     """
+    # pylint: disable=too-many-nested-blocks
     irreps_out = []
     instr = []
     for i_1, (mul_1, ir_1) in enumerate(irreps_in):
@@ -304,10 +305,11 @@ def _square_instructions_fully_connected(irreps_in, irreps_out, irrep_normalizat
     instr : list of tuple
         list of instructions
     """
+    # pylint: disable=too-many-nested-blocks
     instr = []
     for i_1, (mul_1, ir_1) in enumerate(irreps_in):
-        for i_2, (mul_2, ir_2) in enumerate(irreps_in):
-            for i_out, (mul_out, ir_out) in enumerate(irreps_out):
+        for i_2, (_mul_2, ir_2) in enumerate(irreps_in):
+            for i_out, (_mul_out, ir_out) in enumerate(irreps_out):
                 if ir_out in ir_1 * ir_2:
 
                     if irrep_normalization == "component":
@@ -382,8 +384,8 @@ class TensorSquare(TensorProduct):
         if filter_ir_out is not None:
             try:
                 filter_ir_out = [o3.Irrep(ir) for ir in filter_ir_out]
-            except ValueError:
-                raise ValueError(f"filter_ir_out (={filter_ir_out}) must be an iterable of e3nn.o3.Irrep")
+            except ValueError as exc:
+                raise ValueError(f'Error constructing filter_ir_out irrep: {exc}') from exc
 
         if irreps_out is None:
             irreps_out, instr = _square_instructions_full(irreps_in, filter_ir_out, irrep_normalization)
@@ -407,5 +409,5 @@ class TensorSquare(TensorProduct):
             f"-> {self.irreps_out.simplify()} | {npath} paths | {self.weight_numel} weights)"
         )
 
-    def forward(self, x, weight: Optional[torch.Tensor] = None):
+    def forward(self, x, weight: Optional[torch.Tensor] = None):  # pylint: disable=arguments-differ
         return super().forward(x, x, weight)

--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -1,15 +1,15 @@
-import warnings
 from math import sqrt
 from typing import List, Optional, Union, Any, Callable
+import warnings
+
+import torch
+from torch import fx
 
 import e3nn
-import torch
-import torch.fx
 from e3nn import o3
 from e3nn.util import prod
 from e3nn.util.codegen import CodeGenMixin
 from e3nn.util.jit import compile_mode
-from torch import fx
 from ._codegen import codegen_tensor_product_left_right, codegen_tensor_product_right
 from ._instruction import Instruction
 
@@ -642,7 +642,8 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
         verts = np.asarray(verts)
 
         # scale it
-        assert aspect_ratio in ["auto"] or isinstance(aspect_ratio, (float, int))
+        if not (aspect_ratio in ["auto"] or isinstance(aspect_ratio, (float, int))):
+            raise ValueError(f"aspect_ratio must be 'auto' or a float or int, got {aspect_ratio}")
 
         if aspect_ratio == "auto":
             factor = 0.2 / 2
@@ -697,7 +698,7 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
                 path_weight = []
                 for ins_i, ins in enumerate(self.instructions):
                     if ins.has_weight:
-                        this_weight = self.weight_view_for_instruction(ins_i, weight=weight)
+                        this_weight = self.weight_view_for_instruction(ins_i, weight=weight).cpu()
                         path_weight.append(this_weight.pow(2).mean())
                     else:
                         path_weight.append(0)

--- a/tests/o3/irreps_test.py
+++ b/tests/o3/irreps_test.py
@@ -97,6 +97,29 @@ def test_contains():
     assert o3.Irrep("2o") not in o3.Irreps("3x0e + 2x2e + 1x3o")
 
 
+def test_errors():
+    """Test invalid irrep specifications"""
+    # Irrep
+    with pytest.raises(ValueError):
+        o3.Irrep(-1)
+
+    with pytest.raises(ValueError):
+        o3.Irrep(1, p=2)
+
+    with pytest.raises(ValueError):
+        o3.Irrep("-1e")
+
+    # Irreps
+    with pytest.raises(ValueError):
+        o3.Irreps("-1x1e")
+
+    with pytest.raises(ValueError):
+        o3.Irreps("1x-1e")
+
+    with pytest.raises(ValueError):
+        o3.Irreps("bla")
+
+
 @pytest.mark.xfail()
 def test_fail1():
     o3.Irreps([(32, 1)])


### PR DESCRIPTION
## Description
Changed a bunch of asserts to exceptions.  Asserts are best used to check for internal errors when `e3nn` itself does something it didn't expect to do.  However, they were frequently used to do things like report incorrect function parameters in which case it is more common to emit `TypeError` or `ValueError`.

I've also updated `TensorProduct.visualize` to work even if it is located on the GPU.

## Motivation and Context
* Code has become more pythonic
* `TP.visualize` is now more usable.

## How Has This Been Tested?
* Added tests for incorrect values passed to `Irrep`/`Irreps`.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
