### PR TITLE
Add matplotlib to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     packages=find_packages(exclude=["tests.*", "tests"]),
     install_requires=[
         "sympy",
+        "matplotlib",
         "scipy",  # only for SphericalTensor.find_peaks
         "torch>=1.8.0",  # >= 1.8 is required for FX
         "opt_einsum_fx>=0.1.4",  # optimization of TensorProduct FX code


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->
## Description

Add matplotlib to setup.py as requirement
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
`e3nn/o3/_tensor_product/_tensor_product.py:630` imports matplotlib, but it is not in the setup.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
This should be a minimal fix. No testing has been done.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [Changelog](https://github.com/e3nn/e3nn/blob/main/ChangeLog.md).
