### PR TITLE
Irreps assert in `o3.experimental`

### DIFF
--- a/e3nn/o3/experimental/_elementwise_tp.py
+++ b/e3nn/o3/experimental/_elementwise_tp.py
@@ -57,7 +57,7 @@ class ElementwiseTensorProduct(nn.Module):
 
         paths = {}
         irreps_out = []
-        for (mul_1, ir_1), slice_1, (mul_2, ir_2), slice_2 in zip(
+        for (mul_1, ir_1), slice_1, (_, ir_2), slice_2 in zip(
             irreps_in1, irreps_in1.slices(), irreps_in2, irreps_in2.slices()
         ):
             for ir_out in ir_1 * ir_2:
@@ -74,7 +74,7 @@ class ElementwiseTensorProduct(nn.Module):
                 paths[(ir_1.l, ir_2.l, ir_out.l)] = Path(
                     Chunk(mul_1, ir_1.dim, slice_1), Chunk(mul_1, ir_2.dim, slice_2), Chunk(mul_1, ir_out.dim)
                 )
-                irreps_out.append((mul_1 * mul_2, ir_out))
+                irreps_out.append((mul_1, ir_out))
         self.paths = paths
         irreps_out = o3.Irreps(irreps_out)
         self.irreps_out, _, self.inv = irreps_out.sort()

--- a/e3nn/o3/experimental/_elementwise_tp.py
+++ b/e3nn/o3/experimental/_elementwise_tp.py
@@ -71,7 +71,7 @@ class ElementwiseTensorProduct(nn.Module):
                 else:
                     raise ValueError(f"irrep_normalization={irrep_normalization} not supported")
                 self.register_buffer(f"cg_{ir_1.l}_{ir_2.l}_{ir_out.l}", cg)
-                paths[(ir_1.l, ir_2.l, ir_out.l)] = Path(
+                paths[(ir_1.l, ir_1.p, ir_2.l, ir_2.p, ir_out.l, ir_out.p)] = Path(
                     Chunk(mul_1, ir_1.dim, slice_1), Chunk(mul_1, ir_2.dim, slice_2), Chunk(mul_1, ir_out.dim)
                 )
                 irreps_out.append((mul_1, ir_out))
@@ -89,7 +89,7 @@ class ElementwiseTensorProduct(nn.Module):
         input1, input2, leading_shape = _prepare_inputs(input1, input2)
 
         chunks = []
-        for (l1, l2, l3), (
+        for (l1, _, l2, _, l3, _), (
             (mul_1, input_dim1, slice_1),
             (mul_2, input_dim2, slice_2),
             (output_mul, output_dim, _),

--- a/e3nn/o3/experimental/_full_tp.py
+++ b/e3nn/o3/experimental/_full_tp.py
@@ -52,7 +52,7 @@ class FullTensorProduct(nn.Module):
                     else:
                         raise ValueError(f"irrep_normalization={irrep_normalization} not supported")
                     self.register_buffer(f"cg_{ir_1.l}_{ir_2.l}_{ir_out.l}", cg)
-                    paths[(ir_1.l, ir_2.l, ir_out.l)] = Path(
+                    paths[(ir_1.l, ir_1.p, ir_2.l, ir_2.p, ir_out.l, ir_out.p)] = Path(
                         Chunk(mul_1, ir_1.dim, slice_1), Chunk(mul_2, ir_2.dim, slice_2), Chunk(mul_1 * mul_2, ir_out.dim)
                     )
                     irreps_out.append((mul_1 * mul_2, ir_out))
@@ -69,7 +69,7 @@ class FullTensorProduct(nn.Module):
     ) -> torch.Tensor:
         input1, input2, leading_shape = _prepare_inputs(input1, input2)
         chunks = []
-        for (l1, l2, l3), (
+        for (l1, _, l2, _, l3, _), (
             (mul_1, input_dim1, slice_1),
             (mul_2, input_dim2, slice_2),
             (output_mul, output_dim, _),

--- a/tests/o3/experimental/test_elementwise_tp.py
+++ b/tests/o3/experimental/test_elementwise_tp.py
@@ -3,7 +3,7 @@ from e3nn import o3
 import pytest
 
 
-@pytest.mark.parametrize("irreps_in1, irreps_in2", [("10x0e", "5x0e + 5x1o"), ("2x0e + 1x1e", "2x0o + 1x1e")])
+@pytest.mark.parametrize("irreps_in1, irreps_in2", [("15x0e", "5x0e + 5x1o + 5x1e"), ("2x0e + 1x1e", "2x0o + 1x1e")])
 def test_elementwise_tp(irreps_in1, irreps_in2):
 
     irreps_in1 = o3.Irreps(irreps_in1)

--- a/tests/o3/experimental/test_elementwise_tp.py
+++ b/tests/o3/experimental/test_elementwise_tp.py
@@ -17,4 +17,5 @@ def test_elementwise_tp(irreps_in1, irreps_in2):
     result_tp = tp(x1, x2)
     result_tp2 = tp_pt2(x1, x2)
 
+    assert tp.irreps_out == tp_pt2.irreps_out
     torch.testing.assert_close(result_tp, result_tp2)

--- a/tests/o3/experimental/test_fulltp.py
+++ b/tests/o3/experimental/test_fulltp.py
@@ -12,4 +12,5 @@ def test_fulltp(irreps_in1, irreps_in2):
     tp_pt2 = torch.compile(o3.experimental.FullTensorProductv2(irreps_in1, irreps_in2), fullgraph=True)
     tp = o3.FullTensorProduct(irreps_in1, irreps_in2)
 
+    assert tp_pt2.irreps_out == tp.irreps_out
     torch.testing.assert_close(tp_pt2(x, y), tp(x, y))


### PR DESCRIPTION
Sorry these checks got missed in the first round. Found some bugs in elementwise and fulltp

- irreps_out was wrong
- irreps with same parity were overwriting the same path

@mariogeiger 