### PR TITLE
[WIP] Compile on by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,29 @@ It contains fundamental mathematical operations such as [tensor products](https:
 
 ![](https://user-images.githubusercontent.com/333780/79220728-dbe82c00-7e54-11ea-82c7-b3acbd9b2246.gif)
 
+```python
+import torch
+from e3nn import o3
+
+# Create a random array made of scalar (0e) and a vector (1o)
+irreps_in = o3.Irreps("0e + 1o")
+x = irreps_in.randn(-1)
+
+# Apply a linear layer
+irreps_out = o3.Irreps("2x0e + 2x1o")
+linear = o3.Linear(irreps_in=irreps_in, irreps_out=irreps_out)
+y = linear(x)
+
+# Compute a tensor product with itself
+tp = o3.FullTensorProduct(irreps_in1=irreps_in, irreps_in2=irreps_in)
+z = tp(x, x)
+
+# Optionally compile the tensor product
+tp_pt2 = torch.compile(tp, fullgraph=True)
+z_pt2 = tp_pt2(x, x) # Warning: First few calls might be slow due to compilation
+torch.testing.assert_close(z, z_pt2)
+```
+
 ## Installation
 
 **Important:** install pytorch and only then run the command

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -57,12 +57,14 @@ def set_optimization_defaults(**kwargs) -> None:
         if k not in _OPT_DEFAULTS:
             raise ValueError(f"Unknown optimization option: {k}")
 
-        # Handle the legacy jit_script_fx flag
+        # Handles the legacy mapping for jit_script_fx
+        # to jit_mode so that old code can still work
+        # with the new defaults.
         if k == "jit_script_fx":
-            _OPT_DEFAULTS[k] = v
             # Update jit_mode based on the legacy mapping
             new_jit_mode = _handle_jit_script_fx_legacy(v, _OPT_DEFAULTS["jit_mode"])
             _validate_and_set_jit_mode(new_jit_mode)
+            _OPT_DEFAULTS[k] = v
         elif k == "jit_mode":
             # Validate and set the new jit_mode
             _validate_and_set_jit_mode(v)

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -7,7 +7,7 @@ from typing import Dict
 _OPT_DEFAULTS: Dict[str, bool] = dict(
     specialized_code=True,
     optimize_einsums=True,
-    jit_script_fx=False,
+    jit_script_fx=True,
 )
 
 

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -8,7 +8,7 @@ _OPT_DEFAULTS: Dict[str, bool] = dict(
     specialized_code=True,
     optimize_einsums=True,
     jit_script_fx=True,
-    jit_mode="compile"
+    jit_mode="script"
 )
 
 def _handle_jit_script_fx_legacy(jit_script_fx: bool, current_jit_mode: str) -> str:

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -8,8 +8,35 @@ _OPT_DEFAULTS: Dict[str, bool] = dict(
     specialized_code=True,
     optimize_einsums=True,
     jit_script_fx=True,
+    jit_mode="compile"
 )
 
+def _handle_jit_script_fx_legacy(jit_script_fx: bool, current_jit_mode: str) -> str:
+    """Handle the legacy jit_script_fx flag mapping to jit_mode.
+
+    Parameters
+    ----------
+    jit_script_fx : bool
+        The legacy jit_script_fx flag value
+    current_jit_mode : str
+        The current jit_mode value
+
+    Returns
+    -------
+    str
+        The new jit_mode value based on the legacy mapping rules
+    """
+    if not jit_script_fx and current_jit_mode == "eager":
+        # Keep it eager
+        return "eager"
+    elif not jit_script_fx:
+        # Map False to eager if not already eager
+        return "eager"
+    elif jit_script_fx and current_jit_mode not in ["script", "inductor"]:
+        # Map True to script only if not already script or inductor
+        return "script"
+    # In all other cases, keep current jit_mode
+    return current_jit_mode
 
 def set_optimization_defaults(**kwargs) -> None:
     r"""Globally set the default optimization settings.
@@ -22,7 +49,15 @@ def set_optimization_defaults(**kwargs) -> None:
     for k, v in kwargs.items():
         if k not in _OPT_DEFAULTS:
             raise ValueError(f"Unknown optimization option: {k}")
-        _OPT_DEFAULTS[k] = v
+
+        # Handle the legacy jit_script_fx flag
+        if k == "jit_script_fx":
+            _OPT_DEFAULTS[k] = v
+            # Update jit_mode based on the legacy mapping
+            new_jit_mode = _handle_jit_script_fx_legacy(v, _OPT_DEFAULTS["jit_mode"])
+            _OPT_DEFAULTS["jit_mode"] = new_jit_mode
+        else:
+            _OPT_DEFAULTS[k] = v
 
 
 def get_optimization_defaults() -> Dict[str, bool]:

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -7,7 +7,7 @@ from typing import Dict
 _OPT_DEFAULTS: Dict[str, bool] = dict(
     specialized_code=True,
     optimize_einsums=True,
-    jit_script_fx=True,
+    jit_script_fx=False,
 )
 
 

--- a/e3nn/__init__.py
+++ b/e3nn/__init__.py
@@ -4,12 +4,8 @@ __version__ = "0.5.6"
 from typing import Dict
 
 
-_OPT_DEFAULTS: Dict[str, bool] = dict(
-    specialized_code=True,
-    optimize_einsums=True,
-    jit_script_fx=True,
-    jit_mode="script"
-)
+_OPT_DEFAULTS: Dict[str, bool] = dict(specialized_code=True, optimize_einsums=True, jit_script_fx=True, jit_mode="script")
+
 
 def _handle_jit_script_fx_legacy(jit_script_fx: bool, current_jit_mode: str) -> str:
     """Handle the legacy jit_script_fx flag mapping to jit_mode.
@@ -38,6 +34,17 @@ def _handle_jit_script_fx_legacy(jit_script_fx: bool, current_jit_mode: str) -> 
     # In all other cases, keep current jit_mode
     return current_jit_mode
 
+
+def _validate_and_set_jit_mode(jit_mode: str) -> None:
+    """Validate and set the jit_mode in _OPT_DEFAULTS."""
+    assert jit_mode in [
+        "script",
+        "inductor",
+        "eager",
+    ], f"Invalid jit_mode: {jit_mode}. Expected 'script', 'inductor', or 'eager'."
+    _OPT_DEFAULTS["jit_mode"] = jit_mode
+
+
 def set_optimization_defaults(**kwargs) -> None:
     r"""Globally set the default optimization settings.
 
@@ -55,7 +62,10 @@ def set_optimization_defaults(**kwargs) -> None:
             _OPT_DEFAULTS[k] = v
             # Update jit_mode based on the legacy mapping
             new_jit_mode = _handle_jit_script_fx_legacy(v, _OPT_DEFAULTS["jit_mode"])
-            _OPT_DEFAULTS["jit_mode"] = new_jit_mode
+            _validate_and_set_jit_mode(new_jit_mode)
+        elif k == "jit_mode":
+            # Validate and set the new jit_mode
+            _validate_and_set_jit_mode(v)
         else:
             _OPT_DEFAULTS[k] = v
 

--- a/e3nn/io/_spherical_tensor.py
+++ b/e3nn/io/_spherical_tensor.py
@@ -62,6 +62,7 @@ class SphericalTensor(o3.Irreps):
     >>> SphericalTensor(3, 1, -1)
     1x0e+1x1o+1x2e+1x3o
     """
+
     # pylint: disable=abstract-method
 
     def __new__(

--- a/e3nn/math/_soft_unit_step.py
+++ b/e3nn/math/_soft_unit_step.py
@@ -10,9 +10,7 @@ class _SoftUnitStep(torch.autograd.Function):
         y = torch.zeros_like(x)
         mask = x > 0.0
         safe_x = torch.where(mask, x, torch.ones_like(x))  # Avoid division by zero
-        y = torch.where(
-            mask, torch.exp(-1.0 / safe_x), torch.zeros_like(x)
-        )
+        y = torch.where(mask, torch.exp(-1.0 / safe_x), torch.zeros_like(x))
         return y
 
     @staticmethod
@@ -20,11 +18,9 @@ class _SoftUnitStep(torch.autograd.Function):
         (x,) = ctx.saved_tensors
         mask = x > 0.0
         safe_x = torch.where(mask, x, torch.ones_like(x))  # Avoid division by zero
-        dx = torch.where(
-            mask, torch.exp(-1.0 / safe_x) / (safe_x * safe_x), torch.zeros_like(x)
-        )
+        dx = torch.where(mask, torch.exp(-1.0 / safe_x) / (safe_x * safe_x), torch.zeros_like(x))
         return dx * dy
-    
+
 
 def soft_unit_step(x):
     r"""smooth :math:`C^\infty` version of the unit step function

--- a/e3nn/nn/_fc.py
+++ b/e3nn/nn/_fc.py
@@ -64,6 +64,7 @@ class FullyConnectedNet(torch.nn.Sequential):
 
             \int_{-\infty}^{\infty} \phi(z)^2 \frac{e^{-z^2/2}}{\sqrt{2\pi}} dz = 1
     """
+
     hs: List[int]
 
     def __init__(self, hs, act=None, variance_in: int = 1, variance_out: int = 1, out_act: bool = False) -> None:

--- a/e3nn/nn/models/gate_points_2101.py
+++ b/e3nn/nn/models/gate_points_2101.py
@@ -4,6 +4,7 @@ Exact equivariance to :math:`E(3)`
 
 version of january 2021
 """
+
 import math
 from typing import Dict, Optional
 

--- a/e3nn/nn/models/gate_points_2102.py
+++ b/e3nn/nn/models/gate_points_2102.py
@@ -4,6 +4,7 @@ Exact equivariance to :math:`E(3)`
 
 version of february 2021
 """
+
 import math
 from typing import Dict, Optional
 

--- a/e3nn/nn/models/v2103/conv_points_in_out.py
+++ b/e3nn/nn/models/v2103/conv_points_in_out.py
@@ -2,6 +2,7 @@ r"""example of a graph convolution when the input and output nodes are different
 
 >>> test()
 """
+
 from typing import Optional
 
 import torch

--- a/e3nn/nn/models/v2103/gate_points_message_passing.py
+++ b/e3nn/nn/models/v2103/gate_points_message_passing.py
@@ -1,6 +1,7 @@
 """
 >>> test()
 """
+
 import torch
 from e3nn import o3
 from e3nn.nn import Gate

--- a/e3nn/nn/models/v2103/gate_points_networks.py
+++ b/e3nn/nn/models/v2103/gate_points_networks.py
@@ -2,6 +2,7 @@
 >>> test_simple_network()
 >>> test_network_for_a_graph_with_attributes()
 """
+
 from typing import Dict, Union
 
 import torch

--- a/e3nn/nn/models/v2103/voxel_convolution.py
+++ b/e3nn/nn/models/v2103/voxel_convolution.py
@@ -3,6 +3,7 @@ This is a tentative implementation of voxel convolution
 
 >>> test()
 """
+
 import torch
 
 from e3nn import o3

--- a/e3nn/nn/models/v2104/voxel_convolution.py
+++ b/e3nn/nn/models/v2104/voxel_convolution.py
@@ -3,6 +3,7 @@ This is an implementation of voxel convolution
 
 >>> test()
 """
+
 import math
 import torch
 

--- a/e3nn/nn/models/v2106/gate_points_message_passing.py
+++ b/e3nn/nn/models/v2106/gate_points_message_passing.py
@@ -1,6 +1,7 @@
 """
 >>> test()
 """
+
 import torch
 from e3nn import o3
 from e3nn.nn import Gate

--- a/e3nn/nn/models/v2106/gate_points_networks.py
+++ b/e3nn/nn/models/v2106/gate_points_networks.py
@@ -2,6 +2,7 @@
 >>> test_simple_network()
 >>> test_network_for_a_graph_with_attributes()
 """
+
 from typing import Dict
 
 import torch

--- a/e3nn/nn/models/v2106/points_convolution.py
+++ b/e3nn/nn/models/v2106/points_convolution.py
@@ -2,6 +2,7 @@
 Compare to v2103
 - replaced the angle trick by a factor alpha inspired by https://arxiv.org/pdf/2002.10444.pdf
 """
+
 import torch
 from e3nn import o3
 from e3nn.nn import FullyConnectedNet

--- a/e3nn/o3/_angular_spherical_harmonics.py
+++ b/e3nn/o3/_angular_spherical_harmonics.py
@@ -1,5 +1,5 @@
-r"""Spherical Harmonics as functions of Euler angles
-"""
+r"""Spherical Harmonics as functions of Euler angles"""
+
 import math
 from typing import List, Tuple
 

--- a/e3nn/o3/_reduce.py
+++ b/e3nn/o3/_reduce.py
@@ -129,6 +129,7 @@ class ReducedTensorProducts(CodeGenMixin, torch.nn.Module):
     >>> b = tp(x, y)
     >>> assert torch.allclose(a, b, atol=1e-3, rtol=1e-3)
     """
+
     # pylint: disable=abstract-method
 
     def __init__(self, formula, filter_ir_out=None, filter_ir_mid=None, eps: float = 1e-9, **irreps) -> None:

--- a/e3nn/o3/_s2grid.py
+++ b/e3nn/o3/_s2grid.py
@@ -28,6 +28,7 @@ The discrete representation is therefore
 
 .. math:: \{ h_{ij} = f(x_{ij}) \}_{ij}
 """
+
 import math
 
 import torch

--- a/e3nn/o3/_spherical_harmonics.py
+++ b/e3nn/o3/_spherical_harmonics.py
@@ -85,12 +85,11 @@ class SphericalHarmonics(torch.nn.Module):
                 f"spherical_harmonics maximum l implemented is {_lmax}, send us an email to ask for more"
             )
 
-        # TODO: Using this to turn off the torch.jit.script for torch.compile.
-        # Please remove this when torch.script is depracated
-        if get_optimization_defaults()["jit_script_fx"]:
+        if get_optimization_defaults()["jit_mode"] == "script":
             self.sph_func = torch.jit.script(_spherical_harmonics)
+        elif get_optimization_defaults()["jit_mode"] == "compile":
+            self.sph_func = torch.compile(_spherical_harmonics, fullgraph=True)
         else:
-            # Turn off for torch.compile
             self.sph_func = _spherical_harmonics
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/e3nn/o3/_wigner.py
+++ b/e3nn/o3/_wigner.py
@@ -1,5 +1,5 @@
-r"""Core functions of :math:`SO(3)`
-"""
+r"""Core functions of :math:`SO(3)`"""
+
 import functools
 import math
 from typing import Union

--- a/e3nn/o3/_wigner.py
+++ b/e3nn/o3/_wigner.py
@@ -25,7 +25,9 @@ def su2_generators(j: int) -> torch.Tensor:
         dim=0,
     )
 
-
+# Need to do a graph break since Dynamo 
+# cannot handle power of complex numbers and SymInt in L41
+@torch.compiler.disable
 def change_basis_real_to_complex(l: int, dtype=None, device=None) -> torch.Tensor:
     # https://en.wikipedia.org/wiki/Spherical_harmonics#Real_form
     q = torch.zeros((2 * l + 1, 2 * l + 1), dtype=torch.complex128)

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -78,7 +78,7 @@ class CodeGenMixin:
                 smod = getattr(self, fname)
                 buffer_type: str
                 buffer: bytes
-                if isinstance(smod, fx.GraphModule):
+                if isinstance(smod, (fx.GraphModule, torch._dynamo.OptimizedModule)):
                     buffer_type = "fx"
                     # pickle the fx.GraphModule normally
                     buffer = pickle.dumps(smod)
@@ -121,7 +121,7 @@ class CodeGenMixin:
                 assert isinstance(buffer, bytes)
                 if buffer_type == "fx":
                     smod = pickle.loads(buffer)
-                    assert isinstance(smod, fx.GraphModule)
+                    assert isinstance(smod, (fx.GraphModule, torch._dynamo.OptimizedModule))
                 elif buffer_type == "torchscript":
                     # Load the TorchScript IR buffer
                     buffer = io.BytesIO(buffer)

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -44,8 +44,6 @@ class CodeGenMixin:
                 # torch.jit.script(jitable(graphmod))
                 scriptmod = e3nn.util.jit.compile(graphmod, recurse=False)
                 assert isinstance(scriptmod, torch.jit.ScriptModule)
-            elif opt_defaults["jit_mode"] == "compile":
-                scriptmod = torch.compile(graphmod, fullgraph=True)
             else:
                 scriptmod = graphmod
 

--- a/e3nn/util/codegen/_mixin.py
+++ b/e3nn/util/codegen/_mixin.py
@@ -39,11 +39,13 @@ class CodeGenMixin:
         for fname, graphmod in funcs.items():
             assert isinstance(graphmod, fx.GraphModule)
 
-            if opt_defaults["jit_script_fx"]:
+            if opt_defaults["jit_mode"] == "script":
                 # With recurse=False, this more or less is equivalent to
                 # torch.jit.script(jitable(graphmod))
                 scriptmod = e3nn.util.jit.compile(graphmod, recurse=False)
                 assert isinstance(scriptmod, torch.jit.ScriptModule)
+            elif opt_defaults["jit_mode"] == "compile":
+                scriptmod = torch.compile(graphmod, fullgraph=True)
             else:
                 scriptmod = graphmod
 

--- a/e3nn/util/jit.py
+++ b/e3nn/util/jit.py
@@ -4,19 +4,11 @@ import warnings
 import re
 from typing import Optional, Callable, Tuple
 from contextlib import contextmanager
-from functools import wraps
 
-# Borrowed from https://github.com/ACEsuit/mace/blob/126f490a56020c40940f8c7dbabbb23eb58e17a1/mace/tools/compile.py#L56
-
-try:
-    import torch._dynamo as dynamo
-except ImportError:
-    dynamo = None
 from e3nn import get_optimization_defaults, set_optimization_defaults
 import torch
-from torch import autograd, nn
+from torch import nn
 from torch import fx
-from torch.fx import symbolic_trace
 from opt_einsum_fx import jitable
 
 ModuleFactory = Callable[..., nn.Module]
@@ -332,75 +324,3 @@ def disable_e3nn_codegen():
     set_optimization_defaults(jit_script_fx=False)
     yield
     set_optimization_defaults(jit_script_fx=init_val)
-
-
-def prepare(func: ModuleFactory, allow_autograd: bool = True) -> ModuleFactory:
-    """Function transform that prepares a e3nn module for torch.compile
-
-    Args:
-        func (ModuleFactory): A function that creates an nn.Module
-        allow_autograd (bool, optional): Force inductor compiler to inline call to
-            `torch.autograd.grad`. Defaults to True.
-
-    Returns:
-        ModuleFactory: Decorated function that creates a torch.compile compatible module
-    """
-    if allow_autograd:
-        dynamo.allow_in_graph(autograd.grad)
-    elif dynamo.allowed_functions.is_allowed(autograd.grad):
-        dynamo.disallow_in_graph(autograd.grad)
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        with disable_e3nn_codegen():
-            model = func(*args, **kwargs)
-
-        model = simplify(model)
-        return model
-
-    return wrapper
-
-
-_SIMPLIFY_REGISTRY = set()
-
-
-def simplify_if_compile(module: nn.Module) -> nn.Module:
-    """Decorator to register a module for symbolic simplification
-
-    The decorated module will be simplifed using `torch.fx.symbolic_trace`.
-    This constrains the module to not have any dynamic control flow, see:
-
-    https://pytorch.org/docs/stable/fx.html#limitations-of-symbolic-tracing
-
-    Args:
-        module (nn.Module): the module to register
-
-    Returns:
-        nn.Module: registered module
-    """
-    _SIMPLIFY_REGISTRY.add(module)
-    return module
-
-
-def simplify(module: nn.Module) -> nn.Module:
-    """Recursively searches for registered modules to simplify with
-    `torch.fx.symbolic_trace` to support compiling with the PyTorch Dynamo compiler.
-
-    Modules are registered with the `simplify_if_compile` decorator and
-
-    Args:
-        module (nn.Module): the module to simplify
-
-    Returns:
-        nn.Module: the simplified module
-    """
-    simplify_types = tuple(_SIMPLIFY_REGISTRY)
-
-    for name, child in module.named_children():
-        if isinstance(child, simplify_types):
-            traced = symbolic_trace(child)
-            setattr(module, name, traced)
-        else:
-            simplify(child)
-
-    return module

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -10,7 +10,14 @@ import numpy as np
 import torch
 
 from e3nn import o3
-from e3nn.util.jit import compile, get_tracing_inputs, get_compile_mode, _MAKE_TRACING_INPUTS, get_optimization_defaults, set_optimization_defaults
+from e3nn.util.jit import (
+    compile,
+    get_tracing_inputs,
+    get_compile_mode,
+    _MAKE_TRACING_INPUTS,
+    get_optimization_defaults,
+    set_optimization_defaults,
+)
 from ._argtools import _get_args_in, _get_io_irreps, _transform, _rand_args
 
 # pylint: disable=unused-variable
@@ -374,6 +381,7 @@ def assert_auto_jitable(
 
     return func_jit
 
+
 def assert_torch_compile(
     compile_mode: str,
     func: Callable,
@@ -381,7 +389,7 @@ def assert_torch_compile(
     **kwargs,
 ) -> None:
     r"""Assert that func is torch.compile(fullgraph=True)
-    
+
     Parameters
     ----------
         func: Callable thats a functools.partial(torch.nn.Module)
@@ -393,12 +401,13 @@ def assert_torch_compile(
     try:
         set_optimization_defaults(jit_mode=compile_mode)
         m = func()
-        torch._dynamo.reset() # Clear cache from previous runs
+        torch._dynamo.reset()  # Clear cache from previous runs
         m_pt2 = torch.compile(m, fullgraph=True)
-        m_pt2(*args , **kwargs)
+        m_pt2(*args, **kwargs)
     finally:
         set_optimization_defaults(jit_mode=jit_mode_before)
     return m_pt2
+
 
 # TODO: custom in_vars, out_vars support
 def assert_normalized(

--- a/e3nn/util/test.py
+++ b/e3nn/util/test.py
@@ -3,14 +3,14 @@ import math
 import inspect
 import itertools
 import logging
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Callable
 import warnings
 
 import numpy as np
 import torch
 
 from e3nn import o3
-from e3nn.util.jit import compile, get_tracing_inputs, get_compile_mode, _MAKE_TRACING_INPUTS
+from e3nn.util.jit import compile, get_tracing_inputs, get_compile_mode, _MAKE_TRACING_INPUTS, get_optimization_defaults, set_optimization_defaults
 from ._argtools import _get_args_in, _get_io_irreps, _transform, _rand_args
 
 # pylint: disable=unused-variable
@@ -374,6 +374,31 @@ def assert_auto_jitable(
 
     return func_jit
 
+def assert_torch_compile(
+    compile_mode: str,
+    func: Callable,
+    *args,
+    **kwargs,
+) -> None:
+    r"""Assert that func is torch.compile(fullgraph=True)
+    
+    Parameters
+    ----------
+        func: Callable thats a functools.partial(torch.nn.Module)
+        *args: func's forward arguments
+        **kwargs: func's forward positional arguments
+    """
+    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
+    jit_mode_before = get_optimization_defaults()["jit_mode"]
+    try:
+        set_optimization_defaults(jit_mode=compile_mode)
+        m = func()
+        torch._dynamo.reset() # Clear cache from previous runs
+        m_pt2 = torch.compile(m, fullgraph=True)
+        m_pt2(*args , **kwargs)
+    finally:
+        set_optimization_defaults(jit_mode=jit_mode_before)
+    return m_pt2
 
 # TODO: custom in_vars, out_vars support
 def assert_normalized(

--- a/examples/atom_types.py
+++ b/examples/atom_types.py
@@ -9,6 +9,7 @@ we have num_z^2 times the spherical harmonics, all zero except for the type of t
 
 >>> test()
 """
+
 import torch
 from torch_cluster import radius_graph
 from torch_geometric.data import Data, DataLoader

--- a/examples/tetris.py
+++ b/examples/tetris.py
@@ -5,6 +5,7 @@ Exact equivariance to :math:`E(3)`
 
 >>> test()
 """
+
 import torch
 from torch_geometric.data import Data, DataLoader
 

--- a/examples/tetris_gate.py
+++ b/examples/tetris_gate.py
@@ -5,6 +5,7 @@ Exact equivariance to :math:`E(3)`
 
 >>> test()
 """
+
 import logging
 
 import torch

--- a/examples/tetris_polynomial.py
+++ b/examples/tetris_polynomial.py
@@ -10,6 +10,7 @@ This example is minimal:
 
 >>> test()
 """
+
 import logging
 
 import torch

--- a/tests/math/soft_one_hot_test.py
+++ b/tests/math/soft_one_hot_test.py
@@ -25,7 +25,6 @@ def test_with_compile(basis) -> None:
     assert torch.allclose(y, y_compiled, atol=1e-7)
 
 
-
 @pytest.mark.parametrize("basis", ["gaussian", "cosine", "fourier", "bessel", "smooth_finite"])
 def test_zero_out(basis) -> None:
     x1 = torch.linspace(-2.0, -1.1, 20)

--- a/tests/nn/activation_test.py
+++ b/tests/nn/activation_test.py
@@ -5,7 +5,6 @@ import torch
 from e3nn import o3
 from e3nn.nn import Activation
 from e3nn.util.test import assert_equivariant, assert_auto_jitable, assert_normalized
-from e3nn.util.jit import prepare
 
 
 @pytest.mark.parametrize(
@@ -15,24 +14,22 @@ from e3nn.util.jit import prepare
 def test_activation(irreps_in, acts) -> None:
     irreps_in = o3.Irreps(irreps_in)
 
-    def build_module(irreps_in, acts):
-        return Activation(irreps_in, acts)
+    a = Activation(irreps_in, acts)
+    inp = irreps_in.randn(13, -1)
 
-    a = build_module(irreps_in, acts)
-    a_pt2 = prepare(build_module)(irreps_in, acts)
+    a_pt2 = torch.compile(a, fullgraph=True)
+    out_pt2 = a_pt2(inp)
     assert_auto_jitable(a)
     assert_equivariant(a)
 
-    inp = irreps_in.randn(13, -1)
     out = a(inp)
-    out_pt2 = a_pt2(inp)
+
+    torch.testing.assert_close(out, out_pt2)
+
     for ir_slice, act in zip(irreps_in.slices(), acts):
         this_out = out[:, ir_slice]
-        this_out2 = out_pt2[:, ir_slice]
         true_up_to_factor = act(inp[:, ir_slice])
         factors = this_out / true_up_to_factor
-        factor_pt2 = this_out2 / true_up_to_factor
         assert torch.allclose(factors, factors[0])
-        assert torch.allclose(factor_pt2, factors[0])
 
     assert_normalized(a)

--- a/tests/nn/activation_test.py
+++ b/tests/nn/activation_test.py
@@ -17,12 +17,15 @@ def test_activation(irreps_in, acts) -> None:
     a = Activation(irreps_in, acts)
     inp = irreps_in.randn(13, -1)
 
-    a_pt2 = torch.compile(a, fullgraph=True)
-    out_pt2 = a_pt2(inp)
     assert_auto_jitable(a)
     assert_equivariant(a)
 
     out = a(inp)
+
+    a_pt2 = torch.compile(a, fullgraph=True)
+    out_pt2 = a_pt2(inp)
+
+    print(a_pt2)
 
     torch.testing.assert_close(out, out_pt2)
 

--- a/tests/nn/activation_test.py
+++ b/tests/nn/activation_test.py
@@ -19,10 +19,8 @@ def test_activation(irreps_in, acts) -> None:
     inp = irreps_in.randn(13, -1)
 
     assert_auto_jitable(a)
-    assert_torch_compile('inductor',
-                        functools.partial(Activation, irreps_in, acts),
-                        inp)
-    
+    assert_torch_compile("inductor", functools.partial(Activation, irreps_in, acts), inp)
+
     assert_equivariant(a)
 
     out = a(inp)

--- a/tests/nn/dropout_test.py
+++ b/tests/nn/dropout_test.py
@@ -1,5 +1,4 @@
 import copy
-import functools
 
 import torch
 

--- a/tests/nn/dropout_test.py
+++ b/tests/nn/dropout_test.py
@@ -4,15 +4,12 @@ import torch
 
 from e3nn.nn import Dropout
 from e3nn.util.test import assert_auto_jitable, assert_equivariant
-from e3nn.util.jit import prepare
 
 
 def test_dropout() -> None:
-    def build_module():
-        return Dropout(irreps="10x1e + 10x0e", p=0.75)
 
-    c = build_module()
-    c_pt2 = torch.compile(prepare(build_module)(), fullgraph=True)
+    c = Dropout(irreps="10x1e + 10x0e", p=0.75)
+    c_pt2 = torch.compile(c, fullgraph=True)
     x = c.irreps.randn(5, 2, -1)
 
     for c in [c, c_pt2, assert_auto_jitable(c)]:

--- a/tests/nn/dropout_test.py
+++ b/tests/nn/dropout_test.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 
 import torch
 
@@ -9,10 +10,9 @@ from e3nn.util.test import assert_auto_jitable, assert_equivariant
 def test_dropout() -> None:
 
     c = Dropout(irreps="10x1e + 10x0e", p=0.75)
-    c_pt2 = torch.compile(c, fullgraph=True)
     x = c.irreps.randn(5, 2, -1)
 
-    for c in [c, c_pt2, assert_auto_jitable(c)]:
+    for c in [c, assert_auto_jitable(c)]:
         c.eval()
         assert c(x).eq(x).all()
 

--- a/tests/nn/extract_test.py
+++ b/tests/nn/extract_test.py
@@ -6,15 +6,12 @@ import torch
 
 from e3nn.nn import Extract, ExtractIr
 from e3nn.util.test import assert_auto_jitable, assert_equivariant
-from e3nn.util.jit import prepare
 
 
 def test_extract() -> None:
-    def build_module():
-        return Extract("1e + 0e + 0e", ["0e", "0e"], [(1,), (2,)])
 
-    c = build_module()
-    c_pt2 = torch.compile(prepare(build_module)(), fullgraph=True)
+    c = Extract("1e + 0e + 0e", ["0e", "0e"], [(1,), (2,)])
+    c_pt2 = torch.compile(c, fullgraph=True)
     out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     assert out == (torch.Tensor([1.0]), torch.Tensor([2.0]))
@@ -25,11 +22,9 @@ def test_extract() -> None:
 
 @pytest.mark.parametrize("squeeze", [True, False])
 def test_extract_single(squeeze) -> None:
-    def build_module():
-        return Extract("1e + 0e + 0e", ["0e"], [(1,)], squeeze_out=squeeze)
 
-    c = build_module()
-    c_pt2 = torch.compile(prepare(build_module)(), fullgraph=True)
+    c = Extract("1e + 0e + 0e", ["0e"], [(1,)], squeeze_out=squeeze)
+    c_pt2 = torch.compile(c, fullgraph=True)
     out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     if squeeze:
@@ -46,11 +41,9 @@ def test_extract_single(squeeze) -> None:
 
 
 def test_extract_ir() -> None:
-    def build_module():
-        return ExtractIr("1e + 0e + 0e", "0e")
 
-    c = build_module()
-    c_pt2 = torch.compile(prepare(build_module)(), fullgraph=True)
+    c = ExtractIr("1e + 0e + 0e", "0e")
+    c_pt2 = torch.compile(c, fullgraph=True)
     out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     assert torch.all(out == torch.Tensor([1.0, 2.0]))

--- a/tests/nn/extract_test.py
+++ b/tests/nn/extract_test.py
@@ -6,50 +6,78 @@ import torch
 
 from e3nn.nn import Extract, ExtractIr
 from e3nn.util.test import assert_auto_jitable, assert_equivariant
+from e3nn.util.jit import get_optimization_defaults, set_optimization_defaults
 
 
 def test_extract() -> None:
 
     c = Extract("1e + 0e + 0e", ["0e", "0e"], [(1,), (2,)])
-    c_pt2 = torch.compile(c, fullgraph=True)
     out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
-    out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     assert out == (torch.Tensor([1.0]), torch.Tensor([2.0]))
-    assert out == out_pt2
     assert_auto_jitable(c)
     assert_equivariant(c, irreps_out=list(c.irreps_outs))
+
+    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
+    jit_mode_before = get_optimization_defaults()["jit_mode"]
+    try:
+        set_optimization_defaults(jit_mode="inductor")
+        c_new = Extract("1e + 0e + 0e", ["0e", "0e"], [(1,), (2,)])
+        c_pt2 = torch.compile(c_new, fullgraph=True)
+        out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
+        assert out == out_pt2
+    finally:
+        set_optimization_defaults(jit_mode=jit_mode_before)
 
 
 @pytest.mark.parametrize("squeeze", [True, False])
 def test_extract_single(squeeze) -> None:
 
     c = Extract("1e + 0e + 0e", ["0e"], [(1,)], squeeze_out=squeeze)
-    c_pt2 = torch.compile(c, fullgraph=True)
     out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
-    out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     if squeeze:
         assert isinstance(out, torch.Tensor)
     else:
         assert len(out) == 1
         out = out[0]
-        assert len(out_pt2) == 1
-        out_pt2 = out_pt2[0]
     assert out == torch.Tensor([1.0])
-    assert out_pt2 == torch.Tensor([1.0])
+
     assert_auto_jitable(c)
     assert_equivariant(c, irreps_out=list(c.irreps_outs))
 
+    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
+    jit_mode_before = get_optimization_defaults()["jit_mode"]
+    try:
+        set_optimization_defaults(jit_mode="inductor")
+        c_new = Extract("1e + 0e + 0e", ["0e"], [(1,)], squeeze_out=squeeze)
+        c_pt2 = torch.compile(c_new, fullgraph=True)
+        out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
+        if squeeze:
+            assert isinstance(out_pt2, torch.Tensor)
+        else:
+            assert len(out_pt2) == 1
+            out_pt2 = out_pt2[0]
+        assert out_pt2 == torch.Tensor([1.0])
+    finally:
+        set_optimization_defaults(jit_mode=jit_mode_before)
 
 def test_extract_ir() -> None:
 
     c = ExtractIr("1e + 0e + 0e", "0e")
-    c_pt2 = torch.compile(c, fullgraph=True)
     out = c(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
-    out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
     assert torch.all(out == torch.Tensor([1.0, 2.0]))
-    assert torch.all(out_pt2 == out)
     assert_auto_jitable(c)
     assert_equivariant(c)
+
+    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
+    jit_mode_before = get_optimization_defaults()["jit_mode"]
+    try:
+        set_optimization_defaults(jit_mode="inductor")
+        c_new = ExtractIr("1e + 0e + 0e", "0e")
+        c_pt2 = torch.compile(c_new, fullgraph=True)
+        out_pt2 = c_pt2(torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]))
+        assert torch.all(out_pt2 == out)
+    finally:
+        set_optimization_defaults(jit_mode=jit_mode_before)
 
 
 def test_copy() -> None:

--- a/tests/nn/extract_test.py
+++ b/tests/nn/extract_test.py
@@ -8,6 +8,7 @@ import torch
 from e3nn.nn import Extract, ExtractIr
 from e3nn.util.test import assert_auto_jitable, assert_equivariant, assert_torch_compile
 
+
 def test_extract() -> None:
 
     c = Extract("1e + 0e + 0e", ["0e", "0e"], [(1,), (2,)])
@@ -15,12 +16,12 @@ def test_extract() -> None:
     assert out == (torch.Tensor([1.0]), torch.Tensor([2.0]))
     assert_auto_jitable(c)
     assert_torch_compile(
-        'inductor',
+        "inductor",
         functools.partial(Extract, "1e + 0e + 0e", ["0e", "0e"], [(1,), (2,)]),
-        torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0])
-        
+        torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]),
     )
     assert_equivariant(c, irreps_out=list(c.irreps_outs))
+
 
 @pytest.mark.parametrize("squeeze", [True, False])
 def test_extract_single(squeeze) -> None:
@@ -36,11 +37,12 @@ def test_extract_single(squeeze) -> None:
 
     assert_auto_jitable(c)
     assert_torch_compile(
-        'inductor',
+        "inductor",
         functools.partial(Extract, "1e + 0e + 0e", ["0e"], [(1,)], squeeze_out=squeeze),
-        torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0])
+        torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0]),
     )
     assert_equivariant(c, irreps_out=list(c.irreps_outs))
