### PR TITLE
Remove for loop over multiplicities in D_from_angles

### DIFF
--- a/e3nn/o3/_irreps.py
+++ b/e3nn/o3/_irreps.py
@@ -57,10 +57,10 @@ class Irrep(tuple):
         if p is None:
             if isinstance(l, Irrep):
                 return l
-            
+
             if isinstance(l, _MulIr):
                 return l.ir.l
-            
+
             if isinstance(l, str):
                 try:
                     name = l.strip()
@@ -624,7 +624,7 @@ class Irreps(tuple):
         1x0e+2x1e
         """
         return self.sort().irreps.simplify()
-    
+
     def filter(
         self,
         keep: Union["Irreps", List[Irrep], Callable[[_MulIr], bool]] = None,
@@ -740,7 +740,11 @@ class Irreps(tuple):
         `torch.Tensor`
             tensor of shape :math:`(..., \mathrm{dim}, \mathrm{dim})`
         """
-        return direct_sum(*[ir.D_from_angles(alpha, beta, gamma, k) for mul, ir in self for _ in range(mul)])
+        blocks = []
+        for mul, ir in self:
+            D = ir.D_from_angles(alpha, beta, gamma, k)
+            blocks.extend([D] * mul)
+        return direct_sum(*blocks)
 
     def D_from_quaternion(self, q, k=None):
         r"""Matrix of the representation
@@ -795,6 +799,7 @@ class Irreps(tuple):
             tensor of shape :math:`(..., \mathrm{dim}, \mathrm{dim})`
         """
         return self.D_from_angles(*_rotation.axis_angle_to_angles(axis, angle))
+
 
 class _MulIndexSliceHelper:
     irreps: Irreps


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

Remove the unnecessary for loop over multiplicities when using the function D_from_angles in the Irreps class.

## Description
<!-- Describe your changes in detail. -->

Line 743 in _irreps.py `direct_sum(*[ir.D_from_angles(alpha, beta, gamma, k) for mul, ir in self for _ in range(mul)])` performs a for loop over multiplicities which in each iteration calculates `ir.D_from_angles` even though the result is the same each time. The suggested change calculates `D_from_angles` only once per irrep and repeats the resulting block according to the multiplicity.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Replace ??? with the issue number that this pull request resolves, if applicable. -->
The change significantly increases the speed of the function especially in scenarios, where the number of multiplicities is high.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to
     see how your changes affect other areas of the code, etc. -->
The changes were tested by comparing the results of old and new implementation on an irreps object `Irreps("128x0e + 64x1o + 16x2e + 4x3o + 1x4e")` for random tensors of angles and k and asserting that the resulting tensors are the same.

## Checklist:
<!-- Put an `x` in all the boxes that apply. If you're unsure about any of
     these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/e3nn/e3nn/blob/main/.github/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation (if relevant).
- [ ] I have added tests that cover my changes (if relevant).
- [ ] The modified code is cuda compatible (github tests don't test cuda) (if relevant).
- [ ] I have updated the [CHANGELOG](https://github.com/e3nn/e3nn/blob/main/.github/CHANGELOG.md).
