### PR TITLE
Fixing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,13 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip build
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        python -m build
+        python setup.py sdist bdist_wheel
         twine upload dist/*


### PR DESCRIPTION
## Problem

The release workflow [did not run](https://github.com/e3nn/e3nn/actions/runs/10120348432/job/27989989135) for the latest release

## Solution

Doing what NequIP does and explicitly downloading all dependencies should hopefully fix the issue.