+
 
 def test_extract_ir() -> None:
 
@@ -49,11 +51,10 @@ def test_extract_ir() -> None:
     assert torch.all(out == torch.Tensor([1.0, 2.0]))
     assert_auto_jitable(c)
     assert_torch_compile(
-        'inductor',
-        functools.partial(ExtractIr, "1e + 0e + 0e", "0e"),
-        torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0])
+        "inductor", functools.partial(ExtractIr, "1e + 0e + 0e", "0e"), torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0])
     )
     assert_equivariant(c)
+
 
 def test_copy() -> None:
     c = Extract("1e + 0e + 0e", ["0e", "0e"], [(1,), (2,)])

--- a/tests/nn/fc_test.py
+++ b/tests/nn/fc_test.py
@@ -13,9 +13,6 @@ def test_variance(act, var_in, var_out, out_act) -> None:
     f = FullyConnectedNet(hs, act, var_in, var_out, out_act)
     x = torch.randn(2000, hs[0]) * var_in**0.5
 
-    f_pt2 = torch.compile(f, fullgraph=True)
-    f_pt2(x)
-
     y = f(x) / var_out**0.5
 
     if not out_act:
@@ -25,6 +22,9 @@ def test_variance(act, var_in, var_out, out_act) -> None:
     f = assert_auto_jitable(f)
     f(x)
 
