### PR TITLE
Make scalar bias term optional in `_batchnorm.py`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Optional scalar bias term in `_batchnorm.py`
 
 ## [0.5.1] - 2022-12-12
 ### Added

--- a/e3nn/o3/_tensor_product/_sub.py
+++ b/e3nn/o3/_tensor_product/_sub.py
@@ -102,7 +102,6 @@ class ElementwiseTensorProduct(TensorProduct):
     """
 
     def __init__(self, irreps_in1, irreps_in2, filter_ir_out=None, irrep_normalization: str = None, **kwargs) -> None:
-
         irreps_in1 = o3.Irreps(irreps_in1).simplify()
         irreps_in2 = o3.Irreps(irreps_in2).simplify()
         if filter_ir_out is not None:
@@ -135,7 +134,6 @@ class ElementwiseTensorProduct(TensorProduct):
         for i, ((mul, ir_1), (mul_2, ir_2)) in enumerate(zip(irreps_in1, irreps_in2)):
             assert mul == mul_2
             for ir in ir_1 * ir_2:
-
                 if filter_ir_out is not None and ir not in filter_ir_out:
                     continue
 
@@ -179,7 +177,6 @@ class FullTensorProduct(TensorProduct):
         irrep_normalization: str = None,
         **kwargs,
     ) -> None:
-
         irreps_in1 = o3.Irreps(irreps_in1).simplify()
         irreps_in2 = o3.Irreps(irreps_in2).simplify()
         if filter_ir_out is not None:
@@ -193,7 +190,6 @@ class FullTensorProduct(TensorProduct):
         for i_1, (mul_1, ir_1) in enumerate(irreps_in1):
             for i_2, (mul_2, ir_2) in enumerate(irreps_in2):
                 for ir_out in ir_1 * ir_2:
-
                     if filter_ir_out is not None and ir_out not in filter_ir_out:
                         continue
 
@@ -238,7 +234,6 @@ def _square_instructions_full(irreps_in, filter_ir_out=None, irrep_normalization
     for i_1, (mul_1, ir_1) in enumerate(irreps_in):
         for i_2, (mul_2, ir_2) in enumerate(irreps_in):
             for ir_out in ir_1 * ir_2:
-
                 if filter_ir_out is not None and ir_out not in filter_ir_out:
                     continue
 
@@ -311,7 +306,6 @@ def _square_instructions_fully_connected(irreps_in, irreps_out, irrep_normalizat
         for i_2, (_mul_2, ir_2) in enumerate(irreps_in):
             for i_out, (_mul_out, ir_out) in enumerate(irreps_out):
                 if ir_out in ir_1 * ir_2:
-
                     if irrep_normalization == "component":
                         alpha = ir_out.dim
                     if irrep_normalization == "norm":
@@ -374,7 +368,6 @@ class TensorSquare(TensorProduct):
         irrep_normalization: str = None,
         **kwargs,
     ) -> None:
-
         if irrep_normalization is None:
             irrep_normalization = "component"
 

--- a/examples/s2cnn/mnist/gendata.py
+++ b/examples/s2cnn/mnist/gendata.py
@@ -199,7 +199,6 @@ def main() -> None:
     no_rotate = {"train": args.no_rotate_train, "test": args.no_rotate_test}
 
     for label, data in zip(["train", "test"], [mnist_train, mnist_test]):
-
         print(f"projecting {label} data set")
         current = 0
         signals = data["images"].reshape(-1, 28, 28).astype(np.float64)
@@ -207,7 +206,6 @@ def main() -> None:
         projections = np.ndarray((signals.shape[0], 2 * args.bandwidth, 2 * args.bandwidth), dtype=np.uint8)
 
         while current < n_signals:
-
             if not no_rotate[label]:
                 rot = rand_rotation_matrix(deflection=args.noise)
                 rotated_grid = rotate_grid(rot, grid)

--- a/examples/s2cnn/mnist/train.py
+++ b/examples/s2cnn/mnist/train.py
@@ -135,7 +135,6 @@ LEARNING_RATE = 5e-3
 
 
 def load_data(path, batch_size):
-
     with gzip.open(path, "rb") as f:
         dataset = pickle.load(f)
 
@@ -192,7 +191,6 @@ def main() -> None:
         correct = 0
         total = 0
         for images, labels in test_loader:
-
             classifier.eval()
 
             with torch.no_grad():

--- a/tests/o3/cartesian_spherical_harmonics_test.py
+++ b/tests/o3/cartesian_spherical_harmonics_test.py
@@ -77,7 +77,6 @@ def test_backwardable() -> None:
 
 @pytest.mark.parametrize("l", range(10 + 1))
 def test_normalization(float_tolerance, l) -> None:
-
     n = o3.spherical_harmonics(l, torch.randn(3), normalize=True, normalization="integral").pow(2).mean()
     assert abs(n - 1 / (4 * math.pi)) < float_tolerance
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

## Description
With this pull request, the scalar bias term in `_batchnorm.py` can be enabled or disabled (separately from `self.weight`) as desired.

## Motivation and Context
When one does not provide scalar inputs to `BatchNorm`, the `self.bias` term becomes an unused network parameter that should be removed.

## How Has This Been Tested?
I have installed a local copy of this fork and successfully found that I can now remove the bias term for scalar inputs as desired (e.g., in the context of not providing any scalar inputs in the first place).

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if relevant).
- [x] I have added tests that cover my changes (if relevant).
- [x] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [x] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
