### PR TITLE
update deprecated matplotlib option

### DIFF
--- a/e3nn/o3/_tensor_product/_tensor_product.py
+++ b/e3nn/o3/_tensor_product/_tensor_product.py
@@ -708,7 +708,7 @@ class TensorProduct(CodeGenMixin, torch.nn.Module):
                         path_weight.append(0)
                 path_weight = np.asarray(path_weight)
                 path_weight /= np.abs(path_weight).max()
-        cmap = matplotlib.cm.get_cmap("Blues")
+        cmap = matplotlib.colormaps["Blues"]
 
         for ins_index, ins in enumerate(self.instructions):
             y = _intersection(s_in1[ins.i_in1], c_in1, s_in2[ins.i_in2], c_in2)


### PR DESCRIPTION
Updated code to use `matplotlib.colormaps["Blues"]` as `matplotlib.cm.get_cmap()` is deprecated (see https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#deprecation-of-top-level-cmap-registration-and-access-functions-in-mpl-cm )

<!-- Provide a general summary of your changes in the Title above. -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context

Resolves: #474

## How Has This Been Tested?


## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/.github/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [CHANGELOG](https://github.com/e3nn/e3nn/blob/main/.github/CHANGELOG.md).