+    f_new = FullyConnectedNet(hs, act, var_in, var_out, out_act)
+    f_pt2 = torch.compile(f_new, fullgraph=True)
+    f_pt2(x)
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
 def test_data_parallel() -> None:

--- a/tests/nn/fc_test.py
+++ b/tests/nn/fc_test.py
@@ -24,12 +24,9 @@ def test_variance(act, var_in, var_out, out_act) -> None:
     f = assert_auto_jitable(f)
     f(x)
 
-    f_pt2 = assert_torch_compile(
-        'inductor',
-        functools.partial(FullyConnectedNet, hs, act, var_in, var_out, out_act),
-        x
-    )
+    f_pt2 = assert_torch_compile("inductor", functools.partial(FullyConnectedNet, hs, act, var_in, var_out, out_act), x)
     f_pt2(x)
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
 def test_data_parallel() -> None:

--- a/tests/nn/gate_test.py
+++ b/tests/nn/gate_test.py
@@ -26,10 +26,8 @@ def test_gate() -> None:
     assert_equivariant(g)
     assert_auto_jitable(g)
     assert_torch_compile(
-        'inductor',
+        "inductor",
         functools.partial(Gate, irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated),
-        irreps.randn(-1)
-        
+        irreps.randn(-1),
     )
     assert_normalized(g)
