### PR TITLE
fix _batchnorm

### DIFF
--- a/e3nn/nn/_batchnorm.py
+++ b/e3nn/nn/_batchnorm.py
@@ -174,8 +174,10 @@ class BatchNorm(nn.Module):
             assert ib == self.bias.numel()
 
         if self.training and not self.instance:
-            torch.cat(new_means, out=self.running_mean)
-            torch.cat(new_vars, out=self.running_var)
+            if len(new_means) > 0:
+                torch.cat(new_means, out=self.running_mean)
+            if len(new_vars) > 0:
+                torch.cat(new_vars, out=self.running_var)
 
         output = torch.cat(fields, dim=2)  # [batch, sample, stacked features]
         return output.reshape(batch, *size, dim)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->
_batchnorm torch.cat empty Tensors
## Description
       if self.training and not self.instance:
            if len(new_means) > 0:
                torch.cat(new_means, out=self.running_mean)
            if len(new_vars) > 0:
                torch.cat(new_vars, out=self.running_var)

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #???

```
ckages/e3nn/o3/_spherical_harmonics.py:82: UserWarning: FALLBACK path has been taken inside: compileCudaFusionGroup. This is an indication that codegen Failed for some reason.                                          
To debug try disable codegen fallback path via setting the env variable `export PYTORCH_NVFUSER_DISABLE=fallback`                                                                                                        
To report the issue, try enable logging via setting the envvariable ` export PYTORCH_JIT_LOG_LEVEL=manager.cpp`                                                                                                          
 (Triggered internally at  /opt/conda/conda-bld/pytorch_1659484806139/work/torch/csrc/jit/codegen/cuda/manager.cpp:237.)
  sh = _spherical_harmonics(self._lmax, x[..., 0], x[..., 1], x[..., 2])
  0%|                                                                                                                                    | 0/1017 [00:08<?, ?it/s]
Traceback (most recent call last):
  File "/opt/miniconda3/envs/diffdock_new/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/miniconda3/envs/diffdock_new/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/root/code/DiffDock/train.py", line 158, in <module>
    main_function()
  File "/root/code/DiffDock/train.py", line 153, in main_function
    train(args, model, optimizer, scheduler, ema_weights, train_loader, val_loader, t_to_sigma, run_dir)
  File "/root/code/DiffDock/train.py", line 35, in train
    train_losses = train_epoch(model, train_loader, optimizer, device, t_to_sigma, loss_fn, ema_weights)
  File "/root/code/DiffDock/utils/training.py", line 128, in train_epoch
    raise e
  File "/root/code/DiffDock/utils/training.py", line 105, in train_epoch
    tr_pred, rot_pred, tor_pred = model(data)
  File "/opt/miniconda3/envs/diffdock_new/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/miniconda3/envs/diffdock_new/lib/python3.9/site-packages/torch_geometric/nn/data_parallel.py", line 59, in forward
    return self.module(data)
  File "/opt/miniconda3/envs/diffdock_new/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/root/code/DiffDock/models/score_model.py", line 299, in forward
    global_pred = self.final_conv(lig_node_attr, center_edge_index, center_edge_attr, center_edge_sh, out_nodes=data.num_graphs)
  File "/opt/miniconda3/envs/diffdock_new/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/root/code/DiffDock/models/score_model.py", line 88, in forward
    out = self.batch_norm(out)
  File "/opt/miniconda3/envs/diffdock_new/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/miniconda3/envs/diffdock_new/lib/python3.9/site-packages/e3nn/nn/_batchnorm.py", line 178, in forward
    torch.cat(new_means, out=self.running_mean)
```


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
