### PR TITLE
Bump python version to only 3.11 in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.10']
+        python-version: ['3.11']
         torch-version: ['2.4.0']
 
     steps:


### PR DESCRIPTION
Syncing up with python version tested in e3nn-jax