-

--- a/tests/nn/gate_test.py
+++ b/tests/nn/gate_test.py
@@ -4,6 +4,7 @@ from e3nn.o3 import Irreps
 from e3nn.nn import Gate
 from e3nn.nn._gate import _Sortcut
 from e3nn.util.test import assert_equivariant, assert_auto_jitable, assert_normalized
+from e3nn.util.jit import get_optimization_defaults, set_optimization_defaults
 
 
 def test_gate() -> None:
@@ -20,10 +21,17 @@ def test_gate() -> None:
 
     g = Gate(irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated)
 
-    g_pt2 = torch.compile(g, fullgraph=True)
-    test_irreps = Irreps("16x0o+32x0o+16x1e+16x1o")
-    g_pt2(test_irreps.randn(-1))
-
     assert_equivariant(g)
     assert_auto_jitable(g)
     assert_normalized(g)
+
+    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
+    jit_mode_before = get_optimization_defaults()["jit_mode"]
+    try:
+        set_optimization_defaults(jit_mode="inductor")
+        g = Gate(irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated)
+        g_pt2 = torch.compile(g, fullgraph=True)
+        test_irreps = Irreps("16x0o+32x0o+16x1e+16x1o")
+        g_pt2(test_irreps.randn(-1))
+    finally:
+        set_optimization_defaults(jit_mode=jit_mode_before)

