### PR TITLE
Combine` xx = torch.einsum(..., x1, x2)` into `result = torch.einsum(...)`

### DIFF
--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -225,11 +225,11 @@ def codegen_tensor_product_left_right(
                 elif specialized_code and mul_ir_out.ir.l == 0:
                     result = torch.einsum(f"{z}uw,zui,zui->zw", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
                 else:
-                    result = torch.einsum(f"{z}uw,ijk,zui,zvj->zwk", w, w3j, x1, x2)
+                    result = torch.einsum(f"{z}uw,ijk,zui,zuj->zwk", w, w3j, x1, x2)
             else:
                 # equivalent to tp(x, y, 'uuu').sum('u')
                 assert mul_ir_out.mul == 1
-                result = torch.einsum("ijk,zui,zvj->zk", w3j, x1, x2)
+                result = torch.einsum("ijk,zui,zuj->zk", w3j, x1, x2)
         if ins.connection_mode == "uuu":
             assert mul_ir_in1.mul == mul_ir_in2.mul == mul_ir_out.mul
             if ins.has_weight:
@@ -250,7 +250,7 @@ def codegen_tensor_product_left_right(
                 elif specialized_code and mul_ir_out.ir.l == 0:
                     result = torch.einsum(f"{z}u,zui,zui->zu", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
                 else:
-                    result = torch.einsum(f"{z}u,ijk,zui,zvj->zuk", w, w3j, x1, x2)
+                    result = torch.einsum(f"{z}u,ijk,zui,zuj->zuk", w, w3j, x1, x2)
             else:
                 if specialized_code and l1l2l3 == (0, 0, 0):
                     result = torch.einsum(
@@ -265,7 +265,7 @@ def codegen_tensor_product_left_right(
                 elif specialized_code and mul_ir_out.ir.l == 0:
                     result = torch.einsum("zui,zui->zu", x1, x2) / sqrt(mul_ir_in1.ir.dim)
                 else:
-                    result = torch.einsum("ijk,zui,zvj->zuk", w3j, x1, x2)
+                    result = torch.einsum("ijk,zui,zuj->zuk", w3j, x1, x2)
         if ins.connection_mode == "uvuv":
             assert mul_ir_in1.mul * mul_ir_in2.mul == mul_ir_out.mul
             if ins.has_weight:

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -129,17 +129,6 @@ def codegen_tensor_product_left_right(
             )
             flat_weight_index += prod(ins.path_shape)
 
-        # Construct the general xx_string for einsum in case this instruction isn't specialized
-        # If this isn't used, the dead code will get removed
-        key = (ins.i_in1, ins.i_in2, ins.connection_mode[:2])
-        if key not in xx_dict:
-            if ins.connection_mode[:2] == "uu":
-                xx_dict[key] = "zui,zuj->zuij"
-            else:
-                xx_dict[key] = "zui,zvj->zuvij"
-        xx_string = xx_dict[key]
-        del key
-
         # Create a proxy & request for the relevant wigner w3j
         # If not used (because of specialized code), will get removed later.
         w3j_name = f"_w3j_{mul_ir_in1.ir.l}_{mul_ir_in2.ir.l}_{mul_ir_out.ir.l}"
@@ -164,7 +153,10 @@ def codegen_tensor_product_left_right(
             elif specialized_code and mul_ir_out.ir.l == 0:
                 result = torch.einsum(f"{z}uvw,zui,zvi->zw", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
             else:
-                result = torch.einsum(f"{z}uvw,ijk,zuvij->zwk", w, w3j, torch.einsum(xx_string, x1, x2))
+                if ins.connection_mode[:2] == "uu":
+                    result = torch.einsum(f"{z}uvw,ijk,zui,zuj->zwk", w, w3j, x1, x2)
+                else:
+                    result = torch.einsum(f"{z}uvw,ijk,zui,zvj->zwk", w, w3j, x1, x2)
         if ins.connection_mode == "uvu":
             assert mul_ir_in1.mul == mul_ir_out.mul
             if ins.has_weight:

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -280,7 +280,7 @@ def codegen_tensor_product_left_right(
             name = f"_triu_indices_{mul_ir_in1.mul}"
             constants[name] = torch.triu_indices(mul_ir_in1.mul, mul_ir_in1.mul, 1)
             i = fx.Proxy(graph.get_attr(name), tracer=tracer)
-            xx = torch.einsum("zui,zvj->zuvij", x1, x2)[:, i[0], i[1]] # zui,zvj -> zuvij -> zwij
+            xx = torch.einsum("zui,zvj->zuvij", x1, x2)[:, i[0], i[1]]  # zui,zvj -> zuvij -> zwij
             if ins.has_weight:
                 # TODO implement specialized code
                 result = torch.einsum(f"{z}w,ijk,zwij->zwk", w, w3j, xx)
@@ -293,7 +293,7 @@ def codegen_tensor_product_left_right(
             name = f"_triu_indices_{mul_ir_in1.mul}"
             constants[name] = torch.triu_indices(mul_ir_in1.mul, mul_ir_in1.mul, 1)
             i = fx.Proxy(graph.get_attr(name), tracer=tracer)
-            xx = torch.einsum("zui,zvj->zuvij", x1, x2)[:, i[0], i[1]] # zuvij -> zqij
+            xx = torch.einsum("zui,zvj->zuvij", x1, x2)[:, i[0], i[1]]  # zuvij -> zqij
             # TODO implement specialized code
             result = torch.einsum(f"{z}qw,ijk,zqij->zwk", w, w3j, xx)
 


### PR DESCRIPTION
- [ ] Need to find a better alternative for
```python
xx = torch.einsum("zui,zvj->zuvij", x1, x2)[:, i[0], i[1]]
```
