### PR TITLE
Fixing broken tests in #437

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         pip install coveralls
     - name: Test with pytest
       run: |
-        coverage run --source=e3nn -m pytest --doctest-modules --ignore=docs/ .
+        coverage run --source=e3nn -m pytest --doctest-modules --ignore=docs/ --ignore-glob='**/experimental*' tests examples
     - name: Upload to coveralls
       env:
         COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,4 @@
-# .readthedocs.yaml
+# .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,11 @@ version: 2
 # added following nbsphinx instructions
 formats: all
 
+build:
+    os: ubuntu-22.04
+    tools:
+      python: "3.12"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,24 +1,23 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-# added following nbsphinx instructions
-formats: all
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+   configuration: docs/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally declare the Python requirements required to build your docs
 python:
-  version: 3.8
-  install:
-    - requirements: docs/requirements.txt
-  system_packages: true  # added following nbsphinx instructions
+   install:
+   - requirements: docs/requirements.txt
+   - method: pip
+     path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,6 @@ formats: all
 
 build:
     os: ubuntu-22.04
-    tools:
-      python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,6 @@ version: 2
 # added following nbsphinx instructions
 formats: all
 
-build:
-    os: ubuntu-22.04
-
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,11 +6,12 @@ sympy
 
 ipykernel
 plotly
+matplotlib==3.7.3
 jupyter-sphinx
 ase
 
 --find-links https://download.pytorch.org/whl/cpu
-torch==2.0.0
+torch
 
 --find-links https://data.pyg.org/whl/torch-2.0.0+cpu.html
 torch-scatter

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,12 +6,11 @@ sympy
 
 ipykernel
 plotly
-matplotlib==3.7.3
 jupyter-sphinx
 ase
 
 --find-links https://download.pytorch.org/whl/cpu
-torch
+torch==2.*
 
 --find-links https://data.pyg.org/whl/torch-2.0.0+cpu.html
 torch-scatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Operating System :: MacOS",
 ]
 dependencies = [
+  "numpy<2.0",
   "sympy",
   "scipy",
   "torch>=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
   "Operating System :: MacOS",
 ]
 dependencies = [
-  "numpy<2.0",
   "sympy",
   "scipy",
   "torch>=1.8.0",


### PR DESCRIPTION
- [x] Explicitly runs `tests` and `examples` instead of running it from source (similar to [e3nn-jax](https://github.com/e3nn/e3nn-jax/blob/a2a81ab451b9cd597d7be27b3e1faba79457475d/.github/workflows/tests.yml#L42))

- [x] Ignores `experimental` folder in `pytest` workflow