--- a/tests/nn/gate_test.py
+++ b/tests/nn/gate_test.py
@@ -4,7 +4,6 @@ from e3nn.o3 import Irreps
 from e3nn.nn import Gate
 from e3nn.nn._gate import _Sortcut
 from e3nn.util.test import assert_equivariant, assert_auto_jitable, assert_normalized
-from e3nn.util.jit import prepare
 
 
 def test_gate() -> None:
@@ -19,16 +18,12 @@ def test_gate() -> None:
     sc = _Sortcut(irreps_scalars, irreps_gates)
     assert_auto_jitable(sc)
 
-    def build_module(irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated):
-        return Gate(irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated)
+    g = Gate(irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated)
 
-    g = build_module(irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated)
+    g_pt2 = torch.compile(g, fullgraph=True)
+    test_irreps = Irreps("16x0o+32x0o+16x1e+16x1o")
+    g_pt2(test_irreps.randn(-1))
+
     assert_equivariant(g)
     assert_auto_jitable(g)
     assert_normalized(g)
-
-    g_pt2 = torch.compile(
-        prepare(build_module)(irreps_scalars, act_scalars, irreps_gates, act_gates, irreps_gated), fullgraph=True
-    )
-    test_irreps = Irreps("16x0o+32x0o+16x1e+16x1o")
-    g_pt2(test_irreps.randn(-1))

--- a/tests/nn/models/gate_points_2101_test.py
+++ b/tests/nn/models/gate_points_2101_test.py
@@ -72,11 +72,11 @@ def test_save(network) -> None:
     # Get a saved, loaded network
     with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
         torch.save(f, tmp.name)
-        f2 = torch.load(tmp.name)
+        f2 = torch.load(tmp.name, weights_only=False)
     x = random_graph()
     assert torch.all(f(x) == f2(x))
     # Get a double-saved network
     with tempfile.NamedTemporaryFile(suffix=".pth") as tmp:
         torch.save(f2, tmp.name)
-        f3 = torch.load(tmp.name)
+        f3 = torch.load(tmp.name, weights_only=False)
     assert torch.all(f(x) == f3(x))

--- a/tests/nn/normact_test.py
+++ b/tests/nn/normact_test.py
@@ -5,7 +5,6 @@ import torch
 import e3nn
 from e3nn.nn import NormActivation
 from e3nn.util.test import assert_equivariant, assert_auto_jitable
-from e3nn.util.jit import prepare
 
 
 @pytest.mark.parametrize("do_bias", [True, False])
@@ -77,11 +76,8 @@ def test_norm_activation_equivariant(do_bias, nonlin) -> None:
         "2x0e + 3x0o + 5x1o + 1x1e + 2x2e + 1x2o + 1x3e + 1x3o + 1x5e + 1x6o"
     )
 
-    def build_module(irreps_in, nonlin, do_bias):
-        return NormActivation(irreps_in=irreps_in, scalar_nonlinearity=nonlin, bias=do_bias)
-
-    norm_act = build_module(irreps_in, nonlin, do_bias)
-    norm_act2 = torch.compile(prepare(build_module)(irreps_in, nonlin, do_bias), fullgraph=True)
+    norm_act = NormActivation(irreps_in=irreps_in, scalar_nonlinearity=nonlin, bias=do_bias)
+    norm_act2 = torch.compile(norm_act, fullgraph=True)
 
     if do_bias:
         # Set up some nonzero biases
@@ -89,9 +85,9 @@ def test_norm_activation_equivariant(do_bias, nonlin) -> None:
         with torch.no_grad():
             norm_act.biases[:] = torch.randn(norm_act.biases.shape)
 
+    norm_act2(irreps_in.randn(-1))
     assert_equivariant(norm_act)
     assert_auto_jitable(norm_act)
-    norm_act2(irreps_in.randn(-1))
 
 
 @pytest.mark.parametrize("do_bias", [True, False])

--- a/tests/nn/normact_test.py
+++ b/tests/nn/normact_test.py
@@ -88,9 +88,9 @@ def test_norm_activation_equivariant(do_bias, nonlin) -> None:
 
     assert_equivariant(norm_act)
     assert_torch_compile(
-        'inductor',
+        "inductor",
         functools.partial(NormActivation, irreps_in=irreps_in, scalar_nonlinearity=nonlin, bias=do_bias),
-        irreps_in.randn(-1)
+        irreps_in.randn(-1),
     )
     assert_auto_jitable(norm_act)
 

--- a/tests/nn/s2act_test.py
+++ b/tests/nn/s2act_test.py
@@ -14,6 +14,7 @@ from e3nn.util.test import assert_equivariant
 def test_equivariance(float_tolerance, act, normalization, p_val, p_arg) -> None:
     irreps = io.SphericalTensor(3, p_val, p_arg)
 
+    # TODO: torch.compile(fullgraph=True) not working
     m = S2Activation(irreps, act, 120, normalization=normalization, lmax_out=6, random_rot=True)
 
     assert_equivariant(m, ntrials=10, tolerance=torch.sqrt(float_tolerance))

--- a/tests/nn/so3act_test.py
+++ b/tests/nn/so3act_test.py
@@ -13,6 +13,7 @@ def so3_irreps(lmax: int) -> o3.Irreps:
 @pytest.mark.parametrize("lmax", [1, 2, 3, 4])
 @pytest.mark.parametrize("act", [torch.tanh, lambda x: x**2])
 def test_equivariance(act, lmax: int) -> None:
+    # TODO: torch.compile(fullgraph=True) not working
     m = SO3Activation(lmax, lmax, act, 6)
 
     assert_equivariant(m, ntrials=10, tolerance=0.04, irreps_in=so3_irreps(lmax), irreps_out=so3_irreps(lmax))

--- a/tests/nn/so3act_test.py
+++ b/tests/nn/so3act_test.py
@@ -13,6 +13,7 @@ def so3_irreps(lmax: int) -> o3.Irreps:
 @pytest.mark.parametrize("lmax", [1, 2, 3, 4])
 @pytest.mark.parametrize("act", [torch.tanh, lambda x: x**2])
 def test_equivariance(act, lmax: int) -> None:
+
     # TODO: torch.compile(fullgraph=True) not working
     m = SO3Activation(lmax, lmax, act, 6)
 

--- a/tests/nn/so3act_test.py
+++ b/tests/nn/so3act_test.py
@@ -3,7 +3,7 @@ import torch
 from e3nn import o3
 from e3nn.nn import SO3Activation
 from e3nn.util.test import assert_equivariant
-from e3nn.util.jit import compile, prepare
+from e3nn.util.jit import compile
 
 
 def so3_irreps(lmax: int) -> o3.Irreps:
@@ -22,16 +22,13 @@ def test_equivariance(act, lmax: int) -> None:
 def test_identity(aspect_ratio) -> None:
     irreps = o3.Irreps([(2 * l + 1, (l, 1)) for l in range(5 + 1)])
 
-    def build_module():
-        return SO3Activation(5, 5, lambda x: x, 6, aspect_ratio=aspect_ratio)
-
-    m = build_module()
+    m = SO3Activation(5, 5, lambda x: x, 6, aspect_ratio=aspect_ratio)
     m = compile(m)
