### PR TITLE
Using expand() instead of broadcast_to() for ONNX exportability

### DIFF
--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -60,14 +60,10 @@ def codegen_tensor_product_left_right(
         return fx.GraphModule({}, graph, "tp_forward")
 
     # = Broadcast inputs =
-    if shared_weights:
-        x1s, x2s = x1s.broadcast_to(output_shape + (-1,)), x2s.broadcast_to(output_shape + (-1,))
-    else:
-        x1s, x2s, weights = (
-            x1s.broadcast_to(output_shape + (-1,)),
-            x2s.broadcast_to(output_shape + (-1,)),
-            weights.broadcast_to(output_shape + (-1,)),
-        )
+    bc_shape = output_shape + (-1,)
+    x1s, x2s = x1s.expand(bc_shape), x2s.expand(bc_shape)
+    if not shared_weights:
+        weights = weights.expand(bc_shape)
 
     output_shape = output_shape + (irreps_out.dim,)
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->
Using expand() instead of broadcast_to() for ONNX exportability

## Description
<!-- Describe your changes in detail. -->
broadcast_to() is documented as identical to expand(), but is not currently supported by ONNX exporter.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
Resolves: #???

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
