### PR TITLE
Make sure tensor products can be loaded to CPU

### DIFF
--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -101,6 +101,9 @@ class CodeGenMixin:
         else:
             self.__dict__.update(d)
 
+        # Find the location to which tensors must be mapped
+        map_location = getattr(torch._utils._thread_local_state, "map_location", None)
+
         if codegen_state is not None:
             for fname, buffer in codegen_state.items():
                 assert isinstance(fname, str)
@@ -108,7 +111,7 @@ class CodeGenMixin:
                 assert isinstance(buffer, bytes)
                 # Load the TorchScript IR buffer
                 buffer = io.BytesIO(buffer)
-                smod = torch.jit.load(buffer)
+                smod = torch.jit.load(buffer, map_location=map_location)
                 assert isinstance(smod, torch.jit.ScriptModule)
                 # Add the ScriptModule as a submodule
                 setattr(self, fname, smod)


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above. -->

## Description
This change solves the case in which a tensor product module has been stored with its tensors on a CUDA device but must be loaded in the CPU.

Before this change, if I did:

```python
import torch

torch.load("model.ckpt", map_location="cpu")
```

I got:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/gpfs/home/icn2/icn2419564/miniforge3/envs/graph2mat/lib/python3.10/site-packages/torch/serialization.py", line 1097, in load
    return _load(
  File "/gpfs/home/icn2/icn2419564/miniforge3/envs/graph2mat/lib/python3.10/site-packages/torch/serialization.py", line 1525, in _load
    result = unpickler.load()
  File "/gpfs/home/icn2/icn2419564/miniforge3/envs/graph2mat/lib/python3.10/site-packages/e3nn/util/codegen/_mixin.py", line 110, in __setstate__
    smod = torch.jit.load(buffer)
  File "/gpfs/home/icn2/icn2419564/miniforge3/envs/graph2mat/lib/python3.10/site-packages/torch/jit/_serialization.py", line 165, in load
    cpp_module = torch._C.import_ir_module_from_buffer(
RuntimeError: No CUDA GPUs are available
```

My model contains several tensor products, and I checked that some of them got correctly loaded without explicitly passing the `map_location` to `torch.jit.load`, but some others aren't. I don't know why :sweat_smile: 

## How Has This Been Tested?
I checked that I can now load the model in a CPU.

File to reproduce the conda environment (e3nn==0.5.1 , torch==2.4.0, python==3.10.14):
[environment.txt](https://github.com/user-attachments/files/16739807/environment.txt)

And the checkpoint file (must uncompress first):
[model.zip](https://github.com/user-attachments/files/16739815/model.zip)

However this particular environment can't be reproduced in windows because one of the dependencies (`sisl`) needs a fortran compiler.

I'm not sure if one could reproduce the error in a minimal model, I can't check it now because I don't have a device with CUDA to store the model :sweat: 

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/.github/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [CHANGELOG](https://github.com/e3nn/e3nn/blob/main/.github/CHANGELOG.md).