-
-    m_pt2 = torch.compile(prepare(build_module)(), fullgraph=True)
 
     x = irreps.randn(-1)
     y = m(x)
+
+    m_pt2 = torch.compile(m, fullgraph=True)
     y2 = m_pt2(x)
 
     torch.allclose(y, y2)

--- a/tests/o3/angular_spherical_harmonics_test.py
+++ b/tests/o3/angular_spherical_harmonics_test.py
@@ -5,22 +5,22 @@ import torch
 from e3nn import o3
 
 from e3nn.util.test import assert_auto_jitable
-from e3nn.util.jit import prepare
 
 
 def test_jit(float_tolerance) -> None:
-    def build_module():
-        return o3.SphericalHarmonicsAlphaBeta([0, 1, 2])
 
-    sh = build_module()
-    jited = assert_auto_jitable(sh)
+    sh = o3.SphericalHarmonicsAlphaBeta([0, 1, 2])
 
     a = torch.randn(5, 4)
     b = torch.randn(5, 4)
-    assert (sh(a, b) - jited(a, b)).abs().max() < float_tolerance
 
-    m_pt2 = torch.compile(prepare(build_module)(), fullgraph=True)
+    torch._dynamo.reset()  # Clear cache from the previous run
+    m_pt2 = torch.compile(sh, fullgraph=True)
     assert (sh(a, b) - m_pt2(a, b)).abs().max() < float_tolerance
+
+    jited = assert_auto_jitable(sh)
+
+    assert (sh(a, b) - jited(a, b)).abs().max() < float_tolerance
 
 
 def test_sh_equivariance1(float_tolerance) -> None:

--- a/tests/o3/angular_spherical_harmonics_test.py
+++ b/tests/o3/angular_spherical_harmonics_test.py
@@ -7,22 +7,19 @@ from e3nn import o3
 
 from e3nn.util.test import assert_auto_jitable, assert_torch_compile
 
+
 def test_jit(float_tolerance) -> None:
     sh = o3.SphericalHarmonicsAlphaBeta([0, 1, 2])
 
     a = torch.randn(5, 4)
     b = torch.randn(5, 4)
 
-
     jited = assert_auto_jitable(sh)
     assert (sh(a, b) - jited(a, b)).abs().max() < float_tolerance
 
-    pt2 = assert_torch_compile(
-        'inductor',
-        functools.partial(o3.SphericalHarmonicsAlphaBeta, [0, 1, 2]),
-        a,b
-    )
+    pt2 = assert_torch_compile("inductor", functools.partial(o3.SphericalHarmonicsAlphaBeta, [0, 1, 2]), a, b)
     assert (sh(a, b) - pt2(a, b)).abs().max() < float_tolerance
