### PR TITLE
o3.experimental.TensorSquarev2

### DIFF
--- a/e3nn/o3/experimental/__init__.py
+++ b/e3nn/o3/experimental/__init__.py
@@ -1,3 +1,4 @@
 from ._full_tp import FullTensorProduct as FullTensorProductv2
+from ._square_tp import TensorSquare as TensorSquarev2
 
-__all__ = [FullTensorProductv2]
+__all__ = [FullTensorProductv2, TensorSquarev2]

--- a/e3nn/o3/experimental/_square_tp.py
+++ b/e3nn/o3/experimental/_square_tp.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-from e3nn.util.datatypes import Path, Chunk
+from e3nn.util.datatypes import Path, Chunk, TensorProductMode
 from e3nn import o3
 
 import torch
@@ -25,9 +25,7 @@ class TensorSquare(nn.Module):
         if regroup_output:
             irreps_in = o3.Irreps(irreps_in).regroup()
 
-        paths_uvuv = {}
-        paths_uvw = {}
-        paths_uuu = {}
+        paths = {}
         irreps_out = []
         for i_1, ((mul_1, ir_1), slice_1) in enumerate(zip(irreps_in, irreps_in.slices())):
             for i_2, ((mul_2, ir_2), slice_2) in enumerate(zip(irreps_in, irreps_in.slices())):
@@ -52,8 +50,11 @@ class TensorSquare(nn.Module):
                             raise ValueError(f"irrep_normalization={irrep_normalization}")
 
                     if i_1 < i_2:
-                        paths_uvw[(ir_1.l, ir_1.p, ir_2.l, ir_2.p, ir_out.l, ir_out.p)] = Path(
-                            Chunk(mul_1, ir_1.dim, slice_1), Chunk(mul_2, ir_2.dim, slice_2), Chunk(mul_1 * mul_2, ir_out.dim)
+                        paths[(ir_1.l, ir_1.p, ir_2.l, ir_2.p, ir_out.l, ir_out.p)] = Path(
+                            Chunk(mul_1, ir_1.dim, slice_1),
+                            Chunk(mul_2, ir_2.dim, slice_2),
+                            Chunk(mul_1 * mul_2, ir_out.dim),
+                            tensor_product_mode=TensorProductMode.UVW
                         )
                         irreps_out.append((mul_1 * mul_2, ir_out))
                     elif i_1 == i_2:
@@ -62,9 +63,10 @@ class TensorSquare(nn.Module):
                             uvw = torch.zeros((mul_1, mul_1, mul_1 * (mul_1 - 1) // 2))
                             i, j = zip(*itertools.combinations(range(mul_1), 2))
                             uvw[i, j, torch.arange(len(i))] = 1
-                            paths_uvuv[(ir_1.l, ir_1.p, ir_2.l, ir_2.p, ir_out.l, ir_out.p)] = Path(
+                            paths[(ir_1.l, ir_1.p, ir_2.l, ir_2.p, ir_out.l, ir_out.p)] = Path(
                                 input_1_slice=Chunk(mul_1, ir_1.dim, slice_1),
                                 output_slice=Chunk(int(uvw.shape[-1]), ir_out.dim),
+                                tensor_product_mode=TensorProductMode.UVUV
                             )
                             self.register_buffer(f"uvw_{ir_1.l}_{ir_2.l}_{ir_out.l}", uvw)
 
@@ -100,17 +102,17 @@ class TensorSquare(nn.Module):
                                 else:
                                     raise ValueError(f"irrep_normalization={irrep_normalization}")
                             irreps_out.append((mul_1, ir_out))
-                            paths_uuu[(ir_1.l, ir_1.p, ir_2.l, ir_2.p, ir_out.l, ir_out.p)] = Path(
-                                input_1_slice=Chunk(mul_1, ir_1.dim, slice_1), output_slice=Chunk(mul_1, ir_out.dim)
+                            paths[(ir_1.l, ir_1.p, ir_2.l, ir_2.p, ir_out.l, ir_out.p)] = Path(
+                                input_1_slice=Chunk(mul_1, ir_1.dim, slice_1),
+                                output_slice=Chunk(mul_1, ir_out.dim),
+                                tensor_product_mode=TensorProductMode.UUU
                             )
 
                     cg = o3.wigner_3j(ir_1.l, ir_2.l, ir_out.l)
                     cg *= np.sqrt(alpha)
                     self.register_buffer(f"cg_{ir_1.l}_{ir_2.l}_{ir_out.l}", cg)
 
-        self.paths_uvuv = paths_uvuv
-        self.paths_uvw = paths_uvw
-        self.paths_uuu = paths_uuu
+        self.paths = paths
         irreps_out = o3.Irreps(irreps_out)
         self.irreps_out, _, self.inv = irreps_out.sort()
         self.irreps_in = irreps_in
@@ -120,31 +122,34 @@ class TensorSquare(nn.Module):
         input: torch.Tensor,
     ) -> torch.Tensor:
         chunks = []
-        for (l1, _, l2, _, l3, _), (
-            (mul_1, input_dim1, slice_1),
-            (mul_2, input_dim2, slice_2),
-            (output_mul, output_dim, _),
-        ) in self.paths_uvw.items():
-            x1 = input[..., slice_1].reshape(-1, mul_1, input_dim1)
-            x2 = input[..., slice_2].reshape(-1, mul_2, input_dim2)
-            cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
-            chunk = torch.einsum("...ui, ...vj, ijk -> ...uvk", x1, x2, cg)
-            chunk = torch.reshape(chunk, chunk.shape[:-3] + (output_mul * output_dim,))
-            chunks.append(chunk)
+        for (l1, _, l2, _, l3, _), path in self.paths.items():
+            match path.tensor_product_mode:
+                case TensorProductMode.UVW:
+                    ((mul_1, input_dim1, slice_1),
+                     (mul_2, input_dim2, slice_2),
+                     (output_mul, output_dim, _), (_)) = path
+                    x1 = input[..., slice_1].reshape(-1, mul_1, input_dim1)
+                    x2 = input[..., slice_2].reshape(-1, mul_2, input_dim2)
+                    cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
+                    chunk = torch.einsum("...ui, ...vj, ijk -> ...uvk", x1, x2, cg)
+                    chunk = torch.reshape(chunk, chunk.shape[:-3] + (output_mul * output_dim,))
+                    chunks.append(chunk)
 
-        for (l1, _, l2, _, l3, _), ((mul_in, input_dim, slice_in), _, (output_mul, output_dim, _)) in self.paths_uvuv.items():
-            x = input[..., slice_in].reshape(-1, mul_in, input_dim)
-            cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
-            uvw = getattr(self, f"uvw_{l1}_{l2}_{l3}")
-            chunk = torch.einsum("...ui, ...vj, ijk, uvw -> ...wk", x, x, cg, uvw)
-            chunk = torch.reshape(chunk, chunk.shape[:-2] + (output_mul * output_dim,))
-            chunks.append(chunk)
+                case TensorProductMode.UVUV:
+                    ((mul_in, input_dim, slice_in), _, (output_mul, output_dim, _), (_)) = path
+                    x = input[..., slice_in].reshape(-1, mul_in, input_dim)
+                    cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
+                    uvw = getattr(self, f"uvw_{l1}_{l2}_{l3}")
+                    chunk = torch.einsum("...ui, ...vj, ijk, uvw -> ...wk", x, x, cg, uvw)
+                    chunk = torch.reshape(chunk, chunk.shape[:-2] + (output_mul * output_dim,))
+                    chunks.append(chunk)
 
-        for (l1, _, l2, _, l3, _), ((mul_in, input_dim, slice_in), _, (output_mul, output_dim, _)) in self.paths_uuu.items():
-            x = input[..., slice_in].reshape(-1, mul_in, input_dim)
-            cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
-            chunk = torch.einsum("...ui, ...uj, ijk -> ...uk", x, x, cg)
-            chunk = torch.reshape(chunk, chunk.shape[:-2] + (output_mul * output_dim,))
-            chunks.append(chunk)
+                case TensorProductMode.UUU:
+                    ((mul_in, input_dim, slice_in), _, (output_mul, output_dim, _), (_)) = path
+                    x = input[..., slice_in].reshape(-1, mul_in, input_dim)
+                    cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
+                    chunk = torch.einsum("...ui, ...uj, ijk -> ...uk", x, x, cg)
+                    chunk = torch.reshape(chunk, chunk.shape[:-2] + (output_mul * output_dim,))
+                    chunks.append(chunk)
 
         return torch.cat([chunks[i] for i in self.inv], dim=-1)

--- a/e3nn/o3/experimental/_square_tp.py
+++ b/e3nn/o3/experimental/_square_tp.py
@@ -1,0 +1,150 @@
+# flake8: noqa
+
+from e3nn.util.datatypes import Path, Chunk
+from e3nn import o3
+
+import torch
+from torch import nn
+import numpy as np
+
+import itertools
+
+
+class TensorSquare(nn.Module):
+    def __init__(
+        self,
+        irreps_in: o3.Irreps,
+        *,
+        irrep_normalization: str = "component",
+        normalized_input: bool = False,
+        regroup_output: bool = True,
+    ):
+        """Tensor Product adapted from https://github.com/e3nn/e3nn-jax/blob/cf37f3e95264b34587b3a202ea4c3eb82597307e/e3nn_jax/_src/tensor_products.py#L216-L372"""
+        super(TensorSquare, self).__init__()
+
+        if regroup_output:
+            irreps_in = o3.Irreps(irreps_in).regroup()
+
+        paths_uvk = {}
+        paths_wk = {}
+        paths_uk = {}
+        irreps_out = []
+        for i_1, ((mul_1, ir_1), slice_1) in enumerate(zip(irreps_in, irreps_in.slices())):
+            for i_2, ((mul_2, ir_2), slice_2) in enumerate(zip(irreps_in, irreps_in.slices())):
+                for ir_out in ir_1 * ir_2:
+                    if normalized_input:
+                        if irrep_normalization == "component":
+                            alpha = ir_1.dim * ir_2.dim * ir_out.dim
+                        elif irrep_normalization == "norm":
+                            alpha = ir_1.dim * ir_2.dim
+                        elif irrep_normalization == "none":
+                            alpha = 1
+                        else:
+                            raise ValueError(f"irrep_normalization={irrep_normalization}")
+                    else:
+                        if irrep_normalization == "component":
+                            alpha = ir_out.dim
+                        elif irrep_normalization == "norm":
+                            alpha = ir_1.dim * ir_2.dim
+                        elif irrep_normalization == "none":
+                            alpha = 1
+                        else:
+                            raise ValueError(f"irrep_normalization={irrep_normalization}")
+
+                    if i_1 < i_2:
+                        paths_uvk[(ir_1.l, ir_2.l, ir_out.l)] = Path(
+                            Chunk(mul_1, ir_1.dim, slice_1), Chunk(mul_2, ir_2.dim, slice_2), Chunk(mul_1 * mul_2, ir_out.dim)
+                        )
+                        irreps_out.append((mul_1 * mul_2, ir_out))
+                    elif i_1 == i_2:
+                        if mul_1 > 1:
+                            irreps_out.append((mul_1 * (mul_1 - 1) // 2, ir_out))
+                            uvw = torch.zeros((mul_1, mul_1, mul_1 * (mul_1 - 1) // 2))
+                            i, j = zip(*itertools.combinations(range(mul_1), 2))
+                            uvw[i, j, torch.arange(len(i))] = 1
+                            paths_wk[(ir_1.l, ir_2.l, ir_out.l)] = Path(
+                                input_1_slice=Chunk(mul_1, ir_1.dim, slice_1),
+                                output_slice=Chunk(int(uvw.shape[-1]), ir_out.dim),
+                            )
+                            self.register_buffer(f"uvw_{ir_1.l}_{ir_2.l}_{ir_out.l}", uvw)
+
+                        if ir_out.l % 2 == 0:
+                            if normalized_input:
+                                if irrep_normalization == "component":
+                                    if ir_out.l == 0:
+                                        alpha = ir_out.dim * ir_1.dim
+                                    else:
+                                        alpha = ir_1.dim * (ir_1.dim + 2) / 2 * ir_out.dim
+                                elif irrep_normalization == "norm":
+                                    if ir_out.l == 0:
+                                        alpha = ir_out.dim * ir_1.dim
+                                    else:
+                                        alpha = ir_1.dim * (ir_1.dim + 2) / 2
+                                elif irrep_normalization == "none":
+                                    alpha = 1
+                                else:
+                                    raise ValueError(f"irrep_normalization={irrep_normalization}")
+                            else:
+                                if irrep_normalization == "component":
+                                    if ir_out.l == 0:
+                                        alpha = ir_out.dim / (ir_1.dim + 2)
+                                    else:
+                                        alpha = ir_out.dim / 2
+                                elif irrep_normalization == "norm":
+                                    if ir_out.l == 0:
+                                        alpha = ir_1.dim * ir_2.dim / (ir_1.dim + 2)
+                                    else:
+                                        alpha = ir_1.dim * ir_2.dim / 2
+                                elif irrep_normalization == "none":
+                                    alpha = 1
+                                else:
+                                    raise ValueError(f"irrep_normalization={irrep_normalization}")
+                            irreps_out.append((mul_1, ir_out))
+                            paths_uk[(ir_1.l, ir_2.l, ir_out.l)] = Path(
+                                input_1_slice=Chunk(mul_1, ir_1.dim, slice_1), output_slice=Chunk(mul_1, ir_out.dim)
+                            )
+
+                    cg = o3.wigner_3j(ir_1.l, ir_2.l, ir_out.l)
+                    cg *= np.sqrt(alpha)
+                    self.register_buffer(f"cg_{ir_1.l}_{ir_2.l}_{ir_out.l}", cg)
+
+        self.paths_uvk = paths_uvk
+        self.paths_wk = paths_wk
+        self.paths_uk = paths_uk
+        irreps_out = o3.Irreps(irreps_out)
+        self.irreps_out, _, self.inv = irreps_out.sort()
+        self.irreps_in = irreps_in
+
+    def forward(
+        self,
+        input: torch.Tensor,
+    ) -> torch.Tensor:
+        chunks = []
+        for (l1, l2, l3), (
+            (mul_1, input_dim1, slice_1),
+            (mul_2, input_dim2, slice_2),
+            (output_mul, output_dim, _),
+        ) in self.paths_uvk.items():
+            x1 = input[..., slice_1].reshape(-1, mul_1, input_dim1)
+            x2 = input[..., slice_2].reshape(-1, mul_2, input_dim2)
+            cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
+            chunk = torch.einsum("...ui, ...vj, ijk -> ...uvk", x1, x2, cg)
+            chunk = torch.reshape(chunk, chunk.shape[:-3] + (output_mul * output_dim,))
+            chunks.append(chunk)
+
+        for (l1, l2, l3), ((mul_in, input_dim, slice_in), _, (output_mul, output_dim, _)) in self.paths_wk.items():
+            x = input[..., slice_in].reshape(-1, mul_in, input_dim)
+            cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
+            uvw = getattr(self, f"uvw_{l1}_{l2}_{l3}")
+            chunk = torch.einsum("...ui, ...vj, ijk, uvw -> ...wk", x, x, cg, uvw)
+            chunk = torch.reshape(chunk, chunk.shape[:-2] + (output_mul * output_dim,))
+            chunks.append(chunk)
+
+        for (l1, l2, l3), ((mul_in, input_dim, slice_in), _, (output_mul, output_dim, _)) in self.paths_uk.items():
+            x = input[..., slice_in].reshape(-1, mul_in, input_dim)
+            cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
+            chunk = torch.einsum("...ui, ...vj, ijk -> ...uk", x, x, cg)
+            chunk = torch.reshape(chunk, chunk.shape[:-2] + (output_mul * output_dim,))
+            chunks.append(chunk)
+
+        return torch.cat([chunks[i] for i in self.inv], dim=-1)

--- a/e3nn/o3/experimental/_square_tp.py
+++ b/e3nn/o3/experimental/_square_tp.py
@@ -143,7 +143,7 @@ class TensorSquare(nn.Module):
         for (l1, l2, l3), ((mul_in, input_dim, slice_in), _, (output_mul, output_dim, _)) in self.paths_uk.items():
             x = input[..., slice_in].reshape(-1, mul_in, input_dim)
             cg = getattr(self, f"cg_{l1}_{l2}_{l3}")
-            chunk = torch.einsum("...ui, ...vj, ijk -> ...uk", x, x, cg)
+            chunk = torch.einsum("...ui, ...uj, ijk -> ...uk", x, x, cg)
             chunk = torch.reshape(chunk, chunk.shape[:-2] + (output_mul * output_dim,))
             chunks.append(chunk)
 

--- a/e3nn/util/datatypes.py
+++ b/e3nn/util/datatypes.py
@@ -15,4 +15,4 @@ class Path(NamedTuple):
     input_1_slice: Chunk
     input_2_slice: Optional[Chunk] = None
     output_slice: Optional[Chunk] = None
-    # tensor_product_mode: TensorProductMode = TensorProductMode.UUU
+    tensor_product_mode: TensorProductMode = TensorProductMode.UUU

--- a/e3nn/util/datatypes.py
+++ b/e3nn/util/datatypes.py
@@ -1,13 +1,18 @@
 from typing import NamedTuple, Optional
-
+from enum import Enum, auto
 
 class Chunk(NamedTuple):
     mul: int
     dim: int
     slice: Optional[slice] = None
 
+class TensorProductMode(Enum):
+    UUU = auto()
+    UVUV = auto()
+    UVW = auto()
 
 class Path(NamedTuple):
     input_1_slice: Chunk
     input_2_slice: Optional[Chunk] = None
     output_slice: Optional[Chunk] = None
+    # tensor_product_mode: TensorProductMode = TensorProductMode.UUU

--- a/e3nn/util/datatypes.py
+++ b/e3nn/util/datatypes.py
@@ -9,5 +9,5 @@ class Chunk(NamedTuple):
 
 class Path(NamedTuple):
     input_1_slice: Chunk
-    input_2_slice: Chunk
-    output_slice: Chunk
+    input_2_slice: Optional[Chunk] = None
+    output_slice: Optional[Chunk] = None

--- a/tests/o3/experimental/benchmark_squaretp_pt2.py
+++ b/tests/o3/experimental/benchmark_squaretp_pt2.py
@@ -1,0 +1,52 @@
+# flake8: noqa
+
+
+def main():
+    import torch
+    from torch._inductor.utils import print_performance
+
+    # Borrowed from https://github.com/pytorch-labs/gpt-fast/blob/db7b273ab86b75358bd3b014f1f022a19aba4797/generate.py#L16-L18
+    torch.set_float32_matmul_precision("high")
+    import torch._dynamo.config
+    import torch._inductor.config
+
+    torch._inductor.config.coordinate_descent_tuning = True
+    torch._inductor.config.triton.unique_kernel_names = True
+
+    device = "cuda"
+    compile_mode = (
+        "max-autotune"  # Bringing out all of the tricks that Torch 2.0 has but "reduce-overhead" should work as well
+    )
+
+    from e3nn import o3, util
+    import numpy as np
+    from torch import nn
+    import time
+
+    LMAX = 8
+    CHANNEL = 128
+    BATCH = 100
+
+    for lmax in range(1, LMAX + 1):
+        irreps = o3.Irreps.spherical_harmonics(lmax)
+        irreps_x = (CHANNEL * irreps).regroup()
+        x = irreps_x.randn(BATCH, -1).to(device=device)
+        print(f"{irreps_x} \otimes {irreps_x}")
+
+        tp = o3.TensorSquare(irreps_x)  # Doesnt work with fullgraph=True
+
+        tp_compile = torch.compile(tp, mode=compile_mode).to(device=device)
+
+        print(
+            f"TP Torch 2.0 lmax {lmax} channel {CHANNEL} batch {BATCH}: {print_performance(lambda: tp_compile(x), times=100, repeat=10)*1000:.3f}ms"
+        )
+
+        tp_experimental = o3.experimental.TensorSquarev2(irreps_x)
+        tp_experimental_compile = torch.compile(tp_experimental, mode=compile_mode, fullgraph=True).to(device=device)
+        print(
+            f"TP Experimental Torch 2.0 lmax {lmax} channel {CHANNEL} batch {BATCH}: {print_performance(lambda: tp_experimental_compile(x), times=100, repeat=10)*1000:.3f}ms"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/o3/experimental/benchmark_squaretp_pt2.py
+++ b/tests/o3/experimental/benchmark_squaretp_pt2.py
@@ -23,11 +23,11 @@ def main():
     from torch import nn
     import time
 
-    LMAX = 8
-    CHANNEL = 128
+    LMAX = 3
+    CHANNEL = 32
     BATCH = 100
 
-    for lmax in range(1, LMAX + 1):
+    for lmax in range(LMAX, LMAX + 1):
         irreps = o3.Irreps.spherical_harmonics(lmax)
         irreps_x = (CHANNEL * irreps).regroup()
         x = irreps_x.randn(BATCH, -1).to(device=device)

--- a/tests/o3/experimental/test_squaretp.py
+++ b/tests/o3/experimental/test_squaretp.py
@@ -1,0 +1,13 @@
+import torch
+from e3nn import o3
+import pytest
+
+
+@pytest.mark.parametrize("irreps_in", ["0e", "0e + 1e"])
+def test_squaretp(irreps_in):
+    x = o3.Irreps(irreps_in).randn(1, -1)
+    square_tp_pt2 = torch.compile(o3.experimental.TensorSquarev2(irreps_in), fullgraph=True)
+    square_tp = o3.TensorSquare(irreps_in)
+    result_tp2 = square_tp_pt2(x)
+    result_tp = square_tp(x)
+    torch.testing.assert_close(result_tp2, result_tp)


### PR DESCRIPTION
Handles out of order issue in #450 

```
tensor([[ 1.3710,  1.3314, -0.4522, -3.3575,  0.8760, -0.1668,  0.6393,  2.6226,
         -1.2385,  0.1185]])
tensor([[ 1.3710,  1.3314, -0.4522, -3.3575,  0.8760, -0.1668,  0.6393,  2.6226,
         -1.2385,  0.1185]])
```