### PR TITLE
Update _activation.py

### DIFF
--- a/e3nn/nn/_activation.py
+++ b/e3nn/nn/_activation.py
@@ -95,7 +95,8 @@ class Activation(torch.nn.Module):
         # - PROFILER - with torch.autograd.profiler.record_function(repr(self)):
         output = []
         index = 0
-        for mul, (l, _), act in self.paths:
+        # for mul, (l, _), act in self.paths:
+        for (mul, (l, _)), act in zip(self.irreps_in, self.acts): # Fix torchscript incompatible error
             ir_dim = 2 * l + 1
             if act is not None:
                 output.append(act(features.narrow(dim, index, mul)))


### PR DESCRIPTION
Use zip(self.irreps_in, self.acts) rather than self.paths to avoid torchscript error. 

<!-- Provide a general summary of your changes in the Title above. -->

## Description
In e3nn.nn._activation.py in line 98, `for mul, (l, _), act in self.paths:` can work well under pytorch but there would be an in compatible error within torchscript environment. To fix this, `for (mul, (l, _)), act in zip(self.irreps_in, self.acts): ` can work perfectly and realize exactly the same function.

## Motivation and Context
Fix torchscript incompatible error.

## How Has This Been Tested?
Yes, it works perfectly after the patch.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/.github/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [CHANGELOG](https://github.com/e3nn/e3nn/blob/main/.github/CHANGELOG.md).