+
 
 def test_sh_equivariance1(float_tolerance) -> None:
     r"""test

--- a/tests/o3/angular_spherical_harmonics_test.py
+++ b/tests/o3/angular_spherical_harmonics_test.py
@@ -8,7 +8,7 @@ from e3nn.util.test import assert_auto_jitable
 
 
 def test_jit(float_tolerance) -> None:
-
+    import e3nn
     sh = o3.SphericalHarmonicsAlphaBeta([0, 1, 2])
 
     a = torch.randn(5, 4)

--- a/tests/o3/cartesian_spherical_harmonics_test.py
+++ b/tests/o3/cartesian_spherical_harmonics_test.py
@@ -5,9 +5,7 @@ import pytest
 import torch
 
 from e3nn import o3
-from e3nn import set_optimization_defaults, get_optimization_defaults
 from e3nn.util.test import assert_auto_jitable, assert_equivariant
-from e3nn.util.jit import prepare
 
 
 def test_weird_call() -> None:
@@ -150,43 +148,21 @@ def test_recurrence_relation(float_tolerance, l) -> None:
 def test_module(normalization, normalize) -> None:
     l = o3.Irreps("0e + 1o + 3o")
 
-    def build_module(l, normalize, normalization):
-        return o3.SphericalHarmonics(l, normalize, normalization)
-
-    sp = build_module(l, normalize, normalization)
-    sp_jit = assert_auto_jitable(sp)
+    sp = o3.SphericalHarmonics(l, normalize, normalization)
     xyz = torch.randn(11, 3)
-    assert torch.allclose(sp_jit(xyz), o3.spherical_harmonics(l, xyz, normalize, normalization))
-    assert_equivariant(sp)
-    sp_pt2 = torch.compile(prepare(build_module)(l, normalize, normalization), fullgraph=True)
+
+    torch._dynamo.reset()  # Clear cache from the previous run
+    sp_pt2 = torch.compile(sp, fullgraph=True)
     assert torch.allclose(sp_pt2(xyz), sp(xyz))
 
-
-def test_internal_jit_flag():
-    l = o3.Irreps("0e + 1o + 3o")
-    sp = o3.SphericalHarmonics(l, normalization="integral", normalize=True)
-    # Turning off the JIT in _spherical_harmonics to enable torch.compile.
-    # Note that this is a less invasive way then turning off jit_script_fx globally
-    jit_script_fx_before = get_optimization_defaults()["jit_script_fx"]
-    # TODO: Have a more general purpose context manager
-    try:
-        set_optimization_defaults(jit_script_fx=False)
-        sp_pt2 = torch.compile(o3.SphericalHarmonics(l, normalization="integral", normalize=True), fullgraph=True)
-
-        xyz = torch.randn(11, 3)
-        torch.testing.assert_close(sp(xyz), sp_pt2(xyz))
-    finally:
-        set_optimization_defaults(jit_script_fx=jit_script_fx_before)
+    sp_jit = assert_auto_jitable(sp)
+    assert torch.allclose(sp_jit(xyz), o3.spherical_harmonics(l, xyz, normalize, normalization))
+    assert_equivariant(sp)
 
 
 @pytest.mark.parametrize("jit_script_fx", [False])
 def test_pickle(jit_script_fx):
     l = o3.Irreps("0e + 1o + 3o")
-    jit_script_fx_before = get_optimization_defaults()["jit_script_fx"]
-    try:
-        set_optimization_defaults(jit_script_fx=jit_script_fx)
-        sp = o3.SphericalHarmonics(l, normalization="integral", normalize=True)
-        buffer = io.BytesIO()
-        torch.save(sp, buffer)
-    finally:
-        set_optimization_defaults(jit_script_fx=jit_script_fx_before)
+    sp = o3.SphericalHarmonics(l, normalization="integral", normalize=True)
+    buffer = io.BytesIO()
+    torch.save(sp, buffer)

--- a/tests/o3/cartesian_spherical_harmonics_test.py
+++ b/tests/o3/cartesian_spherical_harmonics_test.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from e3nn import o3
+from e3nn import set_optimization_defaults, get_optimization_defaults
 from e3nn.util.test import assert_auto_jitable, assert_equivariant
 
 
@@ -163,6 +164,11 @@ def test_module(normalization, normalize) -> None:
 @pytest.mark.parametrize("jit_script_fx", [False])
 def test_pickle(jit_script_fx):
     l = o3.Irreps("0e + 1o + 3o")
-    sp = o3.SphericalHarmonics(l, normalization="integral", normalize=True)
-    buffer = io.BytesIO()
-    torch.save(sp, buffer)
+    jit_script_fx_before = get_optimization_defaults()["jit_script_fx"]
+    try:
+        set_optimization_defaults(jit_script_fx=jit_script_fx)
+        sp = o3.SphericalHarmonics(l, normalization="integral", normalize=True)
+        buffer = io.BytesIO()
+        torch.save(sp, buffer)
+    finally:
+        set_optimization_defaults(jit_script_fx=jit_script_fx_before)

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -60,7 +60,7 @@ def test_linear() -> None:
     assert_equivariant(m)
     assert_auto_jitable(m)
     assert_torch_compile(
-        'inductor',
+        "inductor",
         functools.partial(o3.Linear, irreps_in, irreps_out),
         torch.randn(irreps_in.dim),
     )

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -1,12 +1,13 @@
 import pytest
 
+import functools
+
 from typing import Optional
 
 import torch
 
 from e3nn import o3
-from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps, assert_normalized
-from e3nn.util.jit import get_optimization_defaults, set_optimization_defaults
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps, assert_normalized, assert_torch_compile
 
 
 class SlowLinear(torch.nn.Module):
@@ -58,17 +59,12 @@ def test_linear() -> None:
 
     assert_equivariant(m)
     assert_auto_jitable(m)
+    assert_torch_compile(
+        'inductor',
+        functools.partial(o3.Linear, irreps_in, irreps_out),
+        torch.randn(irreps_in.dim),
+    )
     assert_normalized(m, n_weight=100, n_input=10_000, atol=0.5)
-
-    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
-    jit_mode_before = get_optimization_defaults()["jit_mode"]
-    try:
-        set_optimization_defaults(jit_mode="inductor")
-        m = o3.Linear(irreps_in, irreps_out)
-        m_pt2 = torch.compile(m, fullgraph=True)
-        m_pt2(torch.randn(irreps_in.dim))
-    finally:
-        set_optimization_defaults(jit_mode=jit_mode_before)
 
 
 def test_bias() -> None:

--- a/tests/o3/linear_test.py
+++ b/tests/o3/linear_test.py
@@ -6,7 +6,6 @@ import torch
 
 from e3nn import o3
 from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps, assert_normalized
-from e3nn.util.jit import prepare
 
 
 class SlowLinear(torch.nn.Module):
@@ -53,18 +52,16 @@ def test_linear() -> None:
     irreps_in = o3.Irreps("1e + 2e + 3x3o")
     irreps_out = o3.Irreps("1e + 2e + 3x3o")
 
-    def build_module(irreps_in, irreps_out):
-        return o3.Linear(irreps_in, irreps_out)
-
-    m = build_module(irreps_in, irreps_out)
+    m = o3.Linear(irreps_in, irreps_out)
     m(torch.randn(irreps_in.dim))
+
+    torch._dynamo.reset()  # Clear cache from the previous run
+    m_pt2 = torch.compile(m, fullgraph=True)
+    m_pt2(torch.randn(irreps_in.dim))
 
     assert_equivariant(m)
     assert_auto_jitable(m)
     assert_normalized(m, n_weight=100, n_input=10_000, atol=0.5)
-
-    m_pt2 = torch.compile(prepare(build_module)(irreps_in, irreps_out), fullgraph=True)
-    m_pt2(torch.randn(irreps_in.dim))
 
 
 def test_bias() -> None:

--- a/tests/o3/norm_test.py
+++ b/tests/o3/norm_test.py
@@ -4,6 +4,7 @@ import torch
 
 from e3nn import o3
 from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps
+from e3nn.util.jit import get_optimization_defaults, set_optimization_defaults
 
 
 @pytest.mark.parametrize("irreps_in", ["", "5x0e", "1e + 2e + 4x1e + 3x3o"] + random_irreps(n=4))
@@ -15,12 +16,19 @@ def test_norm(irreps_in, squared) -> None:
     if m.irreps_in.dim == 0:
         return
     assert_equivariant(m)
-
-    torch._dynamo.reset()  # Clear cache from the previous run
-    m_pt2 = torch.compile(m, fullgraph=True)
-    m_pt2(torch.randn(m_pt2.irreps_in.dim))
-
     assert_auto_jitable(m)
+
+    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
+    jit_mode_before = get_optimization_defaults()["jit_mode"]
+    try:
+        set_optimization_defaults(jit_mode="inductor")
+        m = o3.Norm(irreps_in, squared=squared)
+        torch._dynamo.reset() # Clear cache from the previous run
+        m_pt2 = torch.compile(m, fullgraph=True)
+        m_pt2(torch.randn(m_pt2.irreps_in.dim))
+    finally:
+        set_optimization_defaults(jit_mode=jit_mode_before)
+
 
 
 @pytest.mark.parametrize("squared", [True, False])

--- a/tests/o3/norm_test.py
+++ b/tests/o3/norm_test.py
@@ -17,11 +17,7 @@ def test_norm(irreps_in, squared) -> None:
     if m.irreps_in.dim == 0:
         return
     assert_equivariant(m)
-    assert_torch_compile(
-        'inductor',
-        functools.partial(o3.Norm, irreps_in, squared=squared),
-        torch.randn(m.irreps_in.dim)
-    )
+    assert_torch_compile("inductor", functools.partial(o3.Norm, irreps_in, squared=squared), torch.randn(m.irreps_in.dim))
     assert_auto_jitable(m)
 
 

--- a/tests/o3/norm_test.py
+++ b/tests/o3/norm_test.py
@@ -4,24 +4,23 @@ import torch
 
 from e3nn import o3
 from e3nn.util.test import assert_equivariant, assert_auto_jitable, random_irreps
-from e3nn.util.jit import prepare
 
 
 @pytest.mark.parametrize("irreps_in", ["", "5x0e", "1e + 2e + 4x1e + 3x3o"] + random_irreps(n=4))
 @pytest.mark.parametrize("squared", [True, False])
 def test_norm(irreps_in, squared) -> None:
-    def build_module(irreps_in, squared):
-        return o3.Norm(irreps_in, squared=squared)
 
-    m = build_module(irreps_in, squared=squared)
+    m = o3.Norm(irreps_in, squared=squared)
     m(torch.randn(m.irreps_in.dim))
     if m.irreps_in.dim == 0:
         return
     assert_equivariant(m)
-    assert_auto_jitable(m)
 
-    m_pt2 = torch.compile(prepare(build_module)(irreps_in, squared), fullgraph=True)
+    torch._dynamo.reset()  # Clear cache from the previous run
+    m_pt2 = torch.compile(m, fullgraph=True)
     m_pt2(torch.randn(m_pt2.irreps_in.dim))
+
+    assert_auto_jitable(m)
 
 
 @pytest.mark.parametrize("squared", [True, False])

--- a/tests/o3/reduce_tensor_test.py
+++ b/tests/o3/reduce_tensor_test.py
@@ -4,7 +4,6 @@ import torch
 
 from e3nn import o3
 from e3nn.util.test import assert_auto_jitable, assert_equivariant
-from e3nn.util.jit import prepare
 
 
 def test_save_load() -> None:
@@ -20,22 +19,22 @@ def test_save_load() -> None:
 
 
 def test_antisymmetric_matrix(float_tolerance) -> None:
-    def build_module():
-        return o3.ReducedTensorProducts("ij=-ji", i="5x0e + 1e")
 
-    tp = build_module()
+    tp = o3.ReducedTensorProducts("ij=-ji", i="5x0e + 1e")
+
+    Q = tp.change_of_basis
+    x = torch.randn(2, 5 + 3)
+
+    torch._dynamo.reset()  # Clear cache from the previous run
+    tp_pt2 = torch.compile(tp, fullgraph=True)
+    assert (tp(*x) - tp_pt2(*x)).abs().max() < float_tolerance
 
     assert_equivariant(tp, irreps_in=tp.irreps_in, irreps_out=tp.irreps_out)
     assert_auto_jitable(tp)
 
-    Q = tp.change_of_basis
-    x = torch.randn(2, 5 + 3)
     assert (tp(*x) - torch.einsum("xij,i,j", Q, *x)).abs().max() < float_tolerance
 
     assert (Q + torch.einsum("xij->xji", Q)).abs().max() < float_tolerance
-
-    tp_pt2 = torch.compile(prepare(build_module)(), fullgraph=True)
-    assert (tp(*x) - tp_pt2(*x)).abs().max() < float_tolerance
 
 
 def test_reduce_tensor_Levi_Civita_symbol(float_tolerance) -> None:

--- a/tests/o3/rotation_test.py
+++ b/tests/o3/rotation_test.py
@@ -1,7 +1,6 @@
 import torch
 
 from e3nn import o3
-from e3nn.util.jit import script
 
 
 def test_xyz(float_tolerance) -> None:
@@ -113,20 +112,3 @@ def test_matrix_xyz(float_tolerance) -> None:
 
     y = torch.einsum("zij,zj->zi", o3.matrix_z(torch.randn(100)), x)
     assert (x[:, 2] - y[:, 2]).abs().max() < float_tolerance
-
-
-def test_script():
-    pos = torch.tensor([[0.0, 1.0, 1.0]])
-    angles = o3.xyz_to_angles(pos)
-    print(angles)
-
-    class XYZAngles(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-
-        def forward(self, xyz):
-            return o3.xyz_to_angles(xyz)
-
-    mod = XYZAngles()
-    scripted = script(mod)
-    torch.testing.assert_close(mod(pos), scripted(pos))

--- a/tests/o3/tensor_product_sub_test.py
+++ b/tests/o3/tensor_product_sub_test.py
@@ -1,10 +1,11 @@
 import torch
 
+import functools
+
 from e3nn import o3
 from e3nn.nn import Identity
 from e3nn.o3 import FullyConnectedTensorProduct, FullTensorProduct, Norm, TensorSquare
-from e3nn.util.test import assert_equivariant, assert_auto_jitable
-from e3nn.util.jit import get_optimization_defaults, set_optimization_defaults
+from e3nn.util.test import assert_equivariant, assert_auto_jitable, assert_torch_compile
 
 
 def test_fully_connected() -> None:
@@ -18,17 +19,11 @@ def test_fully_connected() -> None:
 
     assert_equivariant(m)
     assert_auto_jitable(m)
-
-    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
-    jit_mode_before = get_optimization_defaults()["jit_mode"]
-    try:
-        set_optimization_defaults(jit_mode="inductor")
-        m = FullyConnectedTensorProduct(irreps_in1, irreps_in2, irreps_out)
-        torch._dynamo.reset()  # Clear cache from the previous run
-        m_pt2 = torch.compile(m, fullgraph=True)
-        m_pt2(torch.randn(irreps_in1.dim), torch.randn(irreps_in2.dim))
-    finally:
-        set_optimization_defaults(jit_mode=jit_mode_before)
+    assert_torch_compile(
+        'inductor',
+        functools.partial(FullyConnectedTensorProduct, irreps_in1, irreps_in2, irreps_out),
+        torch.randn(irreps_in1.dim), torch.randn(irreps_in2.dim)
+    )
 
 
 def test_fully_connected_normalization() -> None:
@@ -54,17 +49,11 @@ def test_id() -> None:
 
     assert_equivariant(m)
     assert_auto_jitable(m, strict_shapes=False)
-
-    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
-    jit_mode_before = get_optimization_defaults()["jit_mode"]
-    try:
-        set_optimization_defaults(jit_mode="inductor")
-        m = Identity(irreps_in, irreps_out)
-        torch._dynamo.reset()  # Clear cache from the previous run
-        m_pt2 = torch.compile(m, fullgraph=True)
-        m_pt2(torch.randn(irreps_in.dim))
-    finally:
-        set_optimization_defaults(jit_mode=jit_mode_before)
+    assert_torch_compile(
+        'inductor',
+        functools.partial(Identity, irreps_in, irreps_out),
+        torch.randn(irreps_in.dim)
+    )
 
 
 def test_full() -> None:
@@ -76,17 +65,11 @@ def test_full() -> None:
 
     assert_equivariant(m)
     assert_auto_jitable(m)
-
-    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
-    jit_mode_before = get_optimization_defaults()["jit_mode"]
-    try:
-        set_optimization_defaults(jit_mode="inductor")
-        m = FullTensorProduct(irreps_in1, irreps_in2)
-        torch._dynamo.reset()  # Clear cache from the previous run
-        m_pt2 = torch.compile(m, fullgraph=True)
-        m_pt2(irreps_in1.randn(-1), irreps_in2.randn(-1))
-    finally:
-        set_optimization_defaults(jit_mode=jit_mode_before)
+    assert_torch_compile(
+        'inductor',
+        functools.partial(FullTensorProduct, irreps_in1, irreps_in2),
+        irreps_in1.randn(-1), irreps_in2.randn(-1)
+    )
 
 def test_norm() -> None:
     irreps_in = o3.Irreps("3x0e + 5x1o")
@@ -102,17 +85,11 @@ def test_norm() -> None:
 
     assert_equivariant(norm)
     assert_auto_jitable(norm)
-
-    # Turning off the torch.jit.script in CodeGenMix to enable torch.compile.
-    jit_mode_before = get_optimization_defaults()["jit_mode"]
-    try:
-        set_optimization_defaults(jit_mode="inductor")
-        norm = Norm(irreps_in=irreps_in)
-        torch._dynamo.reset()  # Clear cache from the previous run
-        norm_pt2 = torch.compile(norm, fullgraph=True)
-        norm_pt2(torch.cat((scalars.reshape(1, -1), vecs.reshape(1, -1)), dim=-1))
-    finally:
-        set_optimization_defaults(jit_mode=jit_mode_before)
+    assert_torch_compile(
+        'inductor',
+        functools.partial(Norm, irreps_in=irreps_in),
+        torch.cat((scalars.reshape(1, -1), vecs.reshape(1, -1)), dim=-1)
+    )
 
 
 def test_square_normalization() -> None:

--- a/tests/o3/tensor_product_sub_test.py
+++ b/tests/o3/tensor_product_sub_test.py
@@ -20,9 +20,10 @@ def test_fully_connected() -> None:
     assert_equivariant(m)
     assert_auto_jitable(m)
     assert_torch_compile(
-        'inductor',
+        "inductor",
         functools.partial(FullyConnectedTensorProduct, irreps_in1, irreps_in2, irreps_out),
-        torch.randn(irreps_in1.dim), torch.randn(irreps_in2.dim)
+        torch.randn(irreps_in1.dim),
+        torch.randn(irreps_in2.dim),
     )
 
 
@@ -49,11 +50,7 @@ def test_id() -> None:
 
     assert_equivariant(m)
     assert_auto_jitable(m, strict_shapes=False)
-    assert_torch_compile(
-        'inductor',
-        functools.partial(Identity, irreps_in, irreps_out),
-        torch.randn(irreps_in.dim)
-    )
+    assert_torch_compile("inductor", functools.partial(Identity, irreps_in, irreps_out), torch.randn(irreps_in.dim))
 
 
 def test_full() -> None:
@@ -66,10 +63,9 @@ def test_full() -> None:
     assert_equivariant(m)
     assert_auto_jitable(m)
     assert_torch_compile(
-        'inductor',
-        functools.partial(FullTensorProduct, irreps_in1, irreps_in2),
-        irreps_in1.randn(-1), irreps_in2.randn(-1)
+        "inductor", functools.partial(FullTensorProduct, irreps_in1, irreps_in2), irreps_in1.randn(-1), irreps_in2.randn(-1)
     )
+
 
 def test_norm() -> None:
     irreps_in = o3.Irreps("3x0e + 5x1o")
@@ -86,9 +82,9 @@ def test_norm() -> None:
     assert_equivariant(norm)
     assert_auto_jitable(norm)
     assert_torch_compile(
-        'inductor',
+        "inductor",
         functools.partial(Norm, irreps_in=irreps_in),
-        torch.cat((scalars.reshape(1, -1), vecs.reshape(1, -1)), dim=-1)
+        torch.cat((scalars.reshape(1, -1), vecs.reshape(1, -1)), dim=-1),
     )
 
 

--- a/tests/o3/tensor_product_sub_test.py
+++ b/tests/o3/tensor_product_sub_test.py
@@ -4,7 +4,6 @@ from e3nn import o3
 from e3nn.nn import Identity
 from e3nn.o3 import FullyConnectedTensorProduct, FullTensorProduct, Norm, TensorSquare
 from e3nn.util.test import assert_equivariant, assert_auto_jitable
-from e3nn.util.jit import prepare
 
 
 def test_fully_connected() -> None:
@@ -12,17 +11,16 @@ def test_fully_connected() -> None:
     irreps_in2 = o3.Irreps("1e + 2e + 3x3o")
     irreps_out = o3.Irreps("1e + 2e + 3x3o")
 
-    def build_module(irreps_in1, irreps_in2, irreps_out):
-        return FullyConnectedTensorProduct(irreps_in1, irreps_in2, irreps_out)
-
-    m = build_module(irreps_in1, irreps_in2, irreps_out)
+    m = FullyConnectedTensorProduct(irreps_in1, irreps_in2, irreps_out)
     print(m)
     m(torch.randn(irreps_in1.dim), torch.randn(irreps_in2.dim))
 
+    torch._dynamo.reset()  # Clear cache from the previous run
+    m_pt2 = torch.compile(m, fullgraph=True)
+    m_pt2(torch.randn(irreps_in1.dim), torch.randn(irreps_in2.dim))
+
     assert_equivariant(m)
     assert_auto_jitable(m)
-    m_pt2 = torch.compile(prepare(build_module)(irreps_in1, irreps_in2, irreps_out), fullgraph=True)
-    m_pt2(torch.randn(irreps_in1.dim), torch.randn(irreps_in2.dim))
 
 
 def test_fully_connected_normalization() -> None:
@@ -42,35 +40,31 @@ def test_id() -> None:
     irreps_in = o3.Irreps("1e + 2e + 3x3o")
     irreps_out = o3.Irreps("1e + 2e + 3x3o")
 
-    def build_module(irreps_in, irreps_out):
-        return Identity(irreps_in, irreps_out)
-
-    m = build_module(irreps_in, irreps_out)
+    m = Identity(irreps_in, irreps_out)
     print(m)
     m(torch.randn(irreps_in.dim))
 
+    torch._dynamo.reset()  # Clear cache from the previous run
+    m_pt2 = torch.compile(m, fullgraph=True)
+    m_pt2(torch.randn(irreps_in.dim))
+
     assert_equivariant(m)
     assert_auto_jitable(m, strict_shapes=False)
-
-    m_pt2 = torch.compile(prepare(build_module)(irreps_in, irreps_out), fullgraph=True)
-    m_pt2(torch.randn(irreps_in.dim))
 
 
 def test_full() -> None:
     irreps_in1 = o3.Irreps("1e + 2e + 3x3o")
     irreps_in2 = o3.Irreps("1e + 2x2e + 2x3o")
 
-    def build_module(irreps_in1, irreps_in2):
-        return FullTensorProduct(irreps_in1, irreps_in2)
-
-    m = build_module(irreps_in1, irreps_in2)
+    m = FullTensorProduct(irreps_in1, irreps_in2)
     print(m)
+
+    torch._dynamo.reset()  # Clear cache from the previous run
+    m_pt2 = torch.compile(m, fullgraph=True)
+    m_pt2(irreps_in1.randn(-1), irreps_in2.randn(-1))
 
     assert_equivariant(m)
     assert_auto_jitable(m)
-
-    m_pt2 = prepare(build_module)(irreps_in1, irreps_in2)
-    m_pt2(irreps_in1.randn(-1), irreps_in2.randn(-1))
 
 
 def test_norm() -> None:
@@ -78,21 +72,19 @@ def test_norm() -> None:
     scalars = torch.randn(3)
     vecs = torch.randn(5, 3)
 
-    def build_module(irreps_in):
-        return Norm(irreps_in=irreps_in)
-
-    norm = build_module(irreps_in)
+    norm = Norm(irreps_in=irreps_in)
     out_norms = norm(torch.cat((scalars.reshape(1, -1), vecs.reshape(1, -1)), dim=-1))
     true_scalar_norms = torch.abs(scalars)
     true_vec_norms = torch.linalg.norm(vecs, dim=-1)
     assert torch.allclose(out_norms[0, :3], true_scalar_norms)
     assert torch.allclose(out_norms[0, 3:], true_vec_norms)
 
+    torch._dynamo.reset()  # Clear cache from the previous run
+    norm_pt2 = torch.compile(norm, fullgraph=True)
+    norm_pt2(torch.cat((scalars.reshape(1, -1), vecs.reshape(1, -1)), dim=-1))
+
     assert_equivariant(norm)
     assert_auto_jitable(norm)
-
-    norm_pt2 = torch.compile(prepare(build_module)(irreps_in), fullgraph=True)
-    norm_pt2(torch.cat((scalars.reshape(1, -1), vecs.reshape(1, -1)), dim=-1))
 
 
 def test_square_normalization() -> None:


### PR DESCRIPTION
Currently to enable full `torch.compile` capability we need to do `e3nn.set_optimization_defaults(jit_script_fx=False)`.  I am proposing to turn this off by default.

Update: 01/03/2024

- New interface will have ``"jit_mode": "inductor/script/eager"`` 

- Will retain backward compatibility by mapping ``"jit_script_fx"=False`` to ``"jit_mode": "eager"`` and ``"jit_script_fx"=True`` to ``"jit_mode": "script"`` (Will only do this if ``"jit_mode"`` not in ``"inductor/script"``.