### PR TITLE
Adding `torch.jit.fork` functionality to parallelize kernel launches

### DIFF
--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -20,15 +20,17 @@ def _sum_tensors(xs: List[torch.Tensor], shape: torch.Size, like: torch.Tensor):
     return like.new_zeros(shape)
 
 
-def codegen_tensor_product_left_right(
-    irreps_in1: o3.Irreps,
-    irreps_in2: o3.Irreps,
-    irreps_out: o3.Irreps,
-    instructions: List[Instruction],
-    shared_weights: bool = False,
-    specialized_code: bool = True,
-    optimize_einsums: bool = True,
-) -> fx.GraphModule:
+def single_instruction_codegen(
+    ins,
+    flat_weight_index,
+    irreps_in1,
+    irreps_in2,
+    irreps_out,
+    weight_numel,
+    shared_weights,
+    specialized_code,
+    optimize_einsums,
+):
     graph = fx.Graph()
 
     # = Function definitions =
@@ -41,42 +43,39 @@ def codegen_tensor_product_left_right(
 
     empty = fx.Proxy(graph.call_function(torch.empty, ((),), dict(device="cpu")), tracer=tracer)
     if shared_weights:
-        output_shape = torch.broadcast_tensors(empty.expand(x1s.shape[:-1]), empty.expand(x2s.shape[:-1]))[0].shape
+        result_shape = torch.broadcast_tensors(empty.expand(x1s.shape[:-1]), empty.expand(x2s.shape[:-1]))[0].shape
     else:
-        output_shape = torch.broadcast_tensors(
+        result_shape = torch.broadcast_tensors(
             empty.expand(x1s.shape[:-1]), empty.expand(x2s.shape[:-1]), empty.expand(weights.shape[:-1])
         )[0].shape
     del empty
 
     # = Short-circut for zero dimensional =
     # We produce no code for empty instructions
-    instructions = [ins for ins in instructions if 0 not in ins.path_shape]
+    # instructions = [ins for ins in instructions if 0 not in ins.path_shape]
 
-    if len(instructions) == 0:
-        outputs = x1s.new_zeros(output_shape + (irreps_out.dim,))
+    if len(ins) == 0:
+        result = x1s.new_zeros(result_shape + (irreps_out.dim,))
 
-        graph.output(outputs.node, torch.Tensor)
+        graph.output(result.node, torch.Tensor)
         # Short circut
         return fx.GraphModule({}, graph, "tp_forward")
 
     # = Broadcast inputs =
-    bc_shape = output_shape + (-1,)
+    bc_shape = result_shape + (-1,)
     x1s, x2s = x1s.expand(bc_shape), x2s.expand(bc_shape)
     if not shared_weights:
         weights = weights.expand(bc_shape)
 
-    output_shape = output_shape + (irreps_out.dim,)
+    result_shape = result_shape + (irreps_out.dim,)
 
     x1s = x1s.reshape(-1, irreps_in1.dim)
     x2s = x2s.reshape(-1, irreps_in2.dim)
 
     batch_numel = x1s.shape[0]
 
-    # = Determine number of weights and reshape weights ==
-    weight_numel = sum(prod(ins.path_shape) for ins in instructions if ins.has_weight)
     if weight_numel > 0:
         weights = weights.reshape(-1, weight_numel)
-    del weight_numel
 
     # = extract individual input irreps =
     # If only one input irrep, can avoid creating a view
@@ -98,307 +97,232 @@ def codegen_tensor_product_left_right(
     # The einsum string index to prepend to the weights if the weights are not shared and have a batch dimension
     z = "" if shared_weights else "z"
 
+    mul_ir_in1 = irreps_in1[ins.i_in1]
+    mul_ir_in2 = irreps_in2[ins.i_in2]
+    mul_ir_out = irreps_out[ins.i_out]
+
+    assert mul_ir_in1.ir.p * mul_ir_in2.ir.p == mul_ir_out.ir.p
+    assert abs(mul_ir_in1.ir.l - mul_ir_in2.ir.l) <= mul_ir_out.ir.l <= mul_ir_in1.ir.l + mul_ir_in2.ir.l
+
+    if mul_ir_in1.dim == 0 or mul_ir_in2.dim == 0 or mul_ir_out.dim == 0:
+        ...
+
+    x1 = x1_list[ins.i_in1]
+    x2 = x2_list[ins.i_in2]
+
+    assert ins.connection_mode in ["uvw", "uvu", "uvv", "uuw", "uuu", "uvuv", "uvu<v", "u<vw"]
+
+    if ins.has_weight:
+        # Extract the weight from the flattened weight tensor
+        w = weights[:, flat_weight_index : flat_weight_index + prod(ins.path_shape)].reshape(
+            (() if shared_weights else (-1,)) + tuple(ins.path_shape)
+        )
+        flat_weight_index += prod(ins.path_shape)
+
     # Cache of input irrep pairs whose outer products (xx) have already been computed
     xx_dict = dict()
 
-    # Current index in the flat weight tensor
-    flat_weight_index = 0
+    # Construct the general xx in case this instruction isn't specialized
+    # If this isn't used, the dead code will get removed
+    key = (ins.i_in1, ins.i_in2, ins.connection_mode[:2])
+    if key not in xx_dict:
+        if ins.connection_mode[:2] == "uu":
+            xx_dict[key] = torch.einsum("zui,zuj->zuij", x1, x2)
+        else:
+            xx_dict[key] = torch.einsum("zui,zvj->zuvij", x1, x2)
+    xx = xx_dict[key]
+    del key
 
-    outputs = []
-    
-    def kernel_launcher(ins, flat_weight_index):
-        mul_ir_in1 = irreps_in1[ins.i_in1]
-        mul_ir_in2 = irreps_in2[ins.i_in2]
-        mul_ir_out = irreps_out[ins.i_out]
+    # Create a proxy & request for the relevant wigner w3j
+    # If not used (because of specialized code), will get removed later.
+    w3j_name = f"_w3j_{mul_ir_in1.ir.l}_{mul_ir_in2.ir.l}_{mul_ir_out.ir.l}"
+    w3j = fx.Proxy(graph.get_attr(w3j_name), tracer=tracer)
 
-        assert mul_ir_in1.ir.p * mul_ir_in2.ir.p == mul_ir_out.ir.p
-        assert abs(mul_ir_in1.ir.l - mul_ir_in2.ir.l) <= mul_ir_out.ir.l <= mul_ir_in1.ir.l + mul_ir_in2.ir.l
+    l1l2l3 = (mul_ir_in1.ir.l, mul_ir_in2.ir.l, mul_ir_out.ir.l)
 
-        if mul_ir_in1.dim == 0 or mul_ir_in2.dim == 0 or mul_ir_out.dim == 0:
-            ...
-
-        x1 = x1_list[ins.i_in1]
-        x2 = x2_list[ins.i_in2]
-
-        assert ins.connection_mode in ["uvw", "uvu", "uvv", "uuw", "uuu", "uvuv", "uvu<v", "u<vw"]
-
-        if ins.has_weight:
-            # Extract the weight from the flattened weight tensor
-            w = weights[:, flat_weight_index : flat_weight_index + prod(ins.path_shape)].reshape(
-                (() if shared_weights else (-1,)) + tuple(ins.path_shape)
+    if ins.connection_mode == "uvw":
+        assert ins.has_weight
+        if specialized_code and l1l2l3 == (0, 0, 0):
+            result = torch.einsum(
+                f"{z}uvw,zu,zv->zw", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
             )
-            flat_weight_index += prod(ins.path_shape)
-
-        # Construct the general xx in case this instruction isn't specialized
-        # If this isn't used, the dead code will get removed
-        key = (ins.i_in1, ins.i_in2, ins.connection_mode[:2])
-        if key not in xx_dict:
-            if ins.connection_mode[:2] == "uu":
-                xx_dict[key] = torch.einsum("zui,zuj->zuij", x1, x2)
-            else:
-                xx_dict[key] = torch.einsum("zui,zvj->zuvij", x1, x2)
-        xx = xx_dict[key]
-        del key
-
-        # Create a proxy & request for the relevant wigner w3j
-        # If not used (because of specialized code), will get removed later.
-        w3j_name = f"_w3j_{mul_ir_in1.ir.l}_{mul_ir_in2.ir.l}_{mul_ir_out.ir.l}"
-        w3j = fx.Proxy(graph.get_attr(w3j_name), tracer=tracer)
-
-        l1l2l3 = (mul_ir_in1.ir.l, mul_ir_in2.ir.l, mul_ir_out.ir.l)
-
-        if ins.connection_mode == "uvw":
-            assert ins.has_weight
+        elif specialized_code and mul_ir_in1.ir.l == 0:
+            result = torch.einsum(f"{z}uvw,zu,zvj->zwj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
+                mul_ir_out.ir.dim
+            )
+        elif specialized_code and mul_ir_in2.ir.l == 0:
+            result = torch.einsum(f"{z}uvw,zui,zv->zwi", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
+                mul_ir_out.ir.dim
+            )
+        elif specialized_code and mul_ir_out.ir.l == 0:
+            result = torch.einsum(f"{z}uvw,zui,zvi->zw", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
+        else:
+            result = torch.einsum(f"{z}uvw,ijk,zuvij->zwk", w, w3j, xx)
+    if ins.connection_mode == "uvu":
+        assert mul_ir_in1.mul == mul_ir_out.mul
+        if ins.has_weight:
             if specialized_code and l1l2l3 == (0, 0, 0):
                 result = torch.einsum(
-                    f"{z}uvw,zu,zv->zw", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
+                    f"{z}uv,zu,zv->zu", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
                 )
             elif specialized_code and mul_ir_in1.ir.l == 0:
-                result = torch.einsum(f"{z}uvw,zu,zvj->zwj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
+                result = torch.einsum(f"{z}uv,zu,zvj->zuj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
                     mul_ir_out.ir.dim
                 )
             elif specialized_code and mul_ir_in2.ir.l == 0:
-                result = torch.einsum(f"{z}uvw,zui,zv->zwi", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
+                result = torch.einsum(f"{z}uv,zui,zv->zui", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
                     mul_ir_out.ir.dim
                 )
             elif specialized_code and mul_ir_out.ir.l == 0:
-                result = torch.einsum(f"{z}uvw,zui,zvi->zw", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
+                result = torch.einsum(f"{z}uv,zui,zvi->zu", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
             else:
-                result = torch.einsum(f"{z}uvw,ijk,zuvij->zwk", w, w3j, xx)
-        if ins.connection_mode == "uvu":
-            assert mul_ir_in1.mul == mul_ir_out.mul
-            if ins.has_weight:
-                if specialized_code and l1l2l3 == (0, 0, 0):
-                    result = torch.einsum(
-                        f"{z}uv,zu,zv->zu", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
-                    )
-                elif specialized_code and mul_ir_in1.ir.l == 0:
-                    result = torch.einsum(f"{z}uv,zu,zvj->zuj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
-                        mul_ir_out.ir.dim
-                    )
-                elif specialized_code and mul_ir_in2.ir.l == 0:
-                    result = torch.einsum(f"{z}uv,zui,zv->zui", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
-                        mul_ir_out.ir.dim
-                    )
-                elif specialized_code and mul_ir_out.ir.l == 0:
-                    result = torch.einsum(f"{z}uv,zui,zvi->zu", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
-                else:
-                    result = torch.einsum(f"{z}uv,ijk,zuvij->zuk", w, w3j, xx)
-            else:
-                # not so useful operation because v is summed
-                result = torch.einsum("ijk,zuvij->zuk", w3j, xx)
-        if ins.connection_mode == "uvv":
-            assert mul_ir_in2.mul == mul_ir_out.mul
-            if ins.has_weight:
-                if specialized_code and l1l2l3 == (0, 0, 0):
-                    result = torch.einsum(
-                        f"{z}uv,zu,zv->zv", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
-                    )
-                elif specialized_code and mul_ir_in1.ir.l == 0:
-                    result = torch.einsum(f"{z}uv,zu,zvj->zvj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
-                        mul_ir_out.ir.dim
-                    )
-                elif specialized_code and mul_ir_in2.ir.l == 0:
-                    result = torch.einsum(f"{z}uv,zui,zv->zvi", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
-                        mul_ir_out.ir.dim
-                    )
-                elif specialized_code and mul_ir_out.ir.l == 0:
-                    result = torch.einsum(f"{z}uv,zui,zvi->zv", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
-                else:
-                    result = torch.einsum(f"{z}uv,ijk,zuvij->zvk", w, w3j, xx)
-            else:
-                # not so useful operation because u is summed
-                # only specialize out for this path
-                if specialized_code and l1l2l3 == (0, 0, 0):
-                    result = torch.einsum(
-                        "zu,zv->zv", x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
-                    )
-                elif specialized_code and mul_ir_in1.ir.l == 0:
-                    result = torch.einsum("zu,zvj->zvj", x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(mul_ir_out.ir.dim)
-                elif specialized_code and mul_ir_in2.ir.l == 0:
-                    result = torch.einsum("zui,zv->zvi", x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
-                elif specialized_code and mul_ir_out.ir.l == 0:
-                    result = torch.einsum("zui,zvi->zv", x1, x2) / sqrt(mul_ir_in1.ir.dim)
-                else:
-                    result = torch.einsum("ijk,zuvij->zvk", w3j, xx)
-        if ins.connection_mode == "uuw":
-            assert mul_ir_in1.mul == mul_ir_in2.mul
-            if ins.has_weight:
-                if specialized_code and l1l2l3 == (0, 0, 0):
-                    result = torch.einsum(
-                        f"{z}uw,zu,zu->zw", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
-                    )
-                elif specialized_code and mul_ir_in1.ir.l == 0:
-                    result = torch.einsum(f"{z}uw,zu,zuj->zwj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
-                        mul_ir_out.ir.dim
-                    )
-                elif specialized_code and mul_ir_in2.ir.l == 0:
-                    result = torch.einsum(f"{z}uw,zui,zu->zwi", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
-                        mul_ir_out.ir.dim
-                    )
-                elif specialized_code and mul_ir_out.ir.l == 0:
-                    result = torch.einsum(f"{z}uw,zui,zui->zw", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
-                else:
-                    result = torch.einsum(f"{z}uw,ijk,zuij->zwk", w, w3j, xx)
-            else:
-                # equivalent to tp(x, y, 'uuu').sum('u')
-                assert mul_ir_out.mul == 1
-                result = torch.einsum("ijk,zuij->zk", w3j, xx)
-        if ins.connection_mode == "uuu":
-            assert mul_ir_in1.mul == mul_ir_in2.mul == mul_ir_out.mul
-            if ins.has_weight:
-                if specialized_code and l1l2l3 == (0, 0, 0):
-                    result = torch.einsum(
-                        f"{z}u,zu,zu->zu", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
-                    )
-                elif specialized_code and l1l2l3 == (1, 1, 1):
-                    result = torch.einsum(f"{z}u,zui->zui", w, torch.cross(x1, x2, dim=2)) / sqrt(2 * 3)
-                elif specialized_code and mul_ir_in1.ir.l == 0:
-                    result = torch.einsum(f"{z}u,zu,zuj->zuj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
-                        mul_ir_out.ir.dim
-                    )
-                elif specialized_code and mul_ir_in2.ir.l == 0:
-                    result = torch.einsum(f"{z}u,zui,zu->zui", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
-                        mul_ir_out.ir.dim
-                    )
-                elif specialized_code and mul_ir_out.ir.l == 0:
-                    result = torch.einsum(f"{z}u,zui,zui->zu", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
-                else:
-                    result = torch.einsum(f"{z}u,ijk,zuij->zuk", w, w3j, xx)
-            else:
-                if specialized_code and l1l2l3 == (0, 0, 0):
-                    result = torch.einsum(
-                        "zu,zu->zu", x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
-                    )
-                elif specialized_code and l1l2l3 == (1, 1, 1):
-                    result = torch.cross(x1, x2, dim=2) * (1.0 / sqrt(2 * 3))
-                elif specialized_code and mul_ir_in1.ir.l == 0:
-                    result = torch.einsum("zu,zuj->zuj", x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(mul_ir_out.ir.dim)
-                elif specialized_code and mul_ir_in2.ir.l == 0:
-                    result = torch.einsum("zui,zu->zui", x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
-                elif specialized_code and mul_ir_out.ir.l == 0:
-                    result = torch.einsum("zui,zui->zu", x1, x2) / sqrt(mul_ir_in1.ir.dim)
-                else:
-                    result = torch.einsum("ijk,zuij->zuk", w3j, xx)
-        if ins.connection_mode == "uvuv":
-            assert mul_ir_in1.mul * mul_ir_in2.mul == mul_ir_out.mul
-            if ins.has_weight:
-                # TODO implement specialized code
-                result = torch.einsum(f"{z}uv,ijk,zuvij->zuvk", w, w3j, xx)
-            else:
-                # TODO implement specialized code
-                result = torch.einsum("ijk,zuvij->zuvk", w3j, xx)
-        if ins.connection_mode == "uvu<v":
-            assert mul_ir_in1.mul == mul_ir_in2.mul
-            assert mul_ir_in1.mul * (mul_ir_in1.mul - 1) // 2 == mul_ir_out.mul
-            name = f"_triu_indices_{mul_ir_in1.mul}"
-            constants[name] = torch.triu_indices(mul_ir_in1.mul, mul_ir_in1.mul, 1)
-            i = fx.Proxy(graph.get_attr(name), tracer=tracer)
-            xx = xx[:, i[0], i[1]]  # zuvij -> zwij
-            if ins.has_weight:
-                # TODO implement specialized code
-                result = torch.einsum(f"{z}w,ijk,zwij->zwk", w, w3j, xx)
-            else:
-                # TODO implement specialized code
-                result = torch.einsum("ijk,zwij->zwk", w3j, xx)
-        if ins.connection_mode == "u<vw":
-            assert mul_ir_in1.mul == mul_ir_in2.mul
-            assert ins.has_weight
-            name = f"_triu_indices_{mul_ir_in1.mul}"
-            constants[name] = torch.triu_indices(mul_ir_in1.mul, mul_ir_in1.mul, 1)
-            i = fx.Proxy(graph.get_attr(name), tracer=tracer)
-            xx = xx[:, i[0], i[1]]  # zuvij -> zqij
-            # TODO implement specialized code
-            result = torch.einsum(f"{z}qw,ijk,zqij->zwk", w, w3j, xx)
-
-        result = ins.path_weight * result
-        
-        result = result.reshape(batch_numel, mul_ir_out.dim)
-        
-        # Remove unused w3js:
-        if len(w3j.node.users) == 0:
-            # The w3j nodes are reshapes, so we have to remove them from the graph
-            # Although they are dead code, they try to reshape to dimensions that don't exist
-            # (since the corresponding w3js are not in w3j)
-            # so they screw up the shape propagation, even though they would be removed later as dead code by TorchScript.
-            graph.erase_node(w3j.node)
+                result = torch.einsum(f"{z}uv,ijk,zuvij->zuk", w, w3j, xx)
         else:
-            if w3j_name not in constants:
-                constants[w3j_name] = o3.wigner_3j(mul_ir_in1.ir.l, mul_ir_in2.ir.l, mul_ir_out.ir.l)
-    
-        graphmod = fx.GraphModule(constants, graph, class_name="tp_forward")
-        # == Optimize ==
-        # TODO: when eliminate_dead_code() is in PyTorch stable, use that
+            # not so useful operation because v is summed
+            result = torch.einsum("ijk,zuvij->zuk", w3j, xx)
+    if ins.connection_mode == "uvv":
+        assert mul_ir_in2.mul == mul_ir_out.mul
+        if ins.has_weight:
+            if specialized_code and l1l2l3 == (0, 0, 0):
+                result = torch.einsum(
+                    f"{z}uv,zu,zv->zv", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
+                )
+            elif specialized_code and mul_ir_in1.ir.l == 0:
+                result = torch.einsum(f"{z}uv,zu,zvj->zvj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
+                    mul_ir_out.ir.dim
+                )
+            elif specialized_code and mul_ir_in2.ir.l == 0:
+                result = torch.einsum(f"{z}uv,zui,zv->zvi", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
+                    mul_ir_out.ir.dim
+                )
+            elif specialized_code and mul_ir_out.ir.l == 0:
+                result = torch.einsum(f"{z}uv,zui,zvi->zv", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
+            else:
+                result = torch.einsum(f"{z}uv,ijk,zuvij->zvk", w, w3j, xx)
+        else:
+            # not so useful operation because u is summed
+            # only specialize out for this path
+            if specialized_code and l1l2l3 == (0, 0, 0):
+                result = torch.einsum(
+                    "zu,zv->zv", x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
+                )
+            elif specialized_code and mul_ir_in1.ir.l == 0:
+                result = torch.einsum("zu,zvj->zvj", x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(mul_ir_out.ir.dim)
+            elif specialized_code and mul_ir_in2.ir.l == 0:
+                result = torch.einsum("zui,zv->zvi", x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
+            elif specialized_code and mul_ir_out.ir.l == 0:
+                result = torch.einsum("zui,zvi->zv", x1, x2) / sqrt(mul_ir_in1.ir.dim)
+            else:
+                result = torch.einsum("ijk,zuvij->zvk", w3j, xx)
+    if ins.connection_mode == "uuw":
+        assert mul_ir_in1.mul == mul_ir_in2.mul
+        if ins.has_weight:
+            if specialized_code and l1l2l3 == (0, 0, 0):
+                result = torch.einsum(
+                    f"{z}uw,zu,zu->zw", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
+                )
+            elif specialized_code and mul_ir_in1.ir.l == 0:
+                result = torch.einsum(f"{z}uw,zu,zuj->zwj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
+                    mul_ir_out.ir.dim
+                )
+            elif specialized_code and mul_ir_in2.ir.l == 0:
+                result = torch.einsum(f"{z}uw,zui,zu->zwi", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
+                    mul_ir_out.ir.dim
+                )
+            elif specialized_code and mul_ir_out.ir.l == 0:
+                result = torch.einsum(f"{z}uw,zui,zui->zw", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
+            else:
+                result = torch.einsum(f"{z}uw,ijk,zuij->zwk", w, w3j, xx)
+        else:
+            # equivalent to tp(x, y, 'uuu').sum('u')
+            assert mul_ir_out.mul == 1
+            result = torch.einsum("ijk,zuij->zk", w3j, xx)
+    if ins.connection_mode == "uuu":
+        assert mul_ir_in1.mul == mul_ir_in2.mul == mul_ir_out.mul
+        if ins.has_weight:
+            if specialized_code and l1l2l3 == (0, 0, 0):
+                result = torch.einsum(
+                    f"{z}u,zu,zu->zu", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
+                )
+            elif specialized_code and l1l2l3 == (1, 1, 1):
+                result = torch.einsum(f"{z}u,zui->zui", w, torch.cross(x1, x2, dim=2)) / sqrt(2 * 3)
+            elif specialized_code and mul_ir_in1.ir.l == 0:
+                result = torch.einsum(f"{z}u,zu,zuj->zuj", w, x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(
+                    mul_ir_out.ir.dim
+                )
+            elif specialized_code and mul_ir_in2.ir.l == 0:
+                result = torch.einsum(f"{z}u,zui,zu->zui", w, x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(
+                    mul_ir_out.ir.dim
+                )
+            elif specialized_code and mul_ir_out.ir.l == 0:
+                result = torch.einsum(f"{z}u,zui,zui->zu", w, x1, x2) / sqrt(mul_ir_in1.ir.dim)
+            else:
+                result = torch.einsum(f"{z}u,ijk,zuij->zuk", w, w3j, xx)
+        else:
+            if specialized_code and l1l2l3 == (0, 0, 0):
+                result = torch.einsum(
+                    "zu,zu->zu", x1.reshape(batch_numel, mul_ir_in1.dim), x2.reshape(batch_numel, mul_ir_in2.dim)
+                )
+            elif specialized_code and l1l2l3 == (1, 1, 1):
+                result = torch.cross(x1, x2, dim=2) * (1.0 / sqrt(2 * 3))
+            elif specialized_code and mul_ir_in1.ir.l == 0:
+                result = torch.einsum("zu,zuj->zuj", x1.reshape(batch_numel, mul_ir_in1.dim), x2) / sqrt(mul_ir_out.ir.dim)
+            elif specialized_code and mul_ir_in2.ir.l == 0:
+                result = torch.einsum("zui,zu->zui", x1, x2.reshape(batch_numel, mul_ir_in2.dim)) / sqrt(mul_ir_out.ir.dim)
+            elif specialized_code and mul_ir_out.ir.l == 0:
+                result = torch.einsum("zui,zui->zu", x1, x2) / sqrt(mul_ir_in1.ir.dim)
+            else:
+                result = torch.einsum("ijk,zuij->zuk", w3j, xx)
+    if ins.connection_mode == "uvuv":
+        assert mul_ir_in1.mul * mul_ir_in2.mul == mul_ir_out.mul
+        if ins.has_weight:
+            # TODO implement specialized code
+            result = torch.einsum(f"{z}uv,ijk,zuvij->zuvk", w, w3j, xx)
+        else:
+            # TODO implement specialized code
+            result = torch.einsum("ijk,zuvij->zuvk", w3j, xx)
+    if ins.connection_mode == "uvu<v":
+        assert mul_ir_in1.mul == mul_ir_in2.mul
+        assert mul_ir_in1.mul * (mul_ir_in1.mul - 1) // 2 == mul_ir_out.mul
+        name = f"_triu_indices_{mul_ir_in1.mul}"
+        constants[name] = torch.triu_indices(mul_ir_in1.mul, mul_ir_in1.mul, 1)
+        i = fx.Proxy(graph.get_attr(name), tracer=tracer)
+        xx = xx[:, i[0], i[1]]  # zuvij -> zwij
+        if ins.has_weight:
+            # TODO implement specialized code
+            result = torch.einsum(f"{z}w,ijk,zwij->zwk", w, w3j, xx)
+        else:
+            # TODO implement specialized code
+            result = torch.einsum("ijk,zwij->zwk", w3j, xx)
+    if ins.connection_mode == "u<vw":
+        assert mul_ir_in1.mul == mul_ir_in2.mul
+        assert ins.has_weight
+        name = f"_triu_indices_{mul_ir_in1.mul}"
+        constants[name] = torch.triu_indices(mul_ir_in1.mul, mul_ir_in1.mul, 1)
+        i = fx.Proxy(graph.get_attr(name), tracer=tracer)
+        xx = xx[:, i[0], i[1]]  # zuvij -> zqij
+        # TODO implement specialized code
+        result = torch.einsum(f"{z}qw,ijk,zqij->zwk", w, w3j, xx)
 
-        if optimize_einsums:
-            # Note that for our einsums, we can optimize _once_ for _any_ batch dimension
-            # and still get the right path for _all_ batch dimensions.
-            # This is because our einsums are essentially of the form:
-            #    zuvw,ijk,zuvij->zwk    OR     uvw,ijk,zuvij->zwk
-            # In the first case, all but one operands have the batch dimension
-            #    => The first contraction gains the batch dimension
-            #    => All following contractions have batch dimension
-            #    => All possible contraction paths have cost that scales linearly in batch size
-            #    => The optimal path is the same for all batch sizes
-            # For the second case, this logic follows as long as the first contraction is not between the first two operands.
-            # Since those two operands do not share any indexes, contracting them first is a rare pathological case. See
-            # https://github.com/dgasmith/opt_einsum/issues/158
-            # for more details.
-            #
-            # TODO: consider the impact maximum intermediate result size on this logic
-            #         \- this is the `memory_limit` option in opt_einsum
-            # TODO: allow user to choose opt_einsum parameters?
-            #
-            # We use float32 and zeros to save memory and time, since opt_einsum_fx looks only at traced shapes, not values or
-            # dtypes.
-            batchdim = 4
-            example_inputs = (
-                torch.zeros((batchdim, irreps_in1.dim)),
-                torch.zeros((batchdim, irreps_in2.dim)),
-                torch.zeros(
-                    1 if shared_weights else batchdim,
-                    flat_weight_index,
-                ),
-            )
-            graphmod = optimize_einsums_full(graphmod, example_inputs)
-        
-        return graphmod
+    result = ins.path_weight * result
 
-    futures: List[torch.jit.Future[torch.fx.GraphModule]] = []
+    result = result.reshape(batch_numel, mul_ir_out.dim)
 
-    for ins in instructions:
-        futures.append(
-            torch.jit.fork(
-                kernel_launcher,
-                ins,
-                flat_weight_index
-            ))
-        
-    for i,fut in enumerate(futures):
-        outputs += [torch.jit.wait(futures[i])]
-
-    # = Return the result =
-    outputs = [
-        _sum_tensors(
-            [out for ins, out in zip(instructions, outputs) if ins.i_out == i_out],
-            shape=(batch_numel, mul_ir_out.dim),
-            like=x1s,
-        )
-        for i_out, mul_ir_out in enumerate(irreps_out)
-        if mul_ir_out.mul > 0
-    ]
-    if len(outputs) > 1:
-        outputs = torch.cat(outputs, dim=1)
-    else:
-        # Avoid an unnecessary copy in a size one torch.cat
-        outputs = outputs[0]
-
-    outputs = outputs.reshape(output_shape)
-
-    graph.output(outputs.node, torch.Tensor)
+    graph.output(result.node, torch.Tensor)
 
     # check graphs
     graph.lint()
+
+    # Remove unused w3js:
+    if len(w3j.node.users) == 0:
+        # The w3j nodes are reshapes, so we have to remove them from the graph
+        # Although they are dead code, they try to reshape to dimensions that don't exist
+        # (since the corresponding w3js are not in w3j)
+        # so they screw up the shape propagation, even though they would be removed later as dead code by TorchScript.
+        graph.erase_node(w3j.node)
+    else:
+        if w3j_name not in constants:
+            constants[w3j_name] = o3.wigner_3j(mul_ir_in1.ir.l, mul_ir_in2.ir.l, mul_ir_out.ir.l)
 
     # Make GraphModules
 
@@ -409,10 +333,11 @@ def codegen_tensor_product_left_right(
     constants_root = torch.nn.Module()
     for key, value in constants.items():
         constants_root.register_buffer(key, value)
-    graphmod = fx.GraphModule(constants_root, graph, class_name="tp_forward")
 
+    graphmod = fx.GraphModule(constants_root, graph, class_name=f"tp_forward")
     # == Optimize ==
     # TODO: when eliminate_dead_code() is in PyTorch stable, use that
+
     if optimize_einsums:
         # Note that for our einsums, we can optimize _once_ for _any_ batch dimension
         # and still get the right path for _all_ batch dimensions.
@@ -446,6 +371,63 @@ def codegen_tensor_product_left_right(
         graphmod = optimize_einsums_full(graphmod, example_inputs)
 
     return graphmod
+
+
+def codegen_tensor_product_left_right(
+    irreps_in1: o3.Irreps,
+    irreps_in2: o3.Irreps,
+    irreps_out: o3.Irreps,
+    instructions: List[Instruction],
+    shared_weights: bool = False,
+    specialized_code: bool = True,
+    optimize_einsums: bool = True,
+) -> fx.GraphModule:
+    outputs = []
+
+    futures: List[torch.jit.Future[torch.fx.GraphModule]] = []
+
+    # = Determine number of weights and reshape weights ==
+    weight_numel = sum(prod(ins.path_shape) for ins in instructions if ins.has_weight)
+    # del weight_numel
+
+    for ins in instructions:
+        # Current index in the flat weight tensor
+        flat_weight_index = 0
+        futures.append(
+            torch.jit.fork(
+                single_instruction_codegen,
+                ins,
+                flat_weight_index,
+                irreps_in1,
+                irreps_in2,
+                irreps_out,
+                weight_numel,
+                shared_weights,
+                specialized_code,
+                optimize_einsums,
+            )
+        )
+
+    for fut in futures:
+        outputs += [torch.jit.wait(fut)()]
+
+    # = Return the result =
+    outputs = [
+        _sum_tensors(
+            [out for ins, out in zip(instructions, outputs) if ins.i_out == i_out],
+            shape=(batch_numel, mul_ir_out.dim),
+            like=x1s,
+        )
+        for i_out, mul_ir_out in enumerate(irreps_out)
+        if mul_ir_out.mul > 0
+    ]
+    if len(outputs) > 1:
+        outputs = torch.cat(outputs, dim=1)
+    else:
+        # Avoid an unnecessary copy in a size one torch.cat
+        outputs = outputs[0]
+
+    outputs = outputs.reshape(output_shape)
 
 
 def codegen_tensor_product_right(

--- a/e3nn/o3/_tensor_product/_codegen.py
+++ b/e3nn/o3/_tensor_product/_codegen.py
@@ -385,7 +385,7 @@ def codegen_tensor_product_left_right(
         graphmod = single_instruction_codegen(
             ins, irreps_in1, irreps_in2, irreps_out, shared_weights, specialized_code, optimize_einsums
         )
-        graphmods[f"_compiled_main_left_right_{ins.connection_mode}_{ins.i_in1},{ins.i_in2},{ins.i_out}"] = graphmod
+        graphmods[f"_compiled_main_left_right_{ins.connection_mode}_{ins.i_in1}_{ins.i_in2}_{ins.i_out}"] = graphmod
 
     return graphmods
 


### PR DESCRIPTION
Implement multistreaming in kernel launch through `torch.jit.fork`

- [ ] Migrate einsum executions in `_codegen_tensor_product_left_right` to `single_instruction_codegen`
- [ ] Implement `torch.jit.fork` for each instance for `single_instruction_codegen`

# Current State

Getting the following error with the following example:

## Example


```python
import torch
from torch.utils.benchmark import Timer

from e3nn import o3
from e3nn.util.jit import compile

device = "cuda" if torch.cuda.is_available() else "cpu"


# Constants
irreps_string = "1e"
batch = 10

# Training params
n = 1000
warmup = -1
irreps_in1 = o3.Irreps(irreps_string)
irreps_in2 = o3.Irreps(irreps_string)
irreps_out = o3.Irreps.spherical_harmonics(2)
tp = o3.FullyConnectedTensorProduct(irreps_in1, irreps_in2, irreps_out,
                                    _specialized_code=True,
                                    _optimize_einsums=True)
tp = tp.to(device=device)
print(f"Tensor product: {tp}")
print("Instructions:")
for ins in tp.instructions:
    print(f"{ins}")
tp = compile(tp)


inputs = iter(
        [
            (irreps_in1.randn(batch, -1).to(device=device),
             irreps_in2.randn(batch, -1).to(device=device))
            for _ in range(n + warmup)
        ]
    )


tp.zero_grad()
out = tp(*next(inputs))
out.tanh().sum().backward()
```

## Error
```
Traceback (most recent call last):
  File "/home/mkotak/e3nn/../e3nn_profiling/tensor_product/tensor_trace_pytorch.py", line 32, in <module>
    tp = compile(tp)
  File "/home/mkotak/.local/lib/python3.10/site-packages/e3nn/util/jit.py", line 113, in compile
    mod = torch.jit.script(mod, **script_options)
  File "/usr/lib/python3/dist-packages/torch/jit/_script.py", line 1284, in script
    return torch.jit._recursive.create_script_module(
  File "/usr/lib/python3/dist-packages/torch/jit/_recursive.py", line 480, in create_script_module
    return create_script_module_impl(nn_module, concrete_type, stubs_fn)
  File "/usr/lib/python3/dist-packages/torch/jit/_recursive.py", line 546, in create_script_module_impl
    create_methods_and_properties_from_stubs(concrete_type, method_stubs, property_stubs)
  File "/usr/lib/python3/dist-packages/torch/jit/_recursive.py", line 397, in create_methods_and_properties_from_stubs
    concrete_type._create_methods_and_properties(property_defs, property_rcbs, method_defs, method_rcbs, method_defaults)
  File "/usr/lib/python3/dist-packages/torch/jit/_recursive.py", line 898, in compile_unbound_method
    create_methods_and_properties_from_stubs(concrete_type, (stub,), ())
  File "/usr/lib/python3/dist-packages/torch/jit/_recursive.py", line 397, in create_methods_and_properties_from_stubs
    concrete_type._create_methods_and_properties(property_defs, property_rcbs, method_defs, method_rcbs, method_defaults)
RuntimeError: 
attribute lookup is not defined on python value of type 'PudbShortcuts':
  File "/home/mkotak/.local/lib/python3.10/site-packages/e3nn/o3/_tensor_product/_tensor_product.py", line 451
    def _get_weights(self, weight: Optional[torch.Tensor]) -> torch.Tensor:
        pu.db
        ~~~~~ <--- HERE
        if not torch.jit.is_scripting():
            # If we're not scripting, then we're in Python and `weight` could be a List[Tensor]
'FullyConnectedTensorProduct._get_weights' is being compiled since it was called from 'FullyConnectedTensorProduct.forward'
  File "/home/mkotak/.local/lib/python3.10/site-packages/e3nn/o3/_tensor_product/_tensor_product.py", line 547
    
        # - PROFILER - with torch.autograd.profiler.record_function(self._profiling_str):
        real_weight = self._get_weights(weight)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
        return self._compiled_main_left_right(x, y, real_weight)
```

## Generated Code

- `Instruction(i_in1=0, i_in2=0, i_out=0, connection_mode='uvw', has_weight=True, path_weight=1.0, path_shape=(1, 1, 1)) `

```python
class GraphModule(torch.nn.Module):                                                                                                                       
    def forward(self, x1 : torch.Tensor, x2 : torch.Tensor, w : torch.Tensor) -> torch.Tensor:                                                            
        # No stacktrace found for following nodes                                                                                                         
        empty = torch.empty((), device = 'cpu')                                                                                                           
        getattr_1 = x1.shape                                                                                                                              
        getitem = getattr_1[slice(None, -1, None)];  getattr_1 = None
        expand = empty.expand(getitem);  getitem = None  
        getattr_2 = x2.shape                                                                                                                              
        getitem_1 = getattr_2[slice(None, -1, None)];  getattr_2 = None                                                                                   
        expand_1 = empty.expand(getitem_1);  empty = getitem_1 = None                                                                                     
        broadcast_tensors = torch.functional.broadcast_tensors(expand, expand_1);  expand = expand_1 = None                                               
        getitem_2 = broadcast_tensors[0];  broadcast_tensors = None
        getattr_3 = getitem_2.shape;  getitem_2 = None                                                                                                    
        add = getattr_3 + (-1,)                                                                                                                           
        expand_2 = x1.expand(add);  x1 = None                                                                                                             
        expand_3 = x2.expand(add);  x2 = add = None                                                                                                       
        add_1 = getattr_3 + (9,);  getattr_3 = None  
        reshape = expand_2.reshape(-1, 3);  expand_2 = None                                                                                               
        reshape_1 = expand_3.reshape(-1, 3);  expand_3 = None                                                                                             
        getattr_4 = reshape.shape                                                                                                                         
        getitem_3 = getattr_4[0];  getattr_4 = None                                                                                                       
        reshape_2 = w.reshape(-1, 1);  w = None                                                                                                           
        reshape_3 = reshape.reshape(getitem_3, 1, 3);  reshape = None 
        reshape_4 = reshape_1.reshape(getitem_3, 1, 3);  reshape_1 = None                                                                                 
        getitem_4 = reshape_2[(slice(None, None, None), slice(0, 1, None))];  reshape_2 = None                                                            
        reshape_5 = getitem_4.reshape((1, 1, 1));  getitem_4 = None                                                                                       
        einsum = torch.functional.einsum('edb,eca->ecdab', reshape_4, reshape_3) 
        einsum_1 = torch.functional.einsum('dca,dba->dcb', reshape_4, reshape_3);  reshape_4 = reshape_3 = None                                           
        mul = reshape_5 * 0.5773502691896258;  reshape_5 = None                                                                                           
        tensordot = torch.functional.tensordot(einsum_1, mul, dims = ((1, 2), (1, 0)), out = None);  einsum_1 = mul = None                                
        reshape_6 = tensordot.reshape(getitem_3, 1);  tensordot = getitem_3 = None                                                                        
        return reshape_6  
```

- `Instruction(i_in1=0, i_in2=0, i_out=2, connection_mode='uvw', has_weight=True, path_weight=2.23606797749979, path_shape=(1, 1, 1))`

```python
class GraphModule(torch.nn.Module):                                                                                                                       
    def forward(self, x1 : torch.Tensor, x2 : torch.Tensor, w : torch.Tensor) -> torch.Tensor:                                                            
        # No stacktrace found for following nodes                                                                                                         
        empty = torch.empty((), device = 'cpu')                                                                                                           
        getattr_1 = x1.shape                                                                                                                              
        getitem = getattr_1[slice(None, -1, None)];  getattr_1 = None                                                                                     
        expand = empty.expand(getitem);  getitem = None
        getattr_2 = x2.shape                                                                                                                              
        getitem_1 = getattr_2[slice(None, -1, None)];  getattr_2 = None                                                                                   
        expand_1 = empty.expand(getitem_1);  empty = getitem_1 = None                                                                                     
        broadcast_tensors = torch.functional.broadcast_tensors(expand, expand_1);  expand = expand_1 = None                                               
        getitem_2 = broadcast_tensors[0];  broadcast_tensors = None                                                                                       
        getattr_3 = getitem_2.shape;  getitem_2 = None
        add = getattr_3 + (-1,)                                                                                                                           
        expand_2 = x1.expand(add);  x1 = None                                                                                                             
        expand_3 = x2.expand(add);  x2 = add = None                                                                                                       
        add_1 = getattr_3 + (9,);  getattr_3 = None                                                                                                       
        reshape = expand_2.reshape(-1, 3);  expand_2 = None                                                                                               
        reshape_1 = expand_3.reshape(-1, 3);  expand_3 = None                                                                                             
        getattr_4 = reshape.shape
        getitem_3 = getattr_4[0];  getattr_4 = None                                                                                                       
        reshape_2 = w.reshape(-1, 1);  w = None                                                                                                           
        reshape_3 = reshape.reshape(getitem_3, 1, 3);  reshape = None                                                                                     
        reshape_4 = reshape_1.reshape(getitem_3, 1, 3);  reshape_1 = None                                                                                 
        getitem_4 = reshape_2[(slice(None, None, None), slice(0, 1, None))];  reshape_2 = None                                                            
        reshape_5 = getitem_4.reshape((1, 1, 1));  getitem_4 = None
        _w3j_1_1_2 = self._w3j_1_1_2                                                                                                                      
        einsum = torch.functional.einsum('edb,eca->edbca', reshape_4, reshape_3);  reshape_4 = reshape_3 = None                                           
        tensordot = torch.functional.tensordot(einsum, _w3j_1_1_2, dims = ((2, 4), (1, 0)), out = None);  einsum = _w3j_1_1_2 = None                      
        mul = reshape_5 * 2.23606797749979;  reshape_5 = None
        tensordot_1 = torch.functional.tensordot(tensordot, mul, dims = ((1, 2), (1, 0)), out = None);  tensordot = mul = None                            
        permute = tensordot_1.permute(0, 2, 1);  tensordot_1 = None                                                                                       
        reshape_6 = permute.reshape(getitem_3, 5);  permute = getitem_3 = None                                                                            
        return reshape_6
        
        
```