### PR TITLE
Update NetworkForAGraphWithAttributes to use the standard pytorch-geometric field for specifying edges.

### DIFF
--- a/e3nn/nn/models/v2106/gate_points_networks.py
+++ b/e3nn/nn/models/v2106/gate_points_networks.py
@@ -149,9 +149,9 @@ class NetworkForAGraphWithAttributes(torch.nn.Module):
             batch = data["pos"].new_zeros(data["pos"].shape[0], dtype=torch.long)
 
         # Create graph
-        if "edge_src" in data and "edge_dst" in data:
-            edge_src = data["edge_src"]
-            edge_dst = data["edge_dst"]
+        if "edge_index" in data:
+            edge_src = data["edge_index"][0]
+            edge_dst = data["edge_index"][1]
         else:
             edge_index = radius_graph(data["pos"], self.max_radius, batch)
             edge_src = edge_index[0]

--- a/e3nn/nn/models/v2106/gate_points_networks.py
+++ b/e3nn/nn/models/v2106/gate_points_networks.py
@@ -211,8 +211,7 @@ def test_network_for_a_graph_with_attributes():
     net(
         {
             "pos": torch.randn(3, 3),
-            "edge_src": torch.tensor([0, 1, 2]),
-            "edge_dst": torch.tensor([1, 2, 0]),
+            "edge_index": torch.tensor([[0, 1, 2], [1, 2, 0]]),
             "node_input": net.irreps_node_input.randn(3, -1),
             "node_attr": net.irreps_node_attr.randn(3, -1),
             "edge_attr": net.irreps_edge_attr.randn(3, -1),


### PR DESCRIPTION
Allows automatic incrementing of edge indexes when combining multiple graphs for a mini-batch.

## Description
Update edge specification in pytorch-geometric.Data to use 'edge_index' as opposed to 'edge_src' and 'edge_dst'. This allows for automatic incrementing of edge indexes when combining multiple graphs into a single disconnected graph when creating a mini-batch. This is also the standard way of using pytorch-geometrics Data/DataLoader classes. See [here](https://pytorch-geometric.readthedocs.io/en/latest/advanced/batching.html) for more information on pytorch-geometric's mini-batching.

## Motivation and Context
Removes the need to write a custom DataLoader when using NetworkForAGraphWithAttributes to do the edge incrementing yourself.

## How Has This Been Tested?
Ran test function in gate_points_networks.py. Tested on personal dataset with meshes as predefined graph input.

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation (if relevant).
- [X] I have added tests that cover my changes (if relevant).
- [X] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).

I could not find any relevant documentation to update. Similarly, I was unsure if/where to add this change to in the Changelog.