### PR TITLE
Porting slice_by_mul from e3nn-jax + bug fix in filter

### DIFF
--- a/tests/o3/irreps_test.py
+++ b/tests/o3/irreps_test.py
@@ -123,3 +123,10 @@ def test_errors() -> None:
 @pytest.mark.xfail()
 def test_fail1() -> None:
     o3.Irreps([(32, 1)])
+
+def test_slice_by_mul():
+    assert o3.Irreps("10x0e").slice_by_mul[1:4] == o3.Irreps("3x0e")
+    assert o3.Irreps("10x0e + 10x1e").slice_by_mul[5:15] == o3.Irreps("5x0e + 5x1e")
+    assert o3.Irreps("10x0e + 2e + 10x1e").slice_by_mul[5:15] == o3.Irreps(
+        "5x0e + 2e + 4x1e"
+    )


### PR DESCRIPTION
- .filter() was not working with "1x0e" since it was not splitting the mul and irrep in a for loop here.
- Porting slice_by_mul from e3nn-jax https://github.com/e3nn/e3nn-jax/blob/403f0ef159c537c2efa9d3d05799da85a86575d5/e3nn_jax/_src/irreps_array.py#L824